### PR TITLE
release: date v0.2.0 changelog and add crates.io publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+      - name: Verify tag matches crate version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          CRATE="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+          echo "release tag: $TAG   crate version: $CRATE"
+          if [ "$TAG" != "$CRATE" ]; then
+            echo "::error::Release tag ($TAG) does not match Cargo.toml version ($CRATE)"
+            exit 1
+          fi
+      - name: Verify package contents
+        run: cargo package --locked
+      - name: Publish
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 No changes yet.
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-08-09
 
 First public release. Implements Bellbook spec version 0.2, the first
 published compatibility epoch.


### PR DESCRIPTION
Two release-prep changes so v0.2.0 can be tagged and published without a local machine:

1. **Date the changelog.** `## [0.2.0]` heading goes from `Unreleased` to `2026-08-09`. If you publish on a different day, edit that one line before merging.
2. **Add `.github/workflows/release.yml`.** On a published GitHub Release it verifies the tag matches the crate version, runs `cargo package`, and runs `cargo publish --locked` using the `CARGO_REGISTRY_TOKEN` secret. Actions are pinned to the same commit SHAs as CI.

## To release after this merges

1. Add the crates.io token as a repo secret named `CARGO_REGISTRY_TOKEN` (Settings -> Secrets and variables -> Actions).
2. Create a GitHub Release for tag `v0.2.0` targeting `main`. Publishing the release triggers the workflow, which publishes to crates.io.