### PR TITLE
docs: VISION.md and RFC-0001 — spec v0.3 evolution semantics (design only)

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -2,9 +2,11 @@
 
 **Status: long-term direction, not current scope.** This document describes
 where Bellbook is headed if — and only if — each stage earns the next one.
-Nothing in it changes what Bellbook is today. The README, SPEC.md, and the
-published crate describe the shipped system; this document describes a
-direction. Where the two disagree about the present, the README is right.
+Nothing in it changes what Bellbook is today. SPEC.md (normative), the
+README, and the published crate describe the shipped system; this document
+describes a direction. Where this document disagrees with them about the
+present, they are right — SPEC.md first, per the repository's own
+normativity rule.
 
 ## North star
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,12 +1,12 @@
 # Bellbook Vision
 
 **Status: long-term direction, not current scope.** This document describes
-where Bellbook is headed if — and only if — each stage earns the next one.
+where Bellbook is headed if, and only if, each stage earns the next one.
 Nothing in it changes what Bellbook is today. SPEC.md (normative), the
 README, and the published crate describe the shipped system; this document
 describes a direction. Where this document disagrees with them about the
-present, they are right — SPEC.md first, per the repository's own
-normativity rule.
+present, they are right: SPEC.md first, per the repository's own normativity
+rule.
 
 ## North star
 
@@ -15,37 +15,37 @@ normativity rule.
 Git was built around humans changing files. Autonomous coding systems change
 the assumptions underneath that model: they generate, execute, evaluate,
 compare, reject, repair, and evolve many software variants without a human
-inspecting each intermediate change. Infrastructure built for human branching
-can scale to more agents; it cannot naturally represent what those agents are
-actually doing.
+inspecting each intermediate change. Infrastructure built for human
+branching can scale to more agents; it cannot naturally represent what those
+agents are actually doing.
 
 ## Core thesis
 
 Git treats a version primarily as a snapshot of source code. Bellbook treats
-a version as a **software state**: the source *and what is known about it* —
-its lineage, the claims made about it, the evidence behind those claims, the
-evaluations performed on it, and the provenance of all of the above — bound
-together tamper-evidently, so that another party can verify the history of a
-piece of autonomously produced software without trusting the system that
-produced it.
+a version as a **software state**: the source *and what is known about it*,
+meaning its lineage, the claims made about it, the evidence behind those
+claims, the evaluations performed on it, and the provenance of all of the
+above, bound together tamper-evidently, so that another party can verify the
+history of a piece of autonomously produced software without trusting the
+system that produced it.
 
 That second half is not decoration. When no human witnessed the intermediate
-states, the record of how software came to be *is* the only account of it —
+states, the record of how software came to be *is* the only account of it,
 and an account that cannot be verified is an account that must be trusted.
 
 ## The missing semantics
 
-Human version control developed around **branch → change → review → merge**.
+Human version control developed around branch, change, review, merge.
 Autonomous development adds a second fundamental pattern:
 
 ```
-state → fork N candidates → modify independently → evaluate → rank → select → continue
+state -> fork N candidates -> modify independently -> evaluate -> rank -> select -> continue
 ```
 
 Merge remains necessary, but it does not define this pattern. Many candidate
 states are explored, evaluated, and discarded without ever merging. Today
-that entire process — which candidates were considered, what evidence was
-gathered, why one was selected, what lineage the survivor carries — has no
+that entire process (which candidates were considered, what evidence was
+gathered, why one was selected, what lineage the survivor carries) has no
 native, verifiable representation anywhere. It lives in throwaway branches,
 harness logs, and JSON files.
 
@@ -55,14 +55,14 @@ The concepts Bellbook adds are therefore:
 Candidate    a source state proposed under some parent context
 Evaluation   a judgment about a candidate under an explicit criterion
 Selection    a recorded decision over a set of candidates (including a set of one)
-Lineage      derived from refs and lineage payload fields — never stored as a parallel structure
+Lineage      derived from refs and lineage payload fields, never stored as a parallel structure
 ```
 
 together with the trust machinery those records need: content-addressing,
-deterministic verdicts, evidence classes that cannot be inflated, signatures,
-retraction, and transitive taint. That trust machinery is not future work —
-it is the shipped v0.2 kernel, adversarially audited and independently
-reimplemented.
+deterministic verdicts, evidence classes that cannot be inflated,
+signatures, retraction, and transitive taint. That trust machinery is not
+future work: it is the shipped v0.2 kernel, independently reimplemented and
+held to byte-for-decision agreement by a conformance corpus.
 
 ## Sequencing: how we get there without pretending we are there
 
@@ -71,19 +71,19 @@ The architectural principle for the road itself:
 > **Bellbook defines the missing semantics of autonomous software evolution.
 > Git can be the initial storage implementation underneath those semantics.**
 
-### Now — v0.2 (shipped)
+### Now: v0.2 (shipped)
 
 An embeddable evidence kernel: typed, content-addressed records in an
-append-only log; deterministic re-derivable verdicts; the five-class evidence
-lattice with weakest-link derivation; Ed25519 signatures with key pinning;
-retraction with transitive taint; portable offline-verifiable receipts; a
-language-neutral conformance corpus with an independent second
+append-only log; deterministic re-derivable verdicts; the five-class
+evidence lattice with weakest-link derivation; Ed25519 signatures with key
+pinning; retraction with transitive taint; portable offline-verifiable
+receipts; a language-neutral conformance corpus with an independent second
 implementation. This is the trust pillar of everything below, and it exists.
 
-### Next — v0.3 (the wedge, under design)
+### Next: v0.3 (the wedge, under design)
 
 **Verifiable candidate selection and lineage for autonomous coding agents**,
-built *on top of Git*, not instead of it:
+built on top of Git, not instead of it:
 
 - Git remains the source storage substrate. A candidate binds a Git tree
   (identity) and optionally a commit (provenance).
@@ -92,9 +92,10 @@ built *on top of Git*, not instead of it:
   lineage payload fields, never stored.
 - The existing kernel supplies evidence, signatures, retraction, taint, and
   receipts unchanged.
-- The proving workloads are best-of-N candidate selection, autoresearch-style
-  iterative evolution, and single-candidate repair-and-reevaluate loops — the
-  semantics must serve all three without privileging any.
+- The proving workloads are best-of-N candidate selection,
+  autoresearch-style iterative evolution, and single-candidate
+  repair-and-reevaluate loops. The semantics must serve all three without
+  privileging any.
 
 The design is specified in [RFC-0001](rfcs/0001-evolution-semantics.md),
 including pre-registered validation and falsification criteria. The question
@@ -104,29 +105,29 @@ the wedge exists to answer, honestly:
 > candidate states, evaluation evidence, selection decisions, and trusted
 > lineage?
 
-If the answer is no, nothing further below gets built — rebuilding Git would
+If the answer is no, nothing further below gets built. Rebuilding Git would
 not have changed that answer.
 
-### Later — gated on wedge adoption, in rough order of earned need
+### Later: gated on wedge adoption, in rough order of earned need
 
 Each of these is deliberately **not** part of v0.3 and begins only after the
 wedge shows real external adoption (the criteria are in RFC-0001):
 
-1. **Query surface** — lineage and evidence queries beyond simple traversal
+1. **Query surface**: lineage and evidence queries beyond simple traversal
    ("find the best verified descendant of S under objective X").
-2. **Native source storage** — content-addressed blob/tree storage with
+2. **Native source storage**: content-addressed blob/tree storage with
    structural sharing, making the filesystem an execution projection of
    Bellbook state and Git an interoperability surface rather than the
    substrate.
-3. **Distribution** — remotes, incremental sync, reachability, policy-driven
+3. **Distribution**: remotes, incremental sync, reachability, policy-driven
    garbage collection for repositories with very large numbers of ephemeral
    machine-generated states.
-4. **Runtime and control plane** — materialization, sandboxed execution,
-   deployment and observation of states without loss of identity or lineage;
-   hosted repositories and governance.
+4. **Runtime and control plane**: materialization, sandboxed execution,
+   deployment and observation of states without loss of identity or
+   lineage; hosted repositories and governance.
 
 The long-term shape, if every gate is passed: one substrate where autonomous
-software is versioned, evaluated, run, observed, and continuously evolved —
+software is versioned, evaluated, run, observed, and continuously evolved,
 with the same state identity throughout its lifecycle.
 
 ## Design rules
@@ -134,11 +135,11 @@ with the same state identity throughout its lifecycle.
 Every proposed Bellbook feature must pass:
 
 1. *Does this help autonomous software create, store, fork, compare,
-   evaluate, select, reproduce, trust, execute, observe, or continue software
-   states?* If not, it does not belong in Bellbook.
+   evaluate, select, reproduce, trust, execute, observe, or continue
+   software states?* If not, it does not belong in Bellbook.
 2. *Bellbook must never need to understand how an agent thinks in order to
    understand what happened to the software.* No prompts, planners, tasks,
-   repair strategies, models, or conversations in the core — Bellbook
+   repair strategies, models, or conversations in the core. Bellbook
    versions the consequences of intelligence, not its architecture.
 3. *Claims must never be broader than guarantees.* Consistency is not
    completeness; integrity is not confidentiality; tamper-evident is not
@@ -147,9 +148,9 @@ Every proposed Bellbook feature must pass:
 
 ## What Bellbook is not, at any stage
 
-Bellbook does not contain agent planners, prompt storage, model routing, task
-scheduling, repair strategies, ranking or scoring logic, or product UX for
-any particular autonomous development system. Any coding agent, autoresearch
-system, or future architecture not yet invented should be able to read and
-write Bellbook state on equal terms. That independence is what would make
-Bellbook infrastructure rather than a component of one product.
+Bellbook does not contain agent planners, prompt storage, model routing,
+task scheduling, repair strategies, ranking or scoring logic, or product UX
+for any particular autonomous development system. Any coding agent,
+autoresearch system, or future architecture not yet invented should be able
+to read and write Bellbook state on equal terms. That independence is what
+would make Bellbook infrastructure rather than a component of one product.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -55,7 +55,7 @@ The concepts Bellbook adds are therefore:
 Candidate    a source state proposed under some parent context
 Evaluation   a judgment about a candidate under an explicit criterion
 Selection    a recorded decision over a set of candidates (including a set of one)
-Lineage      derived from typed references — never stored as a parallel structure
+Lineage      derived from refs and lineage payload fields — never stored as a parallel structure
 ```
 
 together with the trust machinery those records need: content-addressing,

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,152 @@
+# Bellbook Vision
+
+**Status: long-term direction, not current scope.** This document describes
+where Bellbook is headed if — and only if — each stage earns the next one.
+Nothing in it changes what Bellbook is today. The README, SPEC.md, and the
+published crate describe the shipped system; this document describes a
+direction. Where the two disagree about the present, the README is right.
+
+## North star
+
+> Bellbook is the version-control system for code that evolves autonomously.
+
+Git was built around humans changing files. Autonomous coding systems change
+the assumptions underneath that model: they generate, execute, evaluate,
+compare, reject, repair, and evolve many software variants without a human
+inspecting each intermediate change. Infrastructure built for human branching
+can scale to more agents; it cannot naturally represent what those agents are
+actually doing.
+
+## Core thesis
+
+Git treats a version primarily as a snapshot of source code. Bellbook treats
+a version as a **software state**: the source *and what is known about it* —
+its lineage, the claims made about it, the evidence behind those claims, the
+evaluations performed on it, and the provenance of all of the above — bound
+together tamper-evidently, so that another party can verify the history of a
+piece of autonomously produced software without trusting the system that
+produced it.
+
+That second half is not decoration. When no human witnessed the intermediate
+states, the record of how software came to be *is* the only account of it —
+and an account that cannot be verified is an account that must be trusted.
+
+## The missing semantics
+
+Human version control developed around **branch → change → review → merge**.
+Autonomous development adds a second fundamental pattern:
+
+```
+state → fork N candidates → modify independently → evaluate → rank → select → continue
+```
+
+Merge remains necessary, but it does not define this pattern. Many candidate
+states are explored, evaluated, and discarded without ever merging. Today
+that entire process — which candidates were considered, what evidence was
+gathered, why one was selected, what lineage the survivor carries — has no
+native, verifiable representation anywhere. It lives in throwaway branches,
+harness logs, and JSON files.
+
+The concepts Bellbook adds are therefore:
+
+```
+Candidate    a source state proposed under some parent context
+Evaluation   a judgment about a candidate under an explicit criterion
+Selection    a recorded decision over a set of candidates (including a set of one)
+Lineage      derived from typed references — never stored as a parallel structure
+```
+
+together with the trust machinery those records need: content-addressing,
+deterministic verdicts, evidence classes that cannot be inflated, signatures,
+retraction, and transitive taint. That trust machinery is not future work —
+it is the shipped v0.2 kernel, adversarially audited and independently
+reimplemented.
+
+## Sequencing: how we get there without pretending we are there
+
+The architectural principle for the road itself:
+
+> **Bellbook defines the missing semantics of autonomous software evolution.
+> Git can be the initial storage implementation underneath those semantics.**
+
+### Now — v0.2 (shipped)
+
+An embeddable evidence kernel: typed, content-addressed records in an
+append-only log; deterministic re-derivable verdicts; the five-class evidence
+lattice with weakest-link derivation; Ed25519 signatures with key pinning;
+retraction with transitive taint; portable offline-verifiable receipts; a
+language-neutral conformance corpus with an independent second
+implementation. This is the trust pillar of everything below, and it exists.
+
+### Next — v0.3 (the wedge, under design)
+
+**Verifiable candidate selection and lineage for autonomous coding agents**,
+built *on top of Git*, not instead of it:
+
+- Git remains the source storage substrate. A candidate binds a Git tree
+  (identity) and optionally a commit (provenance).
+- `Candidate`, `Evaluation`, and `Selection` become typed record kinds; the
+  record remains the only primitive; lineage is derived from refs.
+- The existing kernel supplies evidence, signatures, retraction, taint, and
+  receipts unchanged.
+- The proving workloads are best-of-N candidate selection, autoresearch-style
+  iterative evolution, and single-candidate repair-and-reevaluate loops — the
+  semantics must serve all three without privileging any.
+
+The design is specified in [RFC-0001](rfcs/0001-evolution-semantics.md),
+including pre-registered validation and falsification criteria. The question
+the wedge exists to answer, honestly:
+
+> Do autonomous coding systems need a native, verifiable way to represent
+> candidate states, evaluation evidence, selection decisions, and trusted
+> lineage?
+
+If the answer is no, nothing further below gets built — rebuilding Git would
+not have changed that answer.
+
+### Later — gated on wedge adoption, in rough order of earned need
+
+Each of these is deliberately **not** part of v0.3 and begins only after the
+wedge shows real external adoption (the criteria are in RFC-0001):
+
+1. **Query surface** — lineage and evidence queries beyond simple traversal
+   ("find the best verified descendant of S under objective X").
+2. **Native source storage** — content-addressed blob/tree storage with
+   structural sharing, making the filesystem an execution projection of
+   Bellbook state and Git an interoperability surface rather than the
+   substrate.
+3. **Distribution** — remotes, incremental sync, reachability, policy-driven
+   garbage collection for repositories with very large numbers of ephemeral
+   machine-generated states.
+4. **Runtime and control plane** — materialization, sandboxed execution,
+   deployment and observation of states without loss of identity or lineage;
+   hosted repositories and governance.
+
+The long-term shape, if every gate is passed: one substrate where autonomous
+software is versioned, evaluated, run, observed, and continuously evolved —
+with the same state identity throughout its lifecycle.
+
+## Design rules
+
+Every proposed Bellbook feature must pass:
+
+1. *Does this help autonomous software create, store, fork, compare,
+   evaluate, select, reproduce, trust, execute, observe, or continue software
+   states?* If not, it does not belong in Bellbook.
+2. *Bellbook must never need to understand how an agent thinks in order to
+   understand what happened to the software.* No prompts, planners, tasks,
+   repair strategies, models, or conversations in the core — Bellbook
+   versions the consequences of intelligence, not its architecture.
+3. *Claims must never be broader than guarantees.* Consistency is not
+   completeness; integrity is not confidentiality; tamper-evident is not
+   tamper-proof. Every layer states its boundary the way SPEC.md §13 does
+   today.
+
+## What Bellbook is not, at any stage
+
+Bellbook does not contain agent planners, prompt storage, model routing, task
+scheduling, repair strategies, ranking or scoring logic, or product UX for
+any particular autonomous development system. Any coding agent, autoresearch
+system, or future architecture not yet invented should be able to read and
+write Bellbook state on equal terms. That independence is what would make
+Bellbook infrastructure rather than a component of one product.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -88,7 +88,8 @@ built *on top of Git*, not instead of it:
 - Git remains the source storage substrate. A candidate binds a Git tree
   (identity) and optionally a commit (provenance).
 - `Candidate`, `Evaluation`, and `Selection` become typed record kinds; the
-  record remains the only primitive; lineage is derived from refs.
+  record remains the only primitive; lineage is derived from refs and
+  lineage payload fields, never stored.
 - The existing kernel supplies evidence, signatures, retraction, taint, and
   receipts unchanged.
 - The proving workloads are best-of-N candidate selection, autoresearch-style

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,19 +1,9 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
-**Status:** Draft, revision 4. Revision 2 folded in the first adversarial
-review (set-valued selection; reaffirmation). Revision 3 responded to a
-second, code-verified audit — its central change: **lineage standing is a
-replay-derived dimension computed over `Cause` edges, not a use of kernel
-taint via `Require`.** Revision 4 folds in a third, maximum-depth audit that
-verified revision 3's kernel claims against the v0.2 source and closed the
-gaps it found: `Cause` targets of Candidates must be accepted (the
-rejected-anchor hole), standing lives in the replay report only (receipts
-embed nothing derived), the standing section's content is now normative,
-reaffirmation's default trust posture is stated bluntly with an
-identity-binding knob, and the retracted-parent unrestorability asymmetry is
-documented. Nothing in this RFC is implemented; nothing in it changes spec
-v0.2 or the published crate. Kind names and field spellings are tentative
-until accepted.
+**Status:** Draft, revision 5. This document specifies the design for spec
+v0.3. Nothing in it is implemented; nothing in it changes spec v0.2 or the
+published crate. Kind names and field spellings are tentative until
+accepted.
 
 **Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
 *verifiable candidate selection and lineage for autonomous coding agents*,
@@ -23,12 +13,12 @@ on top of Git, reusing the v0.2 trust kernel unchanged.
 
 ## 1. Summary
 
-Spec v0.3 adds three typed record kinds — `Candidate`, `Evaluation`,
-`Selection` — to the existing twelve. The record remains the only primitive.
-Lineage is derived from refs and payload fields, never stored as a parallel
-structure. Source identity binds to Git (tree OID), with an optional
-Bellbook-computed manifest hash for stronger binding. Selections are
-**set-valued** (one survivor or several).
+Spec v0.3 adds three typed record kinds, `Candidate`, `Evaluation`, and
+`Selection`, to the existing twelve. The record remains the only primitive.
+Lineage is derived from refs and lineage payload fields, never stored as a
+parallel structure. Source identity binds to Git (tree OID), with an
+optional Bellbook-computed manifest hash for stronger binding. Selections
+are **set-valued**: one survivor or several.
 
 Dependency semantics are split to match what they mean:
 
@@ -36,41 +26,43 @@ Dependency semantics are split to match what they mean:
   evaluations epistemically depend on their candidates; selections
   epistemically depend on the evaluations they relied on and the candidates
   they selected. Kernel evidence derivation and taint apply here, unchanged.
-- **Standing** — "is this state a legitimate member of a chosen line?" — is
-  a **new, replay-derived dimension** computed over lineage `Cause` edges:
-  continuation anchors (with `parent`) and derivation edges to candidates.
-  It is deterministic, derived identically by every validator, and
-  forgery-proof for the same reason taint is: replay re-derives it. It does
-  not touch evidence derivation, does not freeze appends, and — when the
-  compromise stems from decisions that no longer stand, not from a retracted
-  state itself (§6.3) — is restorable by a single on-record reaffirmation.
+- **Standing**, the question "is this state a legitimate member of a chosen
+  line?", is a **replay-derived dimension** computed over lineage `Cause`
+  edges: continuation anchors (with `parent`) and derivation edges to
+  candidates. It is deterministic, derived identically by every validator,
+  and forgery-proof for the same reason taint is: replay re-derives it. It
+  does not touch evidence derivation and does not freeze appends. When a
+  compromise stems from decisions that no longer stand (not from a retracted
+  state itself, see 6.3), it is restorable by a single on-record
+  reaffirmation.
 
-This split is the revision-3 correction of revision 2's central defect:
-overloading `Require` for lineage bought kernel taint at the cost of
-evidence collapse and frozen lines. Standing gives the flagship guarantee —
-*one retraction visibly compromises the entire selected descendant line* —
-without either side effect, and makes recovery a one-record act at any
-depth.
+Overloading `Require` for lineage would buy kernel taint at the cost of two
+unacceptable side effects: evidence classes would collapse to a fixed point
+within one generation, and tainted lines would freeze against further
+recording. Standing provides the lineage guarantee (one retraction visibly
+compromises the entire selected descendant line) without either side effect,
+and makes recovery a one-record act at any depth for decision-level
+compromise.
 
 ## 2. Motivation
 
 Autonomous coding systems already run this loop today:
 
 ```
-state → generate candidate(s) → evaluate → select (or repair and re-evaluate) → continue
+state -> generate candidate(s) -> evaluate -> select (or repair and re-evaluate) -> continue
 ```
 
-Git can store the file contents at each step but has no native representation
-of the loop itself: which candidates were considered, under what objective,
-on what evidence, why some were selected, and what the surviving lineage
-therefore rests on. That knowledge lives in throwaway branches and harness
-logs, unverifiable after the fact.
+Git can store the file contents at each step but has no native
+representation of the loop itself: which candidates were considered, under
+what objective, on what evidence, why some were selected, and what the
+surviving lineage therefore rests on. That knowledge lives in throwaway
+branches and harness logs, unverifiable after the fact.
 
-v0.2 already provides the hard part — content-addressed records, deterministic
-re-derivable verdicts, an evidence lattice that cannot be inflated,
-signatures with key pinning, retraction with transitive taint, and portable
-offline-verifiable receipts. v0.3 adds the missing vocabulary on top of that
-kernel, and nothing else.
+v0.2 already provides the hard part: content-addressed records,
+deterministic re-derivable verdicts, an evidence lattice that cannot be
+inflated, signatures with key pinning, retraction with transitive taint, and
+portable offline-verifiable receipts. v0.3 adds the missing vocabulary on
+top of that kernel, and nothing else.
 
 ## 3. Design constraints
 
@@ -80,31 +72,31 @@ C1. **One primitive.** No new storage objects. `Candidate`, `Evaluation`,
 
 C2. **Workload generality.** The semantics must serve, without privileging
     any of them:
-    (a) best-of-N — fork N candidates, evaluate, select one;
-    (b) iterative / population evolution (autoresearch) — generations of
+    (a) best-of-N: fork N candidates, evaluate, select one;
+    (b) iterative and population evolution (autoresearch): generations of
         candidates, top-k survivors as parents of the next generation,
         abandoned lines;
-    (c) single-candidate development — one candidate, evaluation fails,
+    (c) single-candidate development: one candidate, evaluation fails,
         repair produces a successor candidate, re-evaluate, accept.
-    Consequences: selections operate over candidate sets of size **≥ 1** and
-    may select **≥ 1** survivors; repair is an ordinary candidate-to-candidate
-    derivation; there is **no** `Generation`, `Tournament`, or `Repair`
-    object — all such structure is derivable (§8).
+    Consequences: selections operate over candidate sets of size at least 1
+    and may select 1 or more survivors; repair is an ordinary
+    candidate-to-candidate derivation; there is **no** `Generation`,
+    `Tournament`, or `Repair` object. All such structure is derivable (§8).
 
 C3. **Kernel engines unchanged; extension is additive.** Canonicalization,
     content addressing, the signature scheme, evidence derivation, taint
-    propagation, and the receipt replay structure are reused exactly as
-    they are — never modified, never scoped, never special-cased. What v0.3
-    adds sits beside them: three kinds with author-role rows and base
-    evidence classes (the same registration every kind has), new per-kind
-    verifier checks, two entries on the existing `Replace` kind whitelist
-    with a Selection compatibility rule, and one new *derived* replay output
-    (standing, §6.2). Anything that would require changing how an existing
-    v0.2 record verifies is out of scope by definition.
+    propagation, and the receipt replay structure are reused exactly as they
+    are: never modified, never scoped, never special-cased. What v0.3 adds
+    sits beside them: three kinds with author-role rows and base evidence
+    classes (the same registration every kind has), new per-kind verifier
+    checks, two entries on the existing `Replace` kind whitelist with a
+    Selection compatibility rule, a Selection approval-binding rule, and one
+    new *derived* replay output (standing, §6.2). Anything that would change
+    how an existing v0.2 record verifies is out of scope by definition.
 
 C4. **Git is the substrate, not the model.** v0.3 reads Git object ids and
-    optionally walks a worktree to compute a manifest. It performs no other
-    Git operations: no materialization, no remotes, no history rewriting.
+    optionally walks a tree to compute a manifest. It performs no other Git
+    operations: no materialization, no remotes, no history rewriting.
 
 C5. **No agent cognition.** Objectives, criteria, and rationales are bounded
     strings supplied by the host. Bellbook records them; it never interprets
@@ -131,18 +123,29 @@ conforming implementations diverge. v0.3 registers:
 
 Rationale. Candidates and evaluations are things any actor may honestly
 report producing or observing; rules narrow this per deployment. Selections
-are decisions, so `Executor` — the role that performs work — may not author
+are decisions, so `Executor`, the role that performs work, may not author
 them. Base classes are conservative: a candidate's binding and an
 evaluation's outcome are host-asserted (`Reported`); a selection is a
 judgment derived by reasoning (`Inferred`). Stored evidence can never exceed
 the derived minimum over base and `Use`/`Require` targets, so under this
-table: evaluations are at most `Reported`, selections at most `Inferred`,
-and per-kind thresholds at those levels are meaningful — their real teeth is
-that any retracted or tainted dependency drags the derived class to the
-`Assumed` floor and below threshold. Whether a key-pinned externally signed
-evaluation can be granted a `Verified` pathway is deliberately **not**
-claimed here (revision 2 overclaimed it); it is open question §16.8, to be
-settled against v0.2's actual `Verified` mechanism.
+table evaluations are at most `Reported`, selections at most `Inferred`, and
+per-kind thresholds at those levels are meaningful: any retracted or tainted
+dependency drags the derived class to the `Assumed` floor and below
+threshold.
+
+**The `Verified` pathway is out of v0.3 scope, and that exclusion is
+epoch-shaped.** The v0.2 mechanism for `Verified` is a dedicated schema with
+base class `Verified` whose use is gated by kind-specific verifier checks
+(signature present, author keys pinned): `Verified` is earned, never
+asserted. Extending that to evaluations requires a **gated pair**: an
+externally-attested Candidate schema and an external Evaluation schema, both
+with base `Verified` and both carrying the signature-and-pinning gate,
+because weakest-link derivation caps an evaluation at its candidate's class.
+Even then the pair is necessary, not sufficient: every additional `Use`
+target of the evaluation must also be at least `Verified`. Because the
+schema set is frozen per compatibility epoch (unknown schemas reject), this
+pathway is impossible to add within the v0.3 epoch; it is the first
+scheduled addition for v0.4 if demand shows (§15).
 
 One consequence for retraction, stated now because the flagship (§10)
 depends on it: v0.2 permits `Retraction` records to be authored only by
@@ -150,8 +153,8 @@ User, Provider, or System, and a record may be retracted only by its author
 or a configured `admin_retraction_actors` entry. **Executor-authored
 evaluations are therefore admin-retractable only.** Hosts that want the
 broken-benchmark recovery story must either author evaluations as Provider
-or System, or configure admin retraction. The RFC makes this a documented
-deployment decision, not an accident.
+or System, or configure admin retraction. This is a documented deployment
+decision, not an accident.
 
 ### 4.1 `Candidate`
 
@@ -182,27 +185,26 @@ development.
 |----------------|-------------------------------------------------|-----------------|
 | `root`         | starts a line (imported / initial state)        | at most one `Cause`, targeting an accepted Request; no other `Cause` targets; no `parent` |
 | `continuation` | continues from a selected state                 | MUST `Cause` exactly one record: an **accepted** `Selection` whose outcome is `selected`; `parent` MUST name a member of that Selection's selected set |
-| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each an **accepted** `Candidate` or `Evaluation`; no `parent` |
+| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` at least one record, each an **accepted** `Candidate` or `Evaluation`; no `parent` |
 
 Acceptance of every `Cause` target is checked at the candidate's commit
 position and, because acceptance is permanent in v0.2, holds forever after.
-This closes what the third audit named the *rejected-anchor hole*: without
-it, a continuation could anchor to a rejected Selection and yield a
-`Clean` receipt with a compromised lineage, and derivation standing would be
-undefined over rejected targets.
+Without this rule a continuation could anchor to a rejected Selection,
+yielding a `Clean` receipt over a compromised lineage, and derivation
+standing would be undefined over rejected targets.
 
-Continuation uses `Cause`, **not** `Require` — this is the revision-3
-change. `Cause` carries neither evidence derivation nor kernel taint, so a
-candidate's evidence class reflects how *its own content* is known, and a
-tainted history never blocks the recording of ongoing work (the log records
-what was attempted). The lineage consequence of the Selection's health is
-carried by **standing** (§6.2), which is derived from exactly these edges.
-The `parent` field is the specific selected state this candidate builds on;
-payload-id resolution rules for it are in §9 (V3-C5).
+Continuation uses `Cause`, not `Require`. `Cause` carries neither evidence
+derivation nor kernel taint, so a candidate's evidence class reflects how
+*its own content* is known, and a tainted history never blocks the recording
+of ongoing work (the log records what was attempted). The lineage
+consequence of the Selection's health is carried by standing (§6.2), which
+is derived from exactly these edges. The `parent` field is the specific
+selected state this candidate builds on; payload-id resolution rules for it
+are in §9.
 
 ### 4.2 `Evaluation`
 
-A judgment about exactly one candidate under an explicit criterion.
+A judgment about exactly one candidate under exactly one criterion.
 
 ```jsonc
 {
@@ -211,35 +213,46 @@ A judgment about exactly one candidate under an explicit criterion.
   "procedure": "<bounded string>", // OPTIONAL: how it was run (command, harness, version)
   "outcome": {
     "status": "passed",            // "passed" | "failed" | "scored"
-    "value": 930,                  // REQUIRED iff status == "scored"; integer
-    "scale": 3                     // REQUIRED iff status == "scored"; value/10^scale
+    "value": 930,                  // REQUIRED iff status == "scored"; signed 64-bit integer
+    "scale": 3                     // REQUIRED iff status == "scored"; 0..=12; value/10^scale
   }
 }
 ```
 
+One criterion per Evaluation is deliberate: retraction is record-granular in
+v0.2, so per-metric evaluations are the only shape that allows retracting
+one broken metric without erasing the others. Multi-metric outcomes are
+rejected for this reason. `value` is bounded to the signed 64-bit range and
+`scale` to 0 through 12 so consumers never face unbounded fixed-point
+arithmetic.
+
 **Ref obligations:** MUST `Use` the record named in `candidate`; MAY `Use`
 additional evidence records (e.g. Results, Usage, traces). The subject
-dependency is `Use` — genuinely epistemic — because the evaluation's content
+dependency is `Use`, genuinely epistemic, because the evaluation's content
 rests on the candidate's binding: if the candidate is retracted, every
 evaluation of it is correctly tainted and its derived evidence falls to the
-`Assumed` floor. This is kernel machinery doing exactly what it was built
-for, and it is kept.
+`Assumed` floor.
+
+Comparative (pairwise) evaluations have no direct form in v0.3; they are
+encoded as unary evaluations by host convention. This is revisited only if
+external users report comparative encoding as a concrete pain point (§15,
+signal 3 with that specific content).
 
 ### 4.3 `Selection`
 
 A recorded decision over a set of candidates under an objective. Selections
-are **set-valued**: the outcome names the surviving candidates — one for
-best-of-N or a repair accept, several for population/beam evolution where the
-top-k jointly become parents of the next generation. A single decision that
-keeps k survivors is one record, not k fragmented ones.
+are **set-valued**: the outcome names the surviving candidates. One for
+best-of-N or a repair accept; several for population or beam evolution where
+the top-k jointly become parents of the next generation. A single decision
+that keeps k survivors is one record, not k fragmented ones.
 
 ```jsonc
 {
   "objective": "<bounded string>",   // REQUIRED, non-empty
-  "considered": ["<id>", "..."],     // REQUIRED: ≥ 1, unique Candidate ids (resolution: §9 V3-S1)
+  "considered": ["<id>", "..."],     // REQUIRED: >= 1, unique Candidate ids (resolution: §9)
   "outcome": {
     "decision": "selected",          // "selected" | "none"
-    "candidates": ["<id>", "..."]    // REQUIRED iff selected: ≥ 1, unique, ⊆ considered
+    "candidates": ["<id>", "..."]    // REQUIRED iff selected: >= 1, unique, subset of considered
   },
   "rationale": "<bounded string>"    // OPTIONAL
 }
@@ -250,83 +263,116 @@ keeps k survivors is one record, not k fragmented ones.
 - If `decision == "selected"`: MUST `Require` every member of
   `outcome.candidates`. These `Require` refs are epistemically honest (the
   decision's validity rests on the winners' integrity) and give commit-time
-  teeth for free under unchanged kernel rules: a Selection whose winner is
-  retracted or tainted at its commit position is rejected outright.
+  teeth under unchanged kernel rules: a Selection whose winner is retracted
+  or tainted at its commit position is rejected outright.
 - Additional `Require` refs are permitted **only** for authority records
-  (Capability/Approval) demanded by the rules — see "Authority" below. No
-  other `Require` targets are allowed (V3-S2).
-- MUST `Use` ≥ 1 `Evaluation` when `decision == "selected"` (rules knob
-  `selection_requires_evaluation`, default true; a `none` decision has no
-  evaluation obligation). The `candidate` of every `Use`d Evaluation MUST
+  (Capability/Approval) demanded by the rules. No other `Require` targets
+  are allowed (V3-S2).
+- MUST `Use` at least one `Evaluation` when `decision == "selected"` (rules
+  knob `selection_requires_evaluation`, default true; a `none` decision has
+  no evaluation obligation). The `candidate` of every `Use`d Evaluation MUST
   appear in `considered`. This is the single normative statement of the
   evaluation obligation; §12's CLI grammar mirrors it.
 - `decision == "none"` records that no candidate was acceptable under the
-  objective — a legal, meaningful outcome (pruning, backtracking). It carries
+  objective: a legal, meaningful outcome (pruning, backtracking). It carries
   no candidate `Require`s.
 - A Selection MAY carry one `Replace` ref targeting a prior Selection: this
   is **reaffirmation** (§6.3), subject to the compatibility rule in V3-S5.
 
-**Authority.** Revision 2 claimed authority "composes unchanged"; that was
-wrong — v0.2's exact-approval machinery is Action-specific (its approval
-hash binds the action author and `ActionData`). v0.3 therefore defines the
-analogous binding for selections: when rules require an approval for
+**Authority.** v0.2's exact-approval machinery is Action-specific (its
+approval hash binds the action author and `ActionData`). v0.3 defines the
+analogous binding for selections. When rules require an approval for
 Selections, the approval's subject hash is
-`SHA-256(canonical((selection_author_id, SelectionData)))` in a
-selection-specific domain, the approving record is referenced by `Require`,
-and single-use consumption follows the existing approval rules. This is new,
-explicitly specified machinery modeled on the Action path — not a claim
-that the Action path already covers it.
 
-Losing candidates are listed in `considered` (descriptive) but not referenced
-via `Use`/`Require`; the decision's *epistemic* premises are the evaluations
-it declares it `Use`d. A comparative selection naturally `Use`s the losers'
-evaluations too. A Selection with `considered` of size 1 and a selected set
-of size 1 is the formal "accept this state under this objective" — the
-single-candidate workflow's terminal step (C2c).
+```
+SHA-256(canonical((
+  "bellbook.selection-approval.v0.3",   // domain
+  selection_author_id,
+  replace_target_id_or_null,            // the Replace target when present, else null
+  SelectionData
+)))
+```
+
+the approving record is referenced by `Require`, and single-use consumption
+follows the existing approval rules (consumption is an event; a later
+`Replace` of the consuming Selection never refunds it, matching v0.2, where
+no code path un-consumes). The Replace target is inside the hash so that an
+approval granted for a fresh Selection cannot be diverted onto a
+reaffirmation with identical data: approving a decision and approving the
+*restoration of a compromised line* are different acts and get different
+approvals. This is new, explicitly specified machinery modeled on the Action
+path, including a parallel consumption step on Selection accept.
+
+Losing candidates are listed in `considered` (descriptive) but not
+referenced via `Use`/`Require`; the decision's *epistemic* premises are the
+evaluations it declares it `Use`d. A comparative selection naturally `Use`s
+the losers' evaluations too. A Selection with `considered` of size 1 and a
+selected set of size 1 is the formal "accept this state under this
+objective": the single-candidate workflow's terminal step (C2c).
 
 ## 5. Source binding model
 
-Identity binds to the **Git tree**, not the commit: two commits with the same
-tree are the same software state. The commit OID, when present, is
+Identity binds to the **Git tree**, not the commit: two commits with the
+same tree are the same software state. The commit OID, when present, is
 provenance.
 
 Two binding modes, distinguished explicitly in the payload:
 
-- **`reported`** — the host asserts the Git OIDs. Cheap (no I/O). Bellbook
-  proves the *claim was recorded*, not that the OIDs match any file contents.
-  Inherits Git's hash properties (SHA-1 for classic repos).
-- **`manifest`** — `manifest_hash` is additionally present: a SHA-256 over
-  the Bellbook canonical manifest of the materialized tree (§5.1), computed
-  by the recording process. Costs one worktree walk; upgrades the receipt to
-  a content commitment independent of Git's hash algorithm: anyone holding
-  the tree can recompute the manifest and compare.
+- **`reported`**: the host asserts the Git OIDs. Cheap (no I/O). Bellbook
+  proves the *claim was recorded*, not that the OIDs match any file
+  contents. Inherits Git's hash properties (SHA-1 for classic repos).
+- **`manifest`**: `manifest_hash` is additionally present, a SHA-256 over
+  the Bellbook canonical manifest of the tree (§5.1), computed by the
+  recording process. Costs one tree walk; upgrades the receipt to a content
+  commitment that a party holding the tree can independently recompute and
+  compare.
 
 **Authority on disagreement.** Nothing inside a record can prove that
-`manifest_hash` and `git.tree` describe the same contents; a false record can
-carry a tree OID and a manifest that disagree. When both are present, the
-**manifest is the authoritative identity commitment** and the tree OID is an
-interoperability pointer; a disagreement makes the record a false claim,
-detectable only by materializing the tree and recomputing the manifest —
-the same boundary v0.2 draws for `Verified` evidence ("origin verified,
-never the real-world effect"). SPEC v0.3 §13 must state this.
+`manifest_hash` and `git.tree` describe the same contents; a false record
+can carry a tree OID and a manifest that disagree. When both are present,
+the **manifest is the authoritative identity commitment** and the tree OID
+is an interoperability pointer; a disagreement makes the record a false
+claim, detectable only by materializing the tree and recomputing the
+manifest. This is the same boundary v0.2 draws for `Verified` evidence
+(origin verified, never the real-world effect). SPEC v0.3 §13 must state it.
 
-**Adoption reality, stated in advance.** The manifest walk is O(worktree) per
+**Algorithm independence, qualified.** For submodule-free trees the manifest
+is independent of Git's hash algorithm, which also makes it the commitment
+of choice for SHA-1 to SHA-256 migration eras; dual-hash bindings are not
+supported (a record cannot prove two tree OIDs describe the same contents,
+the same unverifiable-pairing boundary as above). For trees containing
+submodules the qualification in §5.1 applies: a gitlink entry commits to a
+Git-algorithm commit OID and to no submodule contents at all.
+
+**Adoption reality, stated in advance.** The manifest walk is O(tree) per
 candidate. High-N workloads will predictably use `reported` for the
 population, which means their receipts commit to claims about SHA-1 hashes,
-not to contents. That is acceptable and must be said plainly, not
-discovered. The intended pattern is cheap `reported` bindings for the
-population and strong binding for the states that matter (the selected
-survivors); since a record's binding is immutable, how a survivor's binding
-gets upgraded (e.g. a manifest-bound re-record of the same tree that the
-Selection then `Require`s) is open question §16.6.
+not to contents. That is acceptable and is said plainly here. The intended
+pattern is cheap `reported` bindings for the population and strong binding
+for the survivors, via the upgrade idiom below.
+
+**Binding upgrade idiom.** A record's binding is immutable, so a survivor's
+binding is upgraded by a new Candidate with the **same** `source.git.tree`,
+`binding: "manifest"`, and `basis: "derivation"` with a single `Cause` ref
+to the reported-binding Candidate it upgrades. Under §6.2 the upgrade
+inherits the original's standing, and because a retracted Candidate has
+compromised, unrestorable standing (§6.2), retracting the original also
+compromises the upgrade: the idiom cannot be used to launder a retracted
+state back into a sound line. A Selection may then `Require` the upgrade
+while `Use`-ing evaluations whose subject is the original, provided both
+appear in `considered`. Nothing in the verifier checks tree equality between
+the two records (that is the §11 recording-discipline boundary), so the CLI
+MUST refuse to build an upgrade derivation whose tree differs from its
+target's, and the idiom's documentation states that a differing-tree
+"upgrade" is indistinguishable in-band from an honest one.
 
 **Binding strength and the lattice.** Binding strength is carried by the
 explicit `binding` field plus a per-kind rules threshold (`min_binding`,
-§9) — *not* by overloading the evidence-class definitions, whose v0.2
-meanings stay fixed. Rules like "any candidate a Selection `Require`s must
-have `manifest` binding" are expressible without touching the lattice.
+§9), not by overloading the evidence-class definitions, whose v0.2 meanings
+stay fixed. Rules like "any candidate a Selection `Require`s must have
+`manifest` binding" are expressible without touching the lattice.
 
-### 5.1 Canonical manifest v1 (proposal)
+### 5.1 Canonical manifest v1
 
 A JCS-canonicalized JSON object mapping repo-relative POSIX paths (sorted by
 JCS rules) to entries:
@@ -336,11 +382,18 @@ JCS rules) to entries:
 ```
 
 - Modes: `100644`, `100755`, `120000` (symlink; `sha256` is over the target
-  string). Directories are implicit; empty directories are unrepresented.
-- `.git` is excluded. Bytes are hashed as materialized on disk — no EOL or
-  attribute normalization.
-- `manifest_hash` = SHA-256 over the JCS bytes of that object.
-- Submodules: **out of scope for v1** (open question §16).
+  string), `160000` (gitlink; `sha256` is over the submodule commit OID as a
+  lowercase-hex ASCII string with no trailing newline). Directories are
+  implicit; empty directories are unrepresented.
+- Gitlink entries are sourced from the **Git tree object**, never from
+  worktree state, so initialized and uninitialized submodule checkouts of
+  the same tree yield the same manifest. A gitlink commits to the submodule
+  *pointer* only, never to submodule contents.
+- `.git` is excluded. File bytes are hashed as materialized on disk, with no
+  EOL or attribute normalization.
+- `manifest_hash` = SHA-256 over the JCS bytes of that object. The manifest
+  itself is never stored or embedded; only the hash rides in the payload, so
+  no manifest-specific size bound is needed.
 
 ## 6. Knowledge, taint, and standing
 
@@ -348,116 +401,123 @@ JCS rules) to entries:
 
 v0.2's rules apply verbatim. Evidence derivation: a record's stored evidence
 must equal the weakest of its base class and the evidence of every
-`Use`/`Require` target, with rejected/retracted/tainted targets contributing
-the `Assumed` floor. Taint: propagates transitively through `Use` and
-`Require`, never `Cause`; a record that `Use`s a tainted record commits but
-is tainted; a record that `Require`s a tainted or retracted record is
-rejected. Under §4's ref discipline this yields, per generation:
-evaluations ≤ `Reported`, selections ≤ `Inferred` — and, because
-continuation edges are `Cause`, **evidence does not compound across
-generations**: each candidate's class reflects its own binding, each
-evaluation its own grounding. (Revision 2's design collapsed all lineages to
-a fixed point within one generation and made threshold rules unusable; this
-is the fix.)
+`Use`/`Require` target, with rejected, retracted, or tainted targets
+contributing the `Assumed` floor. Taint: propagates transitively through
+`Use` and `Require`, never `Cause`; a record that `Use`s a tainted record
+commits but is tainted; a record that `Require`s a tainted or retracted
+record is rejected. Under §4's ref discipline this yields, per generation:
+evaluations at most `Reported`, selections at most `Inferred`. Because
+continuation edges are `Cause`, evidence does not compound across
+generations: each candidate's class reflects its own binding, each
+evaluation its own grounding. Mandating `Use` or `Require` on lineage edges
+would instead collapse every lineage to a fixed point within one generation
+and make per-kind thresholds unusable at depth.
 
 ### 6.2 Standing: a derived lineage dimension
 
 **Definition.** Standing answers: *does this candidate's membership in a
-chosen line still rest on decisions that stand?* It is computed at replay
-end, from accepted records only, as a pure function of the log — exactly as
-deterministic and forgery-resistant as the taint set, because a validator
-re-derives it. It is **not** kernel taint: it does not affect evidence, does
-not gate commits by default, and is reported alongside taint, never merged
-with it.
+chosen line still rest on states and decisions that stand?* It is computed
+at replay end, from accepted records only, as a pure function of the log,
+exactly as deterministic and forgery-resistant as the taint set, because a
+validator re-derives it. It is **not** kernel taint: it does not affect
+evidence, does not gate commits by default, and is reported alongside taint,
+never merged with it.
 
 Let a Selection S be **unsound** at replay end iff S is retracted or
 tainted. (A rejected Selection can never be an anchor: V3-C3 requires every
 `Cause` target of a Candidate to be accepted at commit, and acceptance is
-permanent — so an anchor can become unsound only *after* the fact, via
+permanent, so an anchor can become unsound only after the fact, via
 retraction or taint.) Define **anchor soundness** for a continuation
-candidate C with `Cause` → S and `parent` = P:
+candidate C with `Cause` to S and `parent` = P:
 
 - S itself is sound, **or**
-- some accepted, sound Selection S′ exists with a `Replace` chain leading to
+- some accepted, sound Selection S2 exists with a `Replace` chain leading to
   S (one or more hops, every intermediate accepted) whose selected set
   contains P. If multiple replacements of S exist, **any** sound one
   suffices (deterministic: existential over the fixed replay-end set).
-  Intermediates need only be *accepted*, not sound — requiring soundness
+  Intermediates need only be *accepted*, not sound: requiring soundness
   would recreate a frozen-chain pathology while granting nothing, since a
   host can always `Replace` S directly (multiple replacements of one target
-  are legal in v0.2); a corpus case pins this reading.
+  are legal in v0.2). A corpus case pins this reading.
 
 Then standing is derived recursively (well-founded: all edges point to
 earlier records):
 
-- `root` candidate: **sound**.
-- `continuation` candidate: **sound** iff its anchor is sound **and**
-  standing(P) is sound; otherwise **compromised**.
-- `derivation` candidate: **sound** iff every `Cause`d Candidate has sound
-  standing (evaluation targets carry no standing); a derivation with only
-  Evaluation targets is **sound**.
+- **A retracted Candidate is compromised, unconditionally and
+  unrestorably.** No anchor rule, parent rule, or reaffirmation applies to
+  it. Retracting a candidate asserts the state itself was wrong, and a
+  state that was wrong has no legitimate membership in any line. Without
+  this base case, a same-tree derivation of a retracted candidate would
+  re-enter the line with sound standing, defeating retraction entirely.
+- `root` candidate (not retracted): **sound**.
+- `continuation` candidate (not retracted): **sound** iff its anchor is
+  sound **and** standing(P) is sound; otherwise **compromised**.
+- `derivation` candidate (not retracted): **sound** iff every `Cause`d
+  Candidate has sound standing (evaluation targets carry no standing); a
+  derivation with only Evaluation targets is **sound**.
 
 **Where standing lives: the replay report only.** A v0.2 receipt embeds
-nothing derived — it is `{spec_version, rules, records}`, and the
+nothing derived; it is `{spec_version, rules, records}`, and the
 retracted/tainted sets exist only in the validator's report, re-derived on
 every validation. Standing follows the same discipline exactly: the
 **report** gains a `standing` section; receipts are unchanged in shape, and
-there is no embedded standing for anyone to forge — a validator that derives
-a different standing set from the same records is simply nonconforming,
-which the corpus detects the same way it detects taint disagreement.
+there is no embedded standing for anyone to forge. A validator that derives
+a different standing section from the same records is nonconforming, which
+the corpus detects the same way it detects taint disagreement.
 
-**Normative content of the `standing` section** (field names are open
-question §16.7; the content is not):
+**Normative content and encoding of the `standing` section:**
 
 - `compromised`: the set of standing-compromised Candidate ids;
 - `unsound`: the set of unsound Selection ids;
-- `restorations`: for each unsound Selection that has at least one sound
+- `restorations`: for each unsound Selection with at least one sound
   replacement chain, the set of sound replacing Selection ids.
 
-All three are pure functions of the accepted records at replay end, with
-canonical (logical-time) ordering for output. Restored lines are visible as:
-their candidates absent from `compromised`, their anchor present in
-`unsound`, and the restoring Selection listed in `restorations` — closing
-the gap between this section and §7/§10's restoration queries.
+All three are pure functions of the accepted records at replay end. Sets are
+**id-byte-ordered**, matching the ordering of the v0.2 report's retracted
+and tainted sets, and `restorations` is encoded as pairs sorted by key id
+with each value set id-byte-ordered, so both implementations produce
+byte-identical sections. Restored lines are visible as: their candidates
+absent from `compromised`, their anchor present in `unsound`, and the
+restoring Selection listed in `restorations`.
 
-Whenever `compromised` is non-empty, the responsible anchor is necessarily
-retracted or tainted (rejected anchors are impossible per V3-C3, and
-acceptance is permanent), so the report's overall status is already
-`Tainted` under unchanged v0.2 status rules — v0.2 reports `Tainted`
-whenever either the retracted or the tainted set is non-empty. Standing adds
-*which lineage* is affected and *what restored it*; it never manufactures a
-status v0.2 would not report. Two independent implementations must derive
-identical standing sections; corpus receipt cases pin the expected values
-(§13).
+Whenever `compromised` is non-empty, some record is necessarily retracted or
+tainted (a compromised candidate is either itself retracted, or traces to a
+retracted or tainted Selection), so the report's overall status is already
+`Tainted` under unchanged v0.2 status rules: v0.2 reports `Tainted` whenever
+either the retracted or the tainted set is non-empty. Standing adds *which
+lineage* is affected and *what restored it*; it never manufactures a status
+v0.2 would not report. Corpus receipt cases pin the expected sections (§13).
 
 **What standing deliberately does not do.** It does not reject new
-continuations of an unsound Selection — they commit and are born
-compromised, because a ledger that cannot record ongoing work stops being a
-ledger (and produces the perverse incentive to mislabel continuations as
-derivations). Rules MAY opt into commit-time strictness
+continuations of an unsound Selection; they commit and are born compromised,
+because a ledger that cannot record ongoing work stops being a ledger (and
+produces the perverse incentive to mislabel continuations as derivations).
+Rules MAY opt into commit-time strictness
 (`reject_compromised_continuation`, default false).
 
-### 6.3 Reaffirmation: one-record recovery, at any depth
+### 6.3 Reaffirmation: one-record recovery for decision-level compromise
 
-A Selection S′ carrying `Replace` → S is a **reaffirmation**: a new decision
-over the same objective, on evidence that currently stands. Requirements
-(V3-S5): the target is a Selection in the same space with the same
-`objective`; rules MAY restrict reaffirmation authorship
-(`reaffirmation_actors`: an explicit allowlist of actor *identities*; when
-unset, the Selection author-role row applies).
+A Selection S2 carrying `Replace` to S is a **reaffirmation**: a new
+decision over the same objective, on evidence that currently stands.
+Requirements (V3-S5): the target is a Selection in the same space with the
+same `objective`; rules MAY restrict reaffirmation authorship
+(`reaffirmation_actors`: an explicit allowlist of actor identities; when
+unset, the Selection author-role row applies). The same-objective rule makes
+objective strings de facto immutable identifiers; hosts should treat them as
+keys, not prose, because a rephrased objective makes reaffirmation of older
+Selections impossible (new root only).
 
-Because standing (not kernel taint) carries lineage consequence, S′ is
-committable **at any depth**: its `Require`d winners are ordinary untainted
-candidates, its `Use`d evaluations are ordinary untainted evaluations (a
+Because standing, not kernel taint, carries lineage consequence, S2 is
+committable at any depth: its `Require`d winners are ordinary untainted
+candidates and its `Use`d evaluations are ordinary untainted evaluations (a
 candidate is never kernel-tainted by its line's compromise), so nothing
 blocks the append. One committed reaffirmation whose selected set contains
 the relevant parents restores standing for the entire descendant subtree at
-the next replay — zero re-recording. (Revision 2's design required
-re-recording every intervening generation because `Require`-of-tainted is a
-hard rejection; this is the fix.)
+the next replay, with zero re-recording. If continuation edges carried
+`Require` instead, the kernel's hard rejection of `Require`-of-tainted would
+make a reaffirmation uncommittable anywhere but the cascade origin.
 
-Honesty properties, unchanged from revision 2 and now structurally
-guaranteed:
+Properties, all structural:
 
 - **Forward-only, laundering-proof.** The retraction, the tainted Selection,
   and the reaffirmation all remain permanently in the log and the receipt;
@@ -466,39 +526,38 @@ guaranteed:
   restored it. Kernel taint is never cleared, retroactively or otherwise.
 - **Degenerate reaffirmations are inert.** A reaffirmation with
   `decision: "none"` (recorded abandonment: "we reviewed; nothing stands")
-  restores no standing — the §6.2 walk requires the parent in a *selected*
+  restores no standing; the §6.2 walk requires the parent in a *selected*
   set. Competing reaffirmations with different selected sets each restore
   exactly the parents they name; the walk's existential rule keeps the
   result deterministic and order-independent.
 - **Replacement side effects are v0.2's.** A `Replace`d Selection leaves
-  context construction, as any replaced record does today; the RFC adds no
+  context construction, as any replaced record does today; this RFC adds no
   new Replace semantics beyond the whitelist entries and the compatibility
   rule. Consequently, replacing a *sound* Selection is legal (V3-S5 does not
-  require the target to be unsound — a state-dependent Replace rule would be
-  new machinery): standing is unaffected (soundness is never revoked by
-  replacement), but the target still leaves context construction. Hosts
-  should not `Replace` healthy Selections casually; this side effect is
-  documented rather than forbidden.
-- **Retracted parents are unrestorable — by design.** Reaffirmation
-  recovers from retracted or tainted *decisions*. If a selected *candidate*
-  is itself retracted ("the state was wrong," not "the decision no longer
-  stands"), no reaffirmation can restore its descendants: any restoring
-  Selection must `Require` that candidate, and `Require`-of-retracted is a
-  hard rejection. The only path forward is a new `root` — the graver claim
-  gets the graver consequence, and the flagship's recovery story is
-  explicitly conditional on *what* was retracted. Corpus cases cover both
-  (§13).
+  require the target to be unsound; a state-dependent Replace rule would be
+  new machinery): standing is unaffected, but the target still leaves
+  context construction. Hosts should not `Replace` healthy Selections
+  casually; this side effect is documented rather than forbidden.
+- **Retracted states are unrestorable, at every level.** Reaffirmation
+  recovers from retracted or tainted *decisions*. A retracted *candidate*
+  is compromised by the §6.2 base case, its descendants stay compromised
+  through the parent and derivation legs, and any Selection trying to
+  re-select it is rejected outright (`Require`-of-retracted). The only path
+  forward is a new `root`: the graver claim gets the graver consequence,
+  and the recovery story is explicitly conditional on *what* was retracted.
+  Corpus cases cover both (§13).
 - **The default trust posture, stated bluntly.** Under default rules,
   restoration is producible in **two records** by any actor in the Selection
   author-role row: one self-authored Evaluation of the old parent, one
   reaffirming Selection. Restoration is therefore *ownership-unbound* while
   retraction is *ownership-bound* (only a record's author or a configured
-  admin may retract). Everything stays visible — the junk evaluation, the
-  reaffirmation, and their authors are permanently on the record, and a
-  consumer can judge the restoring evidence for itself — but deployments
-  that need restoration to be as guarded as compromise MUST set
-  `reaffirmation_actors` and/or require approvals on Selections (§4.3).
-  The default favors recordability; the knobs supply the guarantees.
+  admin may retract). Everything stays visible; the restoring evidence and
+  its authors are permanently on the record, and a consumer can judge them.
+  But deployments that need restoration to be as guarded as compromise MUST
+  set `reaffirmation_actors` and/or require approvals on Selections (§4.3,
+  whose approval hash binds the Replace target precisely so a fresh-decision
+  approval cannot be diverted onto a restoration). The default favors
+  recordability; the knobs supply the guarantees.
 - **Last resort.** A host abandoning a line entirely may start a new `root`
   candidate with a provenance `note`; the receipt shows the break in
   verifiable lineage. That is the honest cost of a re-baseline.
@@ -508,7 +567,7 @@ guaranteed:
 No lineage is stored. Defined queries over refs and payload fields:
 
 - **line of descent**: from any Candidate, follow its continuation edge
-  (`Cause`d Selection + `parent`) and derivation `Cause` edges back to a
+  (`Cause`d Selection plus `parent`) and derivation `Cause` edges back to a
   `root`.
 - **siblings / a "generation"**: candidates sharing the same `Cause`d
   Selection (continuations) or the same `Cause` targets (derivations).
@@ -522,33 +581,36 @@ non-goal (§14).
 
 ## 8. Workload walkthroughs (generality check, C2)
 
-**Best-of-N.** Selection S₀ selects state A. N candidates, each
-`basis: continuation`, `parent: A`, `Cause` S₀. Each gets one or more
+**Best-of-N.** Selection S0 selects state A. N candidates, each
+`basis: continuation`, `parent: A`, `Cause` S0. Each gets one or more
 Evaluations. One Selection considers all N, `Use`s their evaluations,
 `Require`s and selects one. Continue.
 
 **Population / beam evolution (autoresearch).** A Selection selects the
 top-k survivors {A, B} in one record. Generation k+1 candidates each name
-`parent: A` or `parent: B` and `Cause` that Selection. Mutations *within*
-a generation are `basis: derivation` candidates `Cause`-ing a sibling.
+`parent: A` or `parent: B` and `Cause` that Selection. Mutations within a
+generation are `basis: derivation` candidates `Cause`-ing a sibling.
 Abandoned lines simply have no continuation; recorded pruning is a Selection
-with `decision: none` over the line's frontier.
+with `decision: none` over the line's frontier. If an evaluation behind the
+top-k decision is later retracted, the Selection and both lines are marked;
+a reaffirmation re-selecting {A} on surviving evidence restores forward
+standing for A's line while B's line remains visibly unrestored.
 
-**Deep-taint recovery (the case revision 2 could not handle).** At
-generation 5, the harness discovers the generation-2 benchmark was broken and
-retracts its Evaluations. Kernel taint reaches exactly the generation-2
-Selection (it `Use`d them). Standing marks generations 3–5 compromised.
-Work continues uninterrupted (new continuations commit, born compromised).
-The team re-runs the surviving generation-2 evaluations, commits **one**
-reaffirming Selection (`Replace` → S₂) re-selecting the same parents on that
-evidence — and at the next replay the entire descendant subtree's standing
-is sound again, with the whole episode (retraction, taint, compromise,
-reaffirmation) permanently on the record.
+**Deep-taint recovery.** At generation 5, the harness discovers the
+generation-2 benchmark was broken and retracts its Evaluations. Kernel taint
+reaches exactly the generation-2 Selection (it `Use`d them). Standing marks
+generations 3 through 5 compromised. Work continues uninterrupted (new
+continuations commit, born compromised). The team re-runs the surviving
+generation-2 evaluations, commits **one** reaffirming Selection (`Replace`
+to S2) re-selecting the same parents on that evidence, and at the next
+replay the entire descendant subtree's standing is sound again, with the
+whole episode (retraction, taint, compromise, reaffirmation) permanently on
+the record.
 
-**Single-candidate repair.** C₁ (`root` or `continuation`) → Evaluation E₁
-fails → C₂ `basis: derivation`, `Cause` [C₁, E₁] → Evaluation E₂ passes →
-Selection with `considered: [C₂]` (or `[C₁, C₂]` if the host wants the
-comparison on record), `Use` [E₂ (, E₁)], `Require`-ing and selecting [C₂].
+**Single-candidate repair.** C1 (`root` or `continuation`) gets Evaluation
+E1, which fails. C2 is `basis: derivation`, `Cause` [C1, E1]. Evaluation E2
+passes. A Selection with `considered: [C2]` (or `[C1, C2]` if the host wants
+the comparison on record), `Use` [E2 (, E1)], `Require`s and selects [C2].
 The accept step is the same object best-of-N uses; nothing is privileged.
 
 ## 9. Verifier rules (additions to the per-record battery)
@@ -563,71 +625,78 @@ a triggering corpus case:
 `considered`, and `Evaluation.candidate` are payload ids, not refs; v0.2's
 ref battery never touches them. v0.3 defines: each MUST resolve, in the same
 space, to a previously **accepted** `Candidate` record (retracted or tainted
-targets resolve — those conditions surface through evidence/taint on refs
-and through standing, not through payload lookup). Unresolvable,
+targets resolve; those conditions surface through evidence and taint on
+refs and through standing, not through payload lookup). Unresolvable,
 cross-space, or wrong-kind payload ids reject.
 
 **Candidate**
 - V3-C1: `source.git.tree` present, hex, length matching `algo`.
-- V3-C2: `binding == "manifest"` ⇒ `manifest_hash` present (64-hex);
-  `binding == "reported"` ⇒ `manifest_hash` absent.
+- V3-C2: `binding == "manifest"` implies `manifest_hash` present (64-hex);
+  `binding == "reported"` implies `manifest_hash` absent.
 - V3-C3: basis/ref obligations of §4.1 hold, **including acceptance of every
-  `Cause` target at commit position**: continuation ⇒ exactly one `Cause`,
-  targeting an *accepted* Selection with `decision == "selected"`;
-  derivation ⇒ ≥ 1 `Cause`, each an *accepted* `Candidate` or `Evaluation`,
-  none a `Selection`; root ⇒ at most one `Cause`, targeting an *accepted*
-  Request, and no other `Cause` targets. (Closes the rejected-anchor hole,
-  §4.1/§6.2.)
+  `Cause` target at commit position**: continuation implies exactly one
+  `Cause`, targeting an *accepted* Selection with `decision == "selected"`;
+  derivation implies at least one `Cause`, each an *accepted* `Candidate` or
+  `Evaluation`, none a `Selection`; root implies at most one `Cause`,
+  targeting an *accepted* Request, and no other `Cause` targets.
 - V3-C5: `parent` present iff `basis == "continuation"`; resolves per the
   shared rule; and names a member of the `Cause`d Selection's selected set.
-
-(Revision 2's V3-C4 — rejecting continuation of a retracted Selection — is
-**removed**: with `Cause` edges the generic kernel rules do not apply, and
-its consequence is now correctly carried by standing (§6.2), with the
-optional `reject_compromised_continuation` knob for hosts that want
-commit-time strictness.)
 
 **Evaluation**
 - V3-E1: `candidate` names an accepted Candidate (shared rule) and is
   matched by a `Use` ref.
-- V3-E2: `criterion` non-empty; `outcome` well-formed per status
-  (`scored` ⇔ `value` and `scale` present).
+- V3-E2: `criterion` non-empty; `outcome` well-formed per status (`scored`
+  iff `value` and `scale` present; `value` within the signed 64-bit range;
+  `scale` in 0 through 12).
 
 **Selection**
 - V3-S1: `considered` non-empty, unique, each member resolving per the
-  shared rule.
-- V3-S2: `decision == "selected"` ⇒ `outcome.candidates` non-empty, unique,
-  ⊆ `considered`, each `Require`d; every `Require` target is either a
-  selected candidate or an authority record (Capability/Approval) demanded
-  by the rules; `decision == "none"` ⇒ no candidate `Require`s.
-- V3-S3: every `Use`d Evaluation's `candidate` ∈ `considered`.
-- V3-S4 (knob `selection_requires_evaluation`, default true): ≥ 1 `Use`d
-  Evaluation when `decision == "selected"`.
+  shared rule, and its length at most `max_considered`.
+- V3-S2: `decision == "selected"` implies `outcome.candidates` non-empty,
+  unique, a subset of `considered`, each `Require`d; every `Require` target
+  is either a selected candidate or an authority record
+  (Capability/Approval) demanded by the rules; `decision == "none"` implies
+  no candidate `Require`s.
+- V3-S3: every `Use`d Evaluation's `candidate` is in `considered`.
+- V3-S4 (knob `selection_requires_evaluation`, default true): at least one
+  `Use`d Evaluation when `decision == "selected"`.
 - V3-S5: at most one `Replace` ref (v0.2 rule); if present, the target is a
   Selection, same space, same `objective`; author satisfies
   `reaffirmation_actors` when set.
+- V3-S6: when rules require Selection approvals, the `Require`d approval's
+  subject hash matches §4.3's binding (including the Replace target or
+  null), and consumption follows the existing single-use rules via a
+  parallel consumption step on Selection accept.
 
-**New rules knobs**
+**Rules knobs**
 - `min_binding` per referencing context (e.g. Selections may only `Require`
   candidates with `manifest` binding).
 - `selection_requires_evaluation` (default true).
-- `reaffirmation_actors` (identity allowlist; unset ⇒ the Selection
-  author-role row alone governs — see §6.3's trust-posture statement).
+- `reaffirmation_actors` (identity allowlist; unset means the Selection
+  author-role row alone governs; see §6.3).
 - `reject_compromised_continuation` (default false; §6.2).
+- `max_considered` (default 4096). Note the interplay with receipt limits:
+  the default receipt bound on refs per record is also 4096, and
+  `considered` members are payload ids that carry no refs, but a comparative
+  Selection that `Use`s one evaluation per considered candidate plus its
+  `Require`d winners can exceed the receipt's ref bound even though the
+  verifier accepted the record. The effective bound on `Use`d evaluations is
+  therefore the receipt ref limit; SPEC v0.3 states this interplay and a
+  corpus case pins a Selection near both bounds.
 - Per-kind evidence thresholds and author-role bindings apply to the three
   kinds exactly as to existing kinds, using §4.0's registrations.
 
 **Spec-level changes beyond the battery** (still additive, per C3): the
 `Replace` kind whitelist gains `Selection` (carrier) / `Selection` (target)
 with the V3-S5 compatibility rule; the **replay report** gains the
-`standing` section (§6.2 — receipts embed nothing derived, unchanged from
-v0.2); SPEC v0.3 defines the selection approval-binding hash (§4.3
-"Authority") with its own domain string.
+`standing` section (§6.2; receipts embed nothing derived, unchanged from
+v0.2); SPEC v0.3 defines the selection approval-binding hash and its domain
+string (§4.3).
 
 **Reachability pre-commitment (for VISION stages, decided now while it is
 cheap):** `parent`, `considered`, and `Evaluation.candidate` are edges that
 ref-walking tools cannot see. SPEC v0.3 therefore states normatively that
-**reachability over v0.3 kinds is payload-aware** — any future garbage
+**reachability over v0.3 kinds is payload-aware**: any future garbage
 collection, synchronization, or checkpoint tooling MUST treat these payload
 ids as reachability edges, or it would silently sever the standing spine.
 This is recorded in the spec now, before any such tooling exists, so no
@@ -637,33 +706,36 @@ later stage can inherit ref-only reachability as a hidden default.
 
 The demonstration this release is built around:
 
-> A benchmark harness is discovered to be broken. Its Evaluations — authored
-> by the Provider (or admin-retractable by configuration; §4.0) — are
+> A benchmark harness is discovered to be broken. Its Evaluations, authored
+> by the Provider (or admin-retractable by configuration; §4.0), are
 > retracted. Kernel taint reaches every Selection that `Use`d them, exactly
 > as v0.2 defines. The `standing` section of the replay report now shows
 > every descendant candidate of those Selections as compromised,
 > transitively, at any depth. Repairs and mutations merely *motivated* by
-> the broken evaluations remain sound — a derivation is compromised only
-> when a **candidate** it derives from is compromised; evaluation
-> motivations alone never compromise. Work never stops:
-> the line keeps recording, visibly compromised. The team re-runs the
-> surviving evaluations and commits one reaffirming Selection; the next
-> replay shows the line's standing restored — with the retraction, the
-> taint, the compromise, and the recovery all permanently, verifiably on
-> the record.
+> the broken evaluations remain sound: a derivation is compromised only when
+> a **candidate** it derives from is compromised (including by that
+> candidate's own retraction); evaluation motivations alone never
+> compromise. Work never stops: the line keeps recording, visibly
+> compromised. The team re-runs the surviving evaluations and commits one
+> reaffirming Selection; the next replay shows the line's standing restored,
+> with the retraction, the taint, the compromise, and the recovery all
+> permanently, verifiably on the record.
 
-Standing means "rests on decisions that no longer stand," never "the code is
-wrong" — and the one-record recovery is part of the demo precisely so the
-cascade reads as actionable state, not a permanent alarm or a frozen ledger.
-It ships as a worked example plus corpus receipt cases covering: the full
-compromise cascade, the derivation non-cascade (evaluation-only motivation)
-and the derivation cascade (compromised-candidate derivation), deep
-reaffirmation recovery, a `none`-decision reaffirmation restoring nothing,
-competing reaffirmations, a replacement chain through an accepted-but-unsound
-intermediate, the retracted-parent unrestorable case, and expected-standing
-agreement cases that pin the report's `standing` section byte-for-decision —
-the same mechanism that already enforces taint agreement between the two
-implementations.
+Standing means "rests on states and decisions that no longer stand," never
+"the code is wrong," and the one-record recovery is part of the demo
+precisely so the cascade reads as actionable state, not a permanent alarm or
+a frozen ledger. It ships as a worked example plus corpus receipt cases
+covering: the full compromise cascade; the derivation non-cascade
+(evaluation-only motivation) and the derivation cascade
+(compromised-candidate derivation); deep reaffirmation recovery; a
+`none`-decision reaffirmation restoring nothing; competing reaffirmations; a
+replacement chain through an accepted-but-unsound intermediate; the
+retracted-parent and retracted-candidate unrestorable cases, including the
+binding-upgrade idiom before and after retraction of its original; a
+Selection near both the `max_considered` and receipt ref bounds; and
+expected-standing agreement cases that pin the report's `standing` section
+byte-for-decision, the same mechanism that already enforces taint agreement
+between the two implementations.
 
 ## 11. Receipt boundary
 
@@ -671,12 +743,12 @@ A v0.3 receipt proves the recorded **process**: which candidates were
 recorded, what was claimed about them, which evidence and evaluations
 existed, what was selected under what objective, what is retracted, tainted,
 or standing-compromised and what restored it (all re-derived by the
-validator from the records — never embedded in the receipt), and that none
-of it was altered after the fact. It does **not** contain source contents; Git OIDs
-are pointers whose resolution requires the repository. With `manifest`
+validator from the records, never embedded in the receipt), and that none of
+it was altered after the fact. It does **not** contain source contents; Git
+OIDs are pointers whose resolution requires the repository. With `manifest`
 binding, a party holding the tree can independently recompute
 `manifest_hash` and bind the receipt to actual contents; with `reported`
-binding they hold a verifiable record of an unverified claim — and the
+binding they hold a verifiable record of an unverified claim, and the
 receipt says which, explicitly.
 
 One further boundary, stated with the same bluntness: **the lineage,
@@ -685,22 +757,23 @@ discipline.** `basis`, `parent`, and the choice of refs are producer claims;
 a host that records continuations as derivations escapes the standing
 cascade, and no verifier can detect that, because intent is not checkable.
 Bellbook proves the recorded structure is internally consistent under its
-rules — it does not prove the structure faithfully mirrors the development
+rules; it does not prove the structure faithfully mirrors the development
 process. A receipt consumer trusts the embedded `rules_hash` *and* the
 producer's recording conventions. This is v0.2's "consistency, not
 completeness" boundary extended one level, and it must appear in SPEC v0.3
-§13 verbatim in spirit.
+§13 in the same spirit.
 
 ## 12. CLI surface (the wedge's adoption surface)
 
-Thin wrappers over the crate; JSON in/out; every command prints the committed
-record id; harnesses in any language integrate by shelling out.
+Thin wrappers over the crate; JSON in/out; every command prints the
+committed record id; harnesses in any language integrate by shelling out.
 
 ```
 bellbook candidate add  --git-tree <oid> [--git-commit <oid>] [--algo sha1|sha256]
-                        [--manifest <path-to-worktree>]        # computes manifest binding
+                        [--manifest <path-to-tree>]            # computes manifest binding
                         [--continues <selection-id> --parent <candidate-id>
-                         | --derives-from <id> ...]
+                         | --derives-from <id> ...
+                         | --upgrades <candidate-id>]          # binding upgrade; refuses a differing tree
                         [--note <s>]
 bellbook eval add       --candidate <id> --criterion <s>
                         (--passed | --failed | --score <value> --scale <n>)
@@ -718,112 +791,136 @@ bellbook validate       <receipt>          # v0.2 semantics + the standing secti
 persistent log is deliberately single-writer (`LogWriter` holds an exclusive
 lock, exactly as in v0.2). Parallel candidate *generation* is the workload;
 parallel *recording* is not the mechanism. Hosts generate candidates
-concurrently and record them serially afterward — one process, in a batch
+concurrently and record them serially afterward, in one process, in a batch
 (`checked_batch_commit` for retry-safe batches) or a loop. The CLI is not a
 coordination layer, and integration docs must say so before integrators
 discover the lock by contention.
 
 Signing, roles, and receipt export use existing mechanisms. Python bindings
-remain out of scope (README open-work list); the independent Python validator
-is updated in lockstep via the corpus, as now.
+remain out of scope (README open-work list); the independent Python
+validator is updated in lockstep via the corpus, as now.
 
 ## 13. Compatibility and conformance plan
 
 - v0.3 is a new compatibility epoch: twelve kinds become fifteen; signing
   domain becomes `bellbook.record-signature.v0.3`; v0.2 logs and receipts
-  remain valid under v0.2 rules (no migration of committed history).
+  remain valid under v0.2 rules (no migration of committed history). A v0.3
+  validator rejects a v0.2 receipt with a clear unsupported-version report
+  (itself a corpus case); CI additionally validates the committed v0.2
+  receipts with the pinned, published v0.2 validator so "unchanged under
+  v0.2 rules" is continuously verified rather than assumed.
 - Test vectors regenerated and extended per new kind, including signed
   vectors.
 - Conformance corpus extended with positive and adversarial cases per new
   invariant in §9 (each rejection reason code gets a triggering case), plus
-  the §10 receipt cases and standing-derivation cases (two implementations
-  must produce identical standing sections).
-- **v0.2 corpus backfill (independent of v0.3):** the audit found that no
+  the §10 receipt and standing cases (two implementations must produce
+  byte-identical standing sections).
+- **v0.2 corpus backfill (independent of v0.3, tracked in #21):** no
   existing corpus case exercises the `Require` leg of taint propagation,
-  though SPEC.md claims that coverage. A small v0.2-scope corpus addition
-  should close that gap regardless of this RFC's fate.
+  although SPEC.md claims that coverage. A small v0.2-scope corpus addition
+  closes that gap regardless of this RFC's fate.
 - The Python validator implements the three kinds, the standing derivation,
-  and the Replace extension independently, and the corpus gate in CI holds
-  both implementations to byte-for-decision agreement — same discipline that
-  caught real bugs in the v0.2 cycle and in revisions 1–2 of this RFC.
+  the Selection approval binding, and the Replace extension independently,
+  and the corpus gate in CI holds both implementations to byte-for-decision
+  agreement.
 
 ## 14. Non-goals (binding for v0.3)
 
-No ranking or scoring computation; no evaluation execution; no general query
-engine (lineage traversal only — but see §15's read-side signal, which is the
-designated trigger for revisiting this); no Git plumbing beyond reading OIDs
-and the optional manifest walk; no materialization; no remotes or sync; no
-native source storage; no structured ContextObject system; no `Generation`,
-`Tournament`, or `Repair` kinds; no agent-cognition vocabulary of any sort;
-no retroactive clearing of kernel taint under any mechanism. Each of these
-is either VISION-scope (gated) or excluded permanently.
+No ranking or scoring computation; no evaluation execution; no multi-metric
+or comparative evaluation forms; no general query engine (lineage traversal
+only; §15's read-side signal is the designated trigger for revisiting this);
+no Git plumbing beyond reading OIDs and the optional manifest walk; no
+materialization; no remotes or sync; no native source storage; no structured
+ContextObject system; no `Generation`, `Tournament`, or `Repair` kinds; no
+dual-hash bindings; no `Verified` schemas for the new kinds (impossible
+within the epoch; first candidate for v0.4); no agent-cognition vocabulary
+of any sort; no retroactive clearing of kernel taint under any mechanism.
+Each of these is either VISION-scope (gated), scheduled for a later epoch,
+or excluded permanently.
 
 ## 15. Validation and falsification criteria (pre-registered)
 
 Recorded before implementation so the outcome cannot be rationalized later.
-Evaluation window: **90 days from shipping v0.3 + the flagship example**.
+Evaluation window: **90 days from shipping v0.3 plus the flagship example**.
 
-**Validation — proceed to the next VISION gate only if ≥ 2 hold:**
-1. At least one harness integration authored by someone with no connection to
-   this project, in actual use.
-2. Receipts generated by ≥ 3 external users or organizations (observed via
-   issues, discussions, or shared receipts — not download counts).
-3. Inbound issues or PRs that engage the *semantics* (binding modes, standing
-   and taint flows, selection invariants) — people argue about semantics they
-   use.
+**Validation: proceed to the next VISION gate only if at least 2 hold:**
+1. At least one harness integration authored by someone with no connection
+   to this project, in actual use.
+2. Receipts generated by at least 3 external users or organizations
+   (observed via issues, discussions, or shared receipts, not download
+   counts).
+3. Inbound issues or PRs that engage the *semantics* (binding modes,
+   standing and taint flows, selection invariants): people argue about
+   semantics they use. A specific sub-signal gates comparative evaluations:
+   external reports naming unary encoding as a concrete pain point.
 4. The flagship broken-benchmark scenario independently reproduced or cited
    by an external party.
-5. **Read-side usage**: at least one integration that *queries* — lineage
-   traversal, standing/taint status, or receipt validation inside its own
-   loop — rather than only writing records. This signal specifically gates
+5. **Read-side usage**: at least one integration that *queries* (lineage
+   traversal, standing or taint status, or receipt validation inside its own
+   loop) rather than only writing records. This signal specifically gates
    the VISION query-surface stage: write-side adoption justifies more
    recording semantics; only read-side adoption justifies a query engine.
 
-**Falsification — the thesis fails at this layer if both hold:**
-1. Direct exposure to ≥ 5 teams running best-of-N or iterative-evolution
-   workflows yields zero adoption, with the stated reason being that ad-hoc
-   eval JSON plus branch conventions are sufficient.
-2. Any integrations that do exist use Bellbook as write-only logging — no
-   receipt validation, no standing or taint queries, no selection semantics —
+**Falsification: the thesis fails at this layer if both hold:**
+1. Direct exposure to at least 5 teams running best-of-N or
+   iterative-evolution workflows yields zero adoption, with the stated
+   reason being that ad-hoc eval JSON plus branch conventions are
+   sufficient.
+2. Any integrations that do exist use Bellbook as write-only logging (no
+   receipt validation, no standing or taint queries, no selection semantics)
    for the full window.
 
-**Decision rule:** if falsified, VISION stages 1–4 stay parked indefinitely;
-native storage would not have changed the answer. If neither validated nor
-falsified, extend once by 90 days with a written note on what changed;
-no second extension without new evidence.
+**Decision rule:** if falsified, VISION stages 1 through 4 stay parked
+indefinitely; native storage would not have changed the answer. If neither
+validated nor falsified, extend once by 90 days with a written note on what
+changed; no second extension without new evidence.
 
-## 16. Open questions for review
+## 16. Resolved design decisions
 
-1. **Score representation** — is `{value, scale}` integer fixed-point
-   sufficient, or do hosts need multi-metric outcomes per Evaluation (vs. one
-   Evaluation per metric, the current proposal)?
-2. **Comparative evaluations** — pairwise judgments ("A preferred over B",
-   Elo-style) currently have no direct form; they must be encoded as unary
-   evaluations. Is a two-subject Evaluation variant warranted, or is unary
-   encoding acceptable for the wedge?
-3. **Manifest v1** — submodules; whether `mode` belongs in v1 or only
-   `sha256`; large-file cost and whether a size bound is needed.
-4. **Allowed `Cause` targets for `derivation`** — currently Candidate and
-   Evaluation; should Requests and Results be admitted?
-5. **SHA-256 Git repositories** — `algo` field is included; is dual-hash
-   (tree in both algorithms) worth supporting for migration-era repos?
-6. **Late binding upgrade** — a record's binding is immutable; the intended
-   pattern (reported for the population, manifest for survivors) needs a
-   defined idiom, e.g. a manifest-bound re-record of the same tree that the
-   Selection `Require`s instead of the reported one. Does that re-record need
-   its own basis/ref rule?
-7. **Standing report naming** — exact field names and serialization order
-   for the `standing` section. Its *content* is normative in §6.2
-   (`compromised` candidates, `unsound` selections, `restorations` per
-   anchor); only the naming and presentation remain open.
-8. **`Verified` pathway for evaluations** — under §4.0's base classes,
-   evaluations top out at `Reported`. Whether and how a key-pinned external
-   attestor's evaluation can reach `Verified` must be settled against
-   v0.2's actual `Verified` mechanism (schema base vs. signature-conditioned
-   grants) — deliberately unresolved here rather than overclaimed.
-9. **`considered` size bound** — population workloads may list thousands of
-   ids per Selection; should rules impose a per-record bound consistent with
-   the existing resource bounds?
-10. **Selection approval-binding domain** — final form of the
-    selection-approval hash domain string and its interaction with
-    single-use consumption when a Selection is later `Replace`d.
+Formerly open questions, now settled; the resolutions are normative and
+already reflected in the body sections cited.
+
+1. **Scores** (§4.2): `{value, scale}` integer fixed-point; exactly one
+   criterion per Evaluation; `value` bounded to signed 64-bit, `scale` to
+   0 through 12. Multi-metric outcomes rejected: retraction is
+   record-granular, so per-metric evaluations are the only shape allowing
+   one broken metric to be retracted without erasing the others.
+2. **Comparative evaluations** (§4.2, §14): out of scope for v0.3; encoded
+   unary by host convention; revisited only on external reports naming
+   comparative encoding as a concrete pain point (§15 signal 3).
+3. **Manifest v1** (§5.1): `mode` kept; submodules included as gitlink
+   entries (`160000`, hash of the lowercase-hex commit OID string, no
+   trailing newline), sourced from the Git tree object and never from
+   worktree state; no manifest-specific size bound (the manifest is hashed,
+   never stored).
+4. **Derivation `Cause` targets** (§4.1): Candidate and Evaluation only.
+   Result-motivated repairs route through an Evaluation that `Use`s the
+   Result; admitting Requests or Results would force the standing recursion
+   to define or special-case their standing.
+5. **SHA-256 Git repositories** (§5): one `algo` per candidate; no
+   dual-hash (an unverifiable pairing claim); manifest binding is the
+   algorithm-independent commitment for migration eras, qualified for
+   submodule-bearing trees per §5.1.
+6. **Late binding upgrade** (§5, §6.2, §12): the same-tree derivation idiom,
+   with the CLI refusing a differing tree, and made safe by the §6.2 base
+   case: a retracted Candidate has compromised, unrestorable standing, so
+   the idiom cannot launder a retracted state back into a sound line.
+7. **Standing report naming and encoding** (§6.2): section `standing`,
+   fields `compromised`, `unsound`, `restorations`; id-byte-ordered sets
+   matching the v0.2 report's set ordering; `restorations` as key-sorted
+   pairs with id-ordered value sets.
+8. **`Verified` pathway** (§4.0): a gated pair (externally-attested
+   Candidate schema and external Evaluation schema, both base `Verified`,
+   both signature-and-pinning gated), necessary but not sufficient (every
+   additional `Use` target must also be at least `Verified`); impossible to
+   add within the v0.3 epoch because the schema set is frozen per epoch;
+   first candidate for v0.4.
+9. **`considered` bound** (§9): rules knob `max_considered`, default 4096,
+   with the receipt ref-limit interplay stated normatively and pinned by a
+   corpus case.
+10. **Selection approval binding** (§4.3, §9 V3-S6): domain
+    `bellbook.selection-approval.v0.3`; subject hash over
+    `(domain, selection_author_id, replace_target_id_or_null,
+    SelectionData)` so a fresh-decision approval cannot be diverted onto a
+    reaffirmation; consumption is an event and is never refunded by a later
+    `Replace` of the consuming Selection.

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -41,8 +41,9 @@ Dependency semantics are split to match what they mean:
   continuation anchors (with `parent`) and derivation edges to candidates.
   It is deterministic, derived identically by every validator, and
   forgery-proof for the same reason taint is: replay re-derives it. It does
-  not touch evidence derivation, does not freeze appends, and is restorable
-  by a single on-record reaffirmation.
+  not touch evidence derivation, does not freeze appends, and — when the
+  compromise stems from decisions that no longer stand, not from a retracted
+  state itself (§6.3) — is restorable by a single on-record reaffirmation.
 
 This split is the revision-3 correction of revision 2's central defect:
 overloading `Require` for lineage bought kernel taint at the cost of

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,13 +1,17 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
-**Status:** Draft, revision 3. Revision 2 folded in the first adversarial
-review (set-valued selection; reaffirmation). Revision 3 responds to a
-second, code-verified audit that confirmed two structural defects in
-revision 2 — evidence-class collapse through mandated lineage refs, and
-reaffirmation being uncommittable at depth — and several unspecified
-obligations. The central change: **lineage standing is now a replay-derived
-dimension computed over `Cause` edges, not a use of kernel taint via
-`Require`.** Nothing in this RFC is implemented; nothing in it changes spec
+**Status:** Draft, revision 4. Revision 2 folded in the first adversarial
+review (set-valued selection; reaffirmation). Revision 3 responded to a
+second, code-verified audit — its central change: **lineage standing is a
+replay-derived dimension computed over `Cause` edges, not a use of kernel
+taint via `Require`.** Revision 4 folds in a third, maximum-depth audit that
+verified revision 3's kernel claims against the v0.2 source and closed the
+gaps it found: `Cause` targets of Candidates must be accepted (the
+rejected-anchor hole), standing lives in the replay report only (receipts
+embed nothing derived), the standing section's content is now normative,
+reaffirmation's default trust posture is stated bluntly with an
+identity-binding knob, and the retracted-parent unrestorability asymmetry is
+documented. Nothing in this RFC is implemented; nothing in it changes spec
 v0.2 or the published crate. Kind names and field spellings are tentative
 until accepted.
 
@@ -33,8 +37,9 @@ Dependency semantics are split to match what they mean:
   epistemically depend on the evaluations they relied on and the candidates
   they selected. Kernel evidence derivation and taint apply here, unchanged.
 - **Standing** — "is this state a legitimate member of a chosen line?" — is
-  a **new, replay-derived dimension** computed over continuation edges
-  (`Cause` + `parent`). It is deterministic, receipt-visible, and
+  a **new, replay-derived dimension** computed over lineage `Cause` edges:
+  continuation anchors (with `parent`) and derivation edges to candidates.
+  It is deterministic, derived identically by every validator, and
   forgery-proof for the same reason taint is: replay re-derives it. It does
   not touch evidence derivation, does not freeze appends, and is restorable
   by a single on-record reaffirmation.
@@ -174,9 +179,16 @@ development.
 
 | basis          | meaning                                         | ref obligations |
 |----------------|-------------------------------------------------|-----------------|
-| `root`         | starts a line (imported / initial state)        | MAY `Cause` one Request; no `Cause` to a Selection; no `parent` |
-| `continuation` | continues from a selected state                 | MUST `Cause` exactly one record, of kind `Selection`, whose outcome is `selected`; `parent` MUST name a member of that Selection's selected set |
-| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each of kind `Candidate` or `Evaluation`; no `parent` |
+| `root`         | starts a line (imported / initial state)        | at most one `Cause`, targeting an accepted Request; no other `Cause` targets; no `parent` |
+| `continuation` | continues from a selected state                 | MUST `Cause` exactly one record: an **accepted** `Selection` whose outcome is `selected`; `parent` MUST name a member of that Selection's selected set |
+| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each an **accepted** `Candidate` or `Evaluation`; no `parent` |
+
+Acceptance of every `Cause` target is checked at the candidate's commit
+position and, because acceptance is permanent in v0.2, holds forever after.
+This closes what the third audit named the *rejected-anchor hole*: without
+it, a continuation could anchor to a rejected Selection and yield a
+`Clean` receipt with a compromised lineage, and derivation standing would be
+undefined over rejected targets.
 
 Continuation uses `Cause`, **not** `Require` — this is the revision-3
 change. `Cause` carries neither evidence derivation nor kernel taint, so a
@@ -357,15 +369,22 @@ re-derives it. It is **not** kernel taint: it does not affect evidence, does
 not gate commits by default, and is reported alongside taint, never merged
 with it.
 
-Let a Selection S be **unsound** at replay end iff S is retracted, tainted,
-or was rejected. Define **anchor soundness** for a continuation candidate C
-with `Cause` → S and `parent` = P:
+Let a Selection S be **unsound** at replay end iff S is retracted or
+tainted. (A rejected Selection can never be an anchor: V3-C3 requires every
+`Cause` target of a Candidate to be accepted at commit, and acceptance is
+permanent — so an anchor can become unsound only *after* the fact, via
+retraction or taint.) Define **anchor soundness** for a continuation
+candidate C with `Cause` → S and `parent` = P:
 
 - S itself is sound, **or**
 - some accepted, sound Selection S′ exists with a `Replace` chain leading to
   S (one or more hops, every intermediate accepted) whose selected set
   contains P. If multiple replacements of S exist, **any** sound one
   suffices (deterministic: existential over the fixed replay-end set).
+  Intermediates need only be *accepted*, not sound — requiring soundness
+  would recreate a frozen-chain pathology while granting nothing, since a
+  host can always `Replace` S directly (multiple replacements of one target
+  are legal in v0.2); a corpus case pins this reading.
 
 Then standing is derived recursively (well-founded: all edges point to
 earlier records):
@@ -377,15 +396,38 @@ earlier records):
   standing (evaluation targets carry no standing); a derivation with only
   Evaluation targets is **sound**.
 
-**Report and receipt.** The replay report and receipt gain a `standing`
-section: the set of standing-compromised candidate ids, and for each
-compromised anchor, the unsound Selection responsible. Whenever the
-compromised set is non-empty, the origin Selection is necessarily tainted or
-retracted, so the receipt's overall status is already `Tainted` under
-unchanged v0.2 status rules — standing adds *which lineage* is affected and
-*whether it was restored*, it never manufactures a status v0.2 would not
-report. Two independent implementations must derive identical standing sets;
-corpus receipt cases enforce this (§13).
+**Where standing lives: the replay report only.** A v0.2 receipt embeds
+nothing derived — it is `{spec_version, rules, records}`, and the
+retracted/tainted sets exist only in the validator's report, re-derived on
+every validation. Standing follows the same discipline exactly: the
+**report** gains a `standing` section; receipts are unchanged in shape, and
+there is no embedded standing for anyone to forge — a validator that derives
+a different standing set from the same records is simply nonconforming,
+which the corpus detects the same way it detects taint disagreement.
+
+**Normative content of the `standing` section** (field names are open
+question §16.7; the content is not):
+
+- `compromised`: the set of standing-compromised Candidate ids;
+- `unsound`: the set of unsound Selection ids;
+- `restorations`: for each unsound Selection that has at least one sound
+  replacement chain, the set of sound replacing Selection ids.
+
+All three are pure functions of the accepted records at replay end, with
+canonical (logical-time) ordering for output. Restored lines are visible as:
+their candidates absent from `compromised`, their anchor present in
+`unsound`, and the restoring Selection listed in `restorations` — closing
+the gap between this section and §7/§10's restoration queries.
+
+Whenever `compromised` is non-empty, the responsible anchor is necessarily
+retracted or tainted (rejected anchors are impossible per V3-C3, and
+acceptance is permanent), so the report's overall status is already
+`Tainted` under unchanged v0.2 status rules — v0.2 reports `Tainted`
+whenever either the retracted or the tainted set is non-empty. Standing adds
+*which lineage* is affected and *what restored it*; it never manufactures a
+status v0.2 would not report. Two independent implementations must derive
+identical standing sections; corpus receipt cases pin the expected values
+(§13).
 
 **What standing deliberately does not do.** It does not reject new
 continuations of an unsound Selection — they commit and are born
@@ -400,7 +442,8 @@ A Selection S′ carrying `Replace` → S is a **reaffirmation**: a new decision
 over the same objective, on evidence that currently stands. Requirements
 (V3-S5): the target is a Selection in the same space with the same
 `objective`; rules MAY restrict reaffirmation authorship
-(`reaffirmation_roles`, default: Selection's own author-role row).
+(`reaffirmation_actors`: an explicit allowlist of actor *identities*; when
+unset, the Selection author-role row applies).
 
 Because standing (not kernel taint) carries lineage consequence, S′ is
 committable **at any depth**: its `Require`d winners are ordinary untainted
@@ -429,7 +472,32 @@ guaranteed:
 - **Replacement side effects are v0.2's.** A `Replace`d Selection leaves
   context construction, as any replaced record does today; the RFC adds no
   new Replace semantics beyond the whitelist entries and the compatibility
-  rule.
+  rule. Consequently, replacing a *sound* Selection is legal (V3-S5 does not
+  require the target to be unsound — a state-dependent Replace rule would be
+  new machinery): standing is unaffected (soundness is never revoked by
+  replacement), but the target still leaves context construction. Hosts
+  should not `Replace` healthy Selections casually; this side effect is
+  documented rather than forbidden.
+- **Retracted parents are unrestorable — by design.** Reaffirmation
+  recovers from retracted or tainted *decisions*. If a selected *candidate*
+  is itself retracted ("the state was wrong," not "the decision no longer
+  stands"), no reaffirmation can restore its descendants: any restoring
+  Selection must `Require` that candidate, and `Require`-of-retracted is a
+  hard rejection. The only path forward is a new `root` — the graver claim
+  gets the graver consequence, and the flagship's recovery story is
+  explicitly conditional on *what* was retracted. Corpus cases cover both
+  (§13).
+- **The default trust posture, stated bluntly.** Under default rules,
+  restoration is producible in **two records** by any actor in the Selection
+  author-role row: one self-authored Evaluation of the old parent, one
+  reaffirming Selection. Restoration is therefore *ownership-unbound* while
+  retraction is *ownership-bound* (only a record's author or a configured
+  admin may retract). Everything stays visible — the junk evaluation, the
+  reaffirmation, and their authors are permanently on the record, and a
+  consumer can judge the restoring evidence for itself — but deployments
+  that need restoration to be as guarded as compromise MUST set
+  `reaffirmation_actors` and/or require approvals on Selections (§4.3).
+  The default favors recordability; the knobs supply the guarantees.
 - **Last resort.** A host abandoning a line entirely may start a new `root`
   candidate with a provenance `note`; the receipt shows the break in
   verifiable lineage. That is the honest cost of a re-baseline.
@@ -490,22 +558,25 @@ derivation and thresholds, taint, retraction ownership) apply to the new
 kinds unchanged. New checks, each with a distinct rejection reason code and
 a triggering corpus case:
 
-**Payload-id resolution (shared rule).** `parent` and every member of
-`considered` are payload ids, not refs; v0.2's ref battery never touches
-them. v0.3 defines: each MUST resolve, in the same space, to a
-previously **accepted** `Candidate` record (retracted or tainted targets
-resolve — those conditions surface through evidence/taint on refs and
-through standing, not through payload lookup). Unresolvable, cross-space,
-or wrong-kind payload ids reject.
+**Payload-id resolution (shared rule).** `parent`, every member of
+`considered`, and `Evaluation.candidate` are payload ids, not refs; v0.2's
+ref battery never touches them. v0.3 defines: each MUST resolve, in the same
+space, to a previously **accepted** `Candidate` record (retracted or tainted
+targets resolve — those conditions surface through evidence/taint on refs
+and through standing, not through payload lookup). Unresolvable,
+cross-space, or wrong-kind payload ids reject.
 
 **Candidate**
 - V3-C1: `source.git.tree` present, hex, length matching `algo`.
 - V3-C2: `binding == "manifest"` ⇒ `manifest_hash` present (64-hex);
   `binding == "reported"` ⇒ `manifest_hash` absent.
-- V3-C3: basis/ref obligations of §4.1 hold (continuation ⇒ exactly one
-  `Cause`, targeting a Selection with `decision == "selected"`; derivation ⇒
-  ≥ 1 `Cause`, each `Candidate` or `Evaluation`, none a `Selection`; root ⇒
-  no `Cause` to a Selection).
+- V3-C3: basis/ref obligations of §4.1 hold, **including acceptance of every
+  `Cause` target at commit position**: continuation ⇒ exactly one `Cause`,
+  targeting an *accepted* Selection with `decision == "selected"`;
+  derivation ⇒ ≥ 1 `Cause`, each an *accepted* `Candidate` or `Evaluation`,
+  none a `Selection`; root ⇒ at most one `Cause`, targeting an *accepted*
+  Request, and no other `Cause` targets. (Closes the rejected-anchor hole,
+  §4.1/§6.2.)
 - V3-C5: `parent` present iff `basis == "continuation"`; resolves per the
   shared rule; and names a member of the `Cause`d Selection's selected set.
 
@@ -533,22 +604,33 @@ commit-time strictness.)
   Evaluation when `decision == "selected"`.
 - V3-S5: at most one `Replace` ref (v0.2 rule); if present, the target is a
   Selection, same space, same `objective`; author satisfies
-  `reaffirmation_roles`.
+  `reaffirmation_actors` when set.
 
 **New rules knobs**
 - `min_binding` per referencing context (e.g. Selections may only `Require`
   candidates with `manifest` binding).
 - `selection_requires_evaluation` (default true).
-- `reaffirmation_roles` (default: Selection's author-role row).
+- `reaffirmation_actors` (identity allowlist; unset ⇒ the Selection
+  author-role row alone governs — see §6.3's trust-posture statement).
 - `reject_compromised_continuation` (default false; §6.2).
 - Per-kind evidence thresholds and author-role bindings apply to the three
   kinds exactly as to existing kinds, using §4.0's registrations.
 
 **Spec-level changes beyond the battery** (still additive, per C3): the
 `Replace` kind whitelist gains `Selection` (carrier) / `Selection` (target)
-with the V3-S5 compatibility rule; the replay report and receipt gain the
-`standing` section (§6.2); SPEC v0.3 defines the selection approval-binding
-hash (§4.3 "Authority") with its own domain string.
+with the V3-S5 compatibility rule; the **replay report** gains the
+`standing` section (§6.2 — receipts embed nothing derived, unchanged from
+v0.2); SPEC v0.3 defines the selection approval-binding hash (§4.3
+"Authority") with its own domain string.
+
+**Reachability pre-commitment (for VISION stages, decided now while it is
+cheap):** `parent`, `considered`, and `Evaluation.candidate` are edges that
+ref-walking tools cannot see. SPEC v0.3 therefore states normatively that
+**reachability over v0.3 kinds is payload-aware** — any future garbage
+collection, synchronization, or checkpoint tooling MUST treat these payload
+ids as reachability edges, or it would silently sever the standing spine.
+This is recorded in the spec now, before any such tooling exists, so no
+later stage can inherit ref-only reachability as a hidden default.
 
 ## 10. Retraction and the flagship scenario
 
@@ -559,9 +641,10 @@ The demonstration this release is built around:
 > retracted. Kernel taint reaches every Selection that `Use`d them, exactly
 > as v0.2 defines. The `standing` section of the replay report now shows
 > every descendant candidate of those Selections as compromised,
-> transitively, at any depth — while repairs and mutations merely
-> *motivated* by the broken evaluations remain sound, because motivation is
-> `Cause` and standing follows continuation edges only. Work never stops:
+> transitively, at any depth. Repairs and mutations merely *motivated* by
+> the broken evaluations remain sound — a derivation is compromised only
+> when a **candidate** it derives from is compromised; evaluation
+> motivations alone never compromise. Work never stops:
 > the line keeps recording, visibly compromised. The team re-runs the
 > surviving evaluations and commits one reaffirming Selection; the next
 > replay shows the line's standing restored — with the retraction, the
@@ -572,18 +655,23 @@ Standing means "rests on decisions that no longer stand," never "the code is
 wrong" — and the one-record recovery is part of the demo precisely so the
 cascade reads as actionable state, not a permanent alarm or a frozen ledger.
 It ships as a worked example plus corpus receipt cases covering: the full
-compromise cascade, the derivation non-cascade, deep reaffirmation recovery,
-a `none`-decision reaffirmation restoring nothing, competing reaffirmations,
-and a forged receipt whose standing section disagrees with re-derivation and
-is rejected.
+compromise cascade, the derivation non-cascade (evaluation-only motivation)
+and the derivation cascade (compromised-candidate derivation), deep
+reaffirmation recovery, a `none`-decision reaffirmation restoring nothing,
+competing reaffirmations, a replacement chain through an accepted-but-unsound
+intermediate, the retracted-parent unrestorable case, and expected-standing
+agreement cases that pin the report's `standing` section byte-for-decision —
+the same mechanism that already enforces taint agreement between the two
+implementations.
 
 ## 11. Receipt boundary
 
 A v0.3 receipt proves the recorded **process**: which candidates were
 recorded, what was claimed about them, which evidence and evaluations
 existed, what was selected under what objective, what is retracted, tainted,
-or standing-compromised (and what restored it), and that none of it was
-altered after the fact. It does **not** contain source contents; Git OIDs
+or standing-compromised and what restored it (all re-derived by the
+validator from the records — never embedded in the receipt), and that none
+of it was altered after the fact. It does **not** contain source contents; Git OIDs
 are pointers whose resolution requires the repository. With `manifest`
 binding, a party holding the tree can independently recompute
 `manifest_hash` and bind the receipt to actual contents; with `reported`
@@ -648,7 +736,7 @@ is updated in lockstep via the corpus, as now.
 - Conformance corpus extended with positive and adversarial cases per new
   invariant in §9 (each rejection reason code gets a triggering case), plus
   the §10 receipt cases and standing-derivation cases (two implementations
-  must produce identical standing sets).
+  must produce identical standing sections).
 - **v0.2 corpus backfill (independent of v0.3):** the audit found that no
   existing corpus case exercises the `Require` leg of taint propagation,
   though SPEC.md claims that coverage. A small v0.2-scope corpus addition
@@ -723,10 +811,10 @@ no second extension without new evidence.
    defined idiom, e.g. a manifest-bound re-record of the same tree that the
    Selection `Require`s instead of the reported one. Does that re-record need
    its own basis/ref rule?
-7. **Standing report shape** — exact field naming for the `standing`
-   section; whether restored lines list the restoring Selection per
-   candidate or per anchor; whether replacement chains are flattened in the
-   report.
+7. **Standing report naming** — exact field names and serialization order
+   for the `standing` section. Its *content* is normative in §6.2
+   (`compromised` candidates, `unsound` selections, `restorations` per
+   anchor); only the naming and presentation remain open.
 8. **`Verified` pathway for evaluations** — under §4.0's base classes,
    evaluations top out at `Reported`. Whether and how a key-pinned external
    attestor's evaluation can reach `Verified` must be settled against

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,11 +1,14 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
-**Status:** Draft, revision 2 — incorporates the adversarial review of
-revision 1 (set-valued selection; reaffirmation; binding-authority,
-discipline, and concurrency honesty). Nothing in this RFC is implemented;
-nothing in it changes spec v0.2 or the published crate. The goal is to make
-the object semantics and invariants precise enough to implement without
-re-litigating them mid-build. Kind names and field spellings are tentative
+**Status:** Draft, revision 3. Revision 2 folded in the first adversarial
+review (set-valued selection; reaffirmation). Revision 3 responds to a
+second, code-verified audit that confirmed two structural defects in
+revision 2 — evidence-class collapse through mandated lineage refs, and
+reaffirmation being uncommittable at depth — and several unspecified
+obligations. The central change: **lineage standing is now a replay-derived
+dimension computed over `Cause` edges, not a use of kernel taint via
+`Require`.** Nothing in this RFC is implemented; nothing in it changes spec
+v0.2 or the published crate. Kind names and field spellings are tentative
 until accepted.
 
 **Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
@@ -18,16 +21,30 @@ on top of Git, reusing the v0.2 trust kernel unchanged.
 
 Spec v0.3 adds three typed record kinds — `Candidate`, `Evaluation`,
 `Selection` — to the existing twelve. The record remains the only primitive.
-Lineage is derived from existing typed refs (`Cause`, `Use`, `Require`),
-never stored as a parallel structure. Source identity binds to Git (tree
-OID), with an optional Bellbook-computed manifest hash for stronger binding.
-Selections are **set-valued** (they may select one candidate or several), so
-best-of-N, population/beam evolution, and single-candidate repair share one
-vocabulary. Retraction and transitive taint apply through one carefully
-chosen rule — continuation requires its Selection — so a retracted evaluation
-taints the entire descendant line it selected; a **forward-only
-reaffirmation** mechanism lets a superseding Selection restore a line's
-standing without retroactively erasing taint.
+Lineage is derived from refs and payload fields, never stored as a parallel
+structure. Source identity binds to Git (tree OID), with an optional
+Bellbook-computed manifest hash for stronger binding. Selections are
+**set-valued** (one survivor or several).
+
+Dependency semantics are split to match what they mean:
+
+- **Knowledge** flows through `Use`/`Require` exactly as in v0.2:
+  evaluations epistemically depend on their candidates; selections
+  epistemically depend on the evaluations they relied on and the candidates
+  they selected. Kernel evidence derivation and taint apply here, unchanged.
+- **Standing** — "is this state a legitimate member of a chosen line?" — is
+  a **new, replay-derived dimension** computed over continuation edges
+  (`Cause` + `parent`). It is deterministic, receipt-visible, and
+  forgery-proof for the same reason taint is: replay re-derives it. It does
+  not touch evidence derivation, does not freeze appends, and is restorable
+  by a single on-record reaffirmation.
+
+This split is the revision-3 correction of revision 2's central defect:
+overloading `Require` for lineage bought kernel taint at the cost of
+evidence collapse and frozen lines. Standing gives the flagship guarantee —
+*one retraction visibly compromises the entire selected descendant line* —
+without either side effect, and makes recovery a one-record act at any
+depth.
 
 ## 2. Motivation
 
@@ -68,9 +85,16 @@ C2. **Workload generality.** The semantics must serve, without privileging
     derivation; there is **no** `Generation`, `Tournament`, or `Repair`
     object — all such structure is derivable (§8).
 
-C3. **Kernel unchanged.** The evidence lattice, verdict machinery, signature
-    scheme, retraction/taint engine, and receipt model of v0.2 are reused,
-    not modified. v0.3 defines how the new kinds *participate* in them.
+C3. **Kernel engines unchanged; extension is additive.** Canonicalization,
+    content addressing, the signature scheme, evidence derivation, taint
+    propagation, and the receipt replay structure are reused exactly as
+    they are — never modified, never scoped, never special-cased. What v0.3
+    adds sits beside them: three kinds with author-role rows and base
+    evidence classes (the same registration every kind has), new per-kind
+    verifier checks, two entries on the existing `Replace` kind whitelist
+    with a Selection compatibility rule, and one new *derived* replay output
+    (standing, §6.2). Anything that would require changing how an existing
+    v0.2 record verifies is out of scope by definition.
 
 C4. **Git is the substrate, not the model.** v0.3 reads Git object ids and
     optionally walks a worktree to compute a manifest. It performs no other
@@ -86,6 +110,42 @@ All three kinds are ordinary records: content-addressed via JCS + SHA-256,
 subject to author-role rules, signable, judged by an immediate deterministic
 Verdict, and referenced through typed refs. Numbers in payloads are integers
 only, per the v0.2 wire format.
+
+### 4.0 Registration: author roles and base evidence classes
+
+v0.2 normatively requires every kind to have an allowed-author-type row and
+every schema to have a base evidence class; leaving either undefined lets
+conforming implementations diverge. v0.3 registers:
+
+| Kind        | Allowed author types              | Base evidence class |
+|-------------|-----------------------------------|---------------------|
+| `Candidate` | User, Provider, Executor, System  | `Reported`          |
+| `Evaluation`| User, Provider, Executor, System  | `Reported`          |
+| `Selection` | User, Provider, System            | `Inferred`          |
+
+Rationale. Candidates and evaluations are things any actor may honestly
+report producing or observing; rules narrow this per deployment. Selections
+are decisions, so `Executor` — the role that performs work — may not author
+them. Base classes are conservative: a candidate's binding and an
+evaluation's outcome are host-asserted (`Reported`); a selection is a
+judgment derived by reasoning (`Inferred`). Stored evidence can never exceed
+the derived minimum over base and `Use`/`Require` targets, so under this
+table: evaluations are at most `Reported`, selections at most `Inferred`,
+and per-kind thresholds at those levels are meaningful — their real teeth is
+that any retracted or tainted dependency drags the derived class to the
+`Assumed` floor and below threshold. Whether a key-pinned externally signed
+evaluation can be granted a `Verified` pathway is deliberately **not**
+claimed here (revision 2 overclaimed it); it is open question §16.8, to be
+settled against v0.2's actual `Verified` mechanism.
+
+One consequence for retraction, stated now because the flagship (§10)
+depends on it: v0.2 permits `Retraction` records to be authored only by
+User, Provider, or System, and a record may be retracted only by its author
+or a configured `admin_retraction_actors` entry. **Executor-authored
+evaluations are therefore admin-retractable only.** Hosts that want the
+broken-benchmark recovery story must either author evaluations as Provider
+or System, or configure admin retraction. The RFC makes this a documented
+deployment decision, not an accident.
 
 ### 4.1 `Candidate`
 
@@ -110,18 +170,22 @@ development.
 }
 ```
 
-**Basis semantics and required refs:**
+**Basis semantics and ref obligations:**
 
-| basis          | meaning                                        | ref obligations |
-|----------------|------------------------------------------------|-----------------|
-| `root`         | starts a line (imported / initial state)       | MAY `Cause` a Request; no `parent` |
-| `continuation` | continues from a selected state                | MUST `Require` exactly one `Selection` whose outcome is `selected`, and `parent` MUST name a member of that Selection's selected set |
+| basis          | meaning                                         | ref obligations |
+|----------------|-------------------------------------------------|-----------------|
+| `root`         | starts a line (imported / initial state)        | MAY `Cause` one Request; no `Cause` to a Selection; no `parent` |
+| `continuation` | continues from a selected state                 | MUST `Cause` exactly one record, of kind `Selection`, whose outcome is `selected`; `parent` MUST name a member of that Selection's selected set |
 | `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each of kind `Candidate` or `Evaluation`; no `parent` |
 
-The `continuation`/`derivation` distinction is the taint boundary and is the
-most consequential rule in this RFC; rationale in §6. The `parent` field is
-descriptive lineage (which selected state this builds on); the *epistemic*
-dependency is the `Require` on the Selection.
+Continuation uses `Cause`, **not** `Require` — this is the revision-3
+change. `Cause` carries neither evidence derivation nor kernel taint, so a
+candidate's evidence class reflects how *its own content* is known, and a
+tainted history never blocks the recording of ongoing work (the log records
+what was attempted). The lineage consequence of the Selection's health is
+carried by **standing** (§6.2), which is derived from exactly these edges.
+The `parent` field is the specific selected state this candidate builds on;
+payload-id resolution rules for it are in §9 (V3-C5).
 
 ### 4.2 `Evaluation`
 
@@ -142,15 +206,11 @@ A judgment about exactly one candidate under an explicit criterion.
 
 **Ref obligations:** MUST `Use` the record named in `candidate`; MAY `Use`
 additional evidence records (e.g. Results, Usage, traces). The subject
-dependency is `Use`, not `Cause`, because the evaluation's content
-epistemically rests on the candidate binding: if the candidate is retracted,
-every evaluation of it is correctly tainted.
-
-Evidence class follows the unchanged v0.2 lattice: a harness reporting its
-own results is at most `Reported`; a signed attestation from a key-pinned
-external party is `Verified`; `Deterministic` remains reserved for
-verifier-derived records. Bellbook never computes or re-runs an evaluation
-(C5); it records and grades how the result is known.
+dependency is `Use` — genuinely epistemic — because the evaluation's content
+rests on the candidate's binding: if the candidate is retracted, every
+evaluation of it is correctly tainted and its derived evidence falls to the
+`Assumed` floor. This is kernel machinery doing exactly what it was built
+for, and it is kept.
 
 ### 4.3 `Selection`
 
@@ -163,7 +223,7 @@ keeps k survivors is one record, not k fragmented ones.
 ```jsonc
 {
   "objective": "<bounded string>",   // REQUIRED, non-empty
-  "considered": ["<id>", "..."],     // REQUIRED: ≥ 1, unique, all Candidate ids
+  "considered": ["<id>", "..."],     // REQUIRED: ≥ 1, unique Candidate ids (resolution: §9 V3-S1)
   "outcome": {
     "decision": "selected",          // "selected" | "none"
     "candidates": ["<id>", "..."]    // REQUIRED iff selected: ≥ 1, unique, ⊆ considered
@@ -174,31 +234,42 @@ keeps k survivors is one record, not k fragmented ones.
 
 **Ref obligations:**
 
-- If `decision == "selected"`: MUST `Require` exactly the members of
-  `outcome.candidates` (each of which MUST appear in `considered`).
-- MUST `Use` ≥ 1 `Evaluation` (default rules; a rules knob MAY relax this,
-  see §9), and the `candidate` of every `Use`d Evaluation MUST appear in
-  `considered`.
+- If `decision == "selected"`: MUST `Require` every member of
+  `outcome.candidates`. These `Require` refs are epistemically honest (the
+  decision's validity rests on the winners' integrity) and give commit-time
+  teeth for free under unchanged kernel rules: a Selection whose winner is
+  retracted or tainted at its commit position is rejected outright.
+- Additional `Require` refs are permitted **only** for authority records
+  (Capability/Approval) demanded by the rules — see "Authority" below. No
+  other `Require` targets are allowed (V3-S2).
+- MUST `Use` ≥ 1 `Evaluation` when `decision == "selected"` (rules knob
+  `selection_requires_evaluation`, default true; a `none` decision has no
+  evaluation obligation). The `candidate` of every `Use`d Evaluation MUST
+  appear in `considered`. This is the single normative statement of the
+  evaluation obligation; §12's CLI grammar mirrors it.
 - `decision == "none"` records that no candidate was acceptable under the
   objective — a legal, meaningful outcome (pruning, backtracking). It carries
-  no `Require`.
-- A Selection MAY carry a `Replace` ref to a prior Selection: this is
-  **reaffirmation** (§6.1). If present, the `Replace` target MUST be a
-  Selection.
+  no candidate `Require`s.
+- A Selection MAY carry one `Replace` ref targeting a prior Selection: this
+  is **reaffirmation** (§6.3), subject to the compatibility rule in V3-S5.
+
+**Authority.** Revision 2 claimed authority "composes unchanged"; that was
+wrong — v0.2's exact-approval machinery is Action-specific (its approval
+hash binds the action author and `ActionData`). v0.3 therefore defines the
+analogous binding for selections: when rules require an approval for
+Selections, the approval's subject hash is
+`SHA-256(canonical((selection_author_id, SelectionData)))` in a
+selection-specific domain, the approving record is referenced by `Require`,
+and single-use consumption follows the existing approval rules. This is new,
+explicitly specified machinery modeled on the Action path — not a claim
+that the Action path already covers it.
 
 Losing candidates are listed in `considered` (descriptive) but not referenced
 via `Use`/`Require`; the decision's *epistemic* premises are the evaluations
 it declares it `Use`d. A comparative selection naturally `Use`s the losers'
-evaluations too, and taint then flows through those evaluations — the host
-controls comparative-vs-threshold semantics through what it declares, not
-through special kinds.
-
-A Selection with `considered` of size 1 and a selected set of size 1 is the
-formal version of "accept this state under this objective" — the
-single-candidate workflow's terminal step (C2c). Authority composes
-unchanged: rules may demand that Selections be authored by a given role,
-carry an exact approval, or meet evidence thresholds, using existing v0.2
-machinery.
+evaluations too. A Selection with `considered` of size 1 and a selected set
+of size 1 is the formal "accept this state under this objective" — the
+single-candidate workflow's terminal step (C2c).
 
 ## 5. Source binding model
 
@@ -236,13 +307,11 @@ survivors); since a record's binding is immutable, how a survivor's binding
 gets upgraded (e.g. a manifest-bound re-record of the same tree that the
 Selection then `Require`s) is open question §16.6.
 
-**Deliberate refinement of an earlier framing:** binding strength is carried
-by the explicit `binding` field plus a per-kind rules threshold
-(`min_binding`, §9) — *not* by overloading the evidence-class definitions,
-whose v0.2 meanings stay fixed. The evidence class continues to grade how the
-record's content is known, and the two mechanisms compose. Rules like "any
-candidate a Selection `Require`s must have `manifest` binding" become
-expressible without touching the lattice.
+**Binding strength and the lattice.** Binding strength is carried by the
+explicit `binding` field plus a per-kind rules threshold (`min_binding`,
+§9) — *not* by overloading the evidence-class definitions, whose v0.2
+meanings stay fixed. Rules like "any candidate a Selection `Require`s must
+have `manifest` binding" are expressible without touching the lattice.
 
 ### 5.1 Canonical manifest v1 (proposal)
 
@@ -260,92 +329,124 @@ JCS rules) to entries:
 - `manifest_hash` = SHA-256 over the JCS bytes of that object.
 - Submodules: **out of scope for v1** (open question §16).
 
-## 6. Reference and taint semantics
+## 6. Knowledge, taint, and standing
 
-v0.2's rule is preserved exactly: **taint follows `Use` and `Require`, never
-`Cause`** (this is an existing corpus case). v0.3 adds one principle for
-choosing between them:
+### 6.1 Knowledge: unchanged kernel semantics
 
-> **Artifacts descend by `Cause`; judgments and standing depend by
-> `Use`/`Require`.**
+v0.2's rules apply verbatim. Evidence derivation: a record's stored evidence
+must equal the weakest of its base class and the evidence of every
+`Use`/`Require` target, with rejected/retracted/tainted targets contributing
+the `Assumed` floor. Taint: propagates transitively through `Use` and
+`Require`, never `Cause`; a record that `Use`s a tainted record commits but
+is tainted; a record that `Require`s a tainted or retracted record is
+rejected. Under §4's ref discipline this yields, per generation:
+evaluations ≤ `Reported`, selections ≤ `Inferred` — and, because
+continuation edges are `Cause`, **evidence does not compound across
+generations**: each candidate's class reflects its own binding, each
+evaluation its own grounding. (Revision 2's design collapsed all lineages to
+a fixed point within one generation and made threshold rules unusable; this
+is the fix.)
 
-Applied:
+### 6.2 Standing: a derived lineage dimension
 
-- An **Evaluation** `Use`s its candidate → retracting a candidate taints its
-  evaluations. Correct: the judgments were about content whose binding no
-  longer stands.
-- A **Selection** `Use`s the evaluations it relied on and `Require`s its
-  selected candidates → retracting a relied-on evaluation, or any selected
-  candidate, taints the selection. Correct: the decision's premises are gone.
-- A **continuation Candidate** `Require`s its Selection → a tainted selection
-  taints every candidate that continued from it, and (via their evaluations
-  and subsequent selections) the entire descendant line. This is the rule
-  that makes the flagship scenario (§10) true, and it is epistemically
-  honest: a continuation's claim is not "these files exist" but "this is the
-  chosen line's successor" — standing that genuinely rests on the decision.
-- A **derivation Candidate** (repair, mutation) `Cause`s its origins → taint
-  does *not* flow. Correct: if the failing evaluation that motivated a repair
-  is later retracted, the repaired artifact is not thereby wrong; only its
-  motivation evaporated. Retraction poisons conclusions, not code.
+**Definition.** Standing answers: *does this candidate's membership in a
+chosen line still rest on decisions that stand?* It is computed at replay
+end, from accepted records only, as a pure function of the log — exactly as
+deterministic and forgery-resistant as the taint set, because a validator
+re-derives it. It is **not** kernel taint: it does not affect evidence, does
+not gate commits by default, and is reported alongside taint, never merged
+with it.
 
-Two acknowledged consequences, both deliberate:
+Let a Selection S be **unsound** at replay end iff S is retracted, tainted,
+or was rejected. Define **anchor soundness** for a continuation candidate C
+with `Cause` → S and `parent` = P:
 
-1. **The cascade can be over-broad.** A Selection may be over-determined
-   (the survivors stand on four evaluations even after a fifth is
-   retracted), and taint through a multi-winner Selection reaches *all* its
-   continuation lines even if only one winner's premises collapsed. Taint
-   means "rests on something retracted," never "is wrong" — the recovery
-   path is reaffirmation (§6.1), not weaker taint.
-2. **This asymmetry — continuation `Require`s, derivation `Cause`s — is the
-   single most consequential decision in this RFC** and should be challenged
-   hardest in review.
+- S itself is sound, **or**
+- some accepted, sound Selection S′ exists with a `Replace` chain leading to
+  S (one or more hops, every intermediate accepted) whose selected set
+  contains P. If multiple replacements of S exist, **any** sound one
+  suffices (deterministic: existential over the fixed replay-end set).
 
-### 6.1 Reaffirmation: forward-only taint recovery
+Then standing is derived recursively (well-founded: all edges point to
+earlier records):
 
-Without a recovery mechanism, one retracted evaluation permanently taints an
-entire active line, and the only exit is re-recording the chain. Large,
-mostly-recoverable cascades would teach users to ignore taint — destroying
-the flagship capability through alarm fatigue. v0.3 therefore defines
-**reaffirmation**:
+- `root` candidate: **sound**.
+- `continuation` candidate: **sound** iff its anchor is sound **and**
+  standing(P) is sound; otherwise **compromised**.
+- `derivation` candidate: **sound** iff every `Cause`d Candidate has sound
+  standing (evaluation targets carry no standing); a derivation with only
+  Evaluation targets is **sound**.
 
-- A new Selection S′ MAY carry a `Replace` ref to a prior Selection S
-  (typically tainted, not necessarily). S′ is an ordinary Selection in every
-  respect: its own `considered`, its own `Use`d evaluations (the surviving
-  and/or newly produced evidence), its own selected set, the full rules
-  battery, and whatever role/approval requirements the rules impose on
-  Selections — rules MAY impose *stricter* requirements when `Replace` is
-  present (knob: `reaffirmation_roles`).
-- **Effect is forward-only.** Continuations recorded after S′ `Require` S′
-  and are untainted. Records that `Require`d S remain tainted — taint is
-  never retroactively cleared. The replay report SHOULD annotate such
-  records as *superseded* (tainted via S, where S is `Replace`d by S′), so a
-  consumer can distinguish "rests on retracted evidence, standing restored
-  downstream" from "rests on retracted evidence, abandoned." Exact report
-  shape is open question §16.7.
-- **Retroactive clearing is explicitly rejected.** If a later record could
-  un-taint earlier ones, a producer could launder history: retract
-  inconvenient evidence, reaffirm, and present a clean receipt. Taint must
-  be monotone with respect to committed history; recovery happens only by
-  extending history, in the open, with the reaffirmation itself on the
-  record.
-- **Last resort:** a host abandoning a long-tainted line entirely may start
-  a new `root` candidate with a provenance `note`. This deliberately severs
-  verifiable lineage continuity, and the receipt shows the break — that is
-  the honest cost of a re-baseline.
+**Report and receipt.** The replay report and receipt gain a `standing`
+section: the set of standing-compromised candidate ids, and for each
+compromised anchor, the unsound Selection responsible. Whenever the
+compromised set is non-empty, the origin Selection is necessarily tainted or
+retracted, so the receipt's overall status is already `Tainted` under
+unchanged v0.2 status rules — standing adds *which lineage* is affected and
+*whether it was restored*, it never manufactures a status v0.2 would not
+report. Two independent implementations must derive identical standing sets;
+corpus receipt cases enforce this (§13).
+
+**What standing deliberately does not do.** It does not reject new
+continuations of an unsound Selection — they commit and are born
+compromised, because a ledger that cannot record ongoing work stops being a
+ledger (and produces the perverse incentive to mislabel continuations as
+derivations). Rules MAY opt into commit-time strictness
+(`reject_compromised_continuation`, default false).
+
+### 6.3 Reaffirmation: one-record recovery, at any depth
+
+A Selection S′ carrying `Replace` → S is a **reaffirmation**: a new decision
+over the same objective, on evidence that currently stands. Requirements
+(V3-S5): the target is a Selection in the same space with the same
+`objective`; rules MAY restrict reaffirmation authorship
+(`reaffirmation_roles`, default: Selection's own author-role row).
+
+Because standing (not kernel taint) carries lineage consequence, S′ is
+committable **at any depth**: its `Require`d winners are ordinary untainted
+candidates, its `Use`d evaluations are ordinary untainted evaluations (a
+candidate is never kernel-tainted by its line's compromise), so nothing
+blocks the append. One committed reaffirmation whose selected set contains
+the relevant parents restores standing for the entire descendant subtree at
+the next replay — zero re-recording. (Revision 2's design required
+re-recording every intervening generation because `Require`-of-tainted is a
+hard rejection; this is the fix.)
+
+Honesty properties, unchanged from revision 2 and now structurally
+guaranteed:
+
+- **Forward-only, laundering-proof.** The retraction, the tainted Selection,
+  and the reaffirmation all remain permanently in the log and the receipt;
+  standing is a derived judgment *over* them, never an edit *of* them. A
+  consumer always sees that the line was compromised and exactly what
+  restored it. Kernel taint is never cleared, retroactively or otherwise.
+- **Degenerate reaffirmations are inert.** A reaffirmation with
+  `decision: "none"` (recorded abandonment: "we reviewed; nothing stands")
+  restores no standing — the §6.2 walk requires the parent in a *selected*
+  set. Competing reaffirmations with different selected sets each restore
+  exactly the parents they name; the walk's existential rule keeps the
+  result deterministic and order-independent.
+- **Replacement side effects are v0.2's.** A `Replace`d Selection leaves
+  context construction, as any replaced record does today; the RFC adds no
+  new Replace semantics beyond the whitelist entries and the compatibility
+  rule.
+- **Last resort.** A host abandoning a line entirely may start a new `root`
+  candidate with a provenance `note`; the receipt shows the break in
+  verifiable lineage. That is the honest cost of a re-baseline.
 
 ## 7. Derived lineage
 
-No lineage is stored. Defined queries over the ref graph:
+No lineage is stored. Defined queries over refs and payload fields:
 
-- **line of descent**: from any Candidate, follow its `Require`d Selection
-  and `parent` field (continuations) and `Cause` edges (derivations) back to
-  a `root`.
-- **siblings / a "generation"**: candidates sharing the same `Require`d
+- **line of descent**: from any Candidate, follow its continuation edge
+  (`Cause`d Selection + `parent`) and derivation `Cause` edges back to a
+  `root`.
+- **siblings / a "generation"**: candidates sharing the same `Cause`d
   Selection (continuations) or the same `Cause` targets (derivations).
-- **frontier**: candidates that are not in any Selection's `considered`, plus
+- **frontier**: candidates that appear in no Selection's `considered`, plus
   selected candidates with no continuation yet.
-- **standing**: for any record, its taint status plus any superseding
-  reaffirmation chain (§6.1).
+- **standing**: per §6.2, including which reaffirmation (if any) restored a
+  line.
 
 These are traversals the CLI exposes (§12); a general query engine is a
 non-goal (§14).
@@ -353,119 +454,153 @@ non-goal (§14).
 ## 8. Workload walkthroughs (generality check, C2)
 
 **Best-of-N.** Selection S₀ selects state A. N candidates, each
-`basis: continuation`, `parent: A`, `Require` S₀. Each gets one or more
-Evaluations. One Selection considers all N, `Use`s their evaluations, selects
-one. Continue.
+`basis: continuation`, `parent: A`, `Cause` S₀. Each gets one or more
+Evaluations. One Selection considers all N, `Use`s their evaluations,
+`Require`s and selects one. Continue.
 
 **Population / beam evolution (autoresearch).** A Selection selects the
 top-k survivors {A, B} in one record. Generation k+1 candidates each name
-`parent: A` or `parent: B` and `Require` that Selection. Mutations *within*
+`parent: A` or `parent: B` and `Cause` that Selection. Mutations *within*
 a generation are `basis: derivation` candidates `Cause`-ing a sibling.
 Abandoned lines simply have no continuation; recorded pruning is a Selection
-with `decision: none` over the line's frontier. If an evaluation behind the
-top-k decision is later retracted, the Selection and both lines taint; a
-reaffirmation S′ (`Replace` → S) re-selecting {A} on surviving evidence
-restores forward standing for A's line while B's line remains visibly
-tainted-and-not-reaffirmed. No new kinds needed.
+with `decision: none` over the line's frontier.
+
+**Deep-taint recovery (the case revision 2 could not handle).** At
+generation 5, the harness discovers the generation-2 benchmark was broken and
+retracts its Evaluations. Kernel taint reaches exactly the generation-2
+Selection (it `Use`d them). Standing marks generations 3–5 compromised.
+Work continues uninterrupted (new continuations commit, born compromised).
+The team re-runs the surviving generation-2 evaluations, commits **one**
+reaffirming Selection (`Replace` → S₂) re-selecting the same parents on that
+evidence — and at the next replay the entire descendant subtree's standing
+is sound again, with the whole episode (retraction, taint, compromise,
+reaffirmation) permanently on the record.
 
 **Single-candidate repair.** C₁ (`root` or `continuation`) → Evaluation E₁
 fails → C₂ `basis: derivation`, `Cause` [C₁, E₁] → Evaluation E₂ passes →
 Selection with `considered: [C₂]` (or `[C₁, C₂]` if the host wants the
-comparison on record), `Use` [E₂ (, E₁)], selecting [C₂]. The accept step is
-the same object best-of-N uses; nothing is privileged.
+comparison on record), `Use` [E₂ (, E₁)], `Require`-ing and selecting [C₂].
+The accept step is the same object best-of-N uses; nothing is privileged.
 
 ## 9. Verifier rules (additions to the per-record battery)
 
-All existing v0.2 checks (author roles, identity-to-role binding, signatures,
-canonical payloads with typed decode, evidence thresholds, retraction
-ownership) apply to the new kinds unchanged. New checks, each with a distinct
-rejection reason code and a triggering corpus case:
+All existing v0.2 checks (author roles per §4.0's table, identity-to-role
+binding, signatures, canonical payloads with typed decode, evidence
+derivation and thresholds, taint, retraction ownership) apply to the new
+kinds unchanged. New checks, each with a distinct rejection reason code and
+a triggering corpus case:
+
+**Payload-id resolution (shared rule).** `parent` and every member of
+`considered` are payload ids, not refs; v0.2's ref battery never touches
+them. v0.3 defines: each MUST resolve, in the same space, to a
+previously **accepted** `Candidate` record (retracted or tainted targets
+resolve — those conditions surface through evidence/taint on refs and
+through standing, not through payload lookup). Unresolvable, cross-space,
+or wrong-kind payload ids reject.
 
 **Candidate**
 - V3-C1: `source.git.tree` present, hex, length matching `algo`.
 - V3-C2: `binding == "manifest"` ⇒ `manifest_hash` present (64-hex);
   `binding == "reported"` ⇒ `manifest_hash` absent.
 - V3-C3: basis/ref obligations of §4.1 hold (continuation ⇒ exactly one
-  `Require`d Selection with outcome `selected`; derivation ⇒ ≥ 1 `Cause` of
-  allowed kinds; root ⇒ no `Require`).
-- V3-C4: a `Require`d Selection must not be retracted at commit time
-  (retracted authority stops authorizing — same principle as v0.2 capability
-  revocation).
-- V3-C5: `parent` present iff `basis == "continuation"`, and it names a
-  member of the `Require`d Selection's selected set.
+  `Cause`, targeting a Selection with `decision == "selected"`; derivation ⇒
+  ≥ 1 `Cause`, each `Candidate` or `Evaluation`, none a `Selection`; root ⇒
+  no `Cause` to a Selection).
+- V3-C5: `parent` present iff `basis == "continuation"`; resolves per the
+  shared rule; and names a member of the `Cause`d Selection's selected set.
+
+(Revision 2's V3-C4 — rejecting continuation of a retracted Selection — is
+**removed**: with `Cause` edges the generic kernel rules do not apply, and
+its consequence is now correctly carried by standing (§6.2), with the
+optional `reject_compromised_continuation` knob for hosts that want
+commit-time strictness.)
 
 **Evaluation**
-- V3-E1: `candidate` names an existing Candidate record and is matched by a
-  `Use` ref.
+- V3-E1: `candidate` names an accepted Candidate (shared rule) and is
+  matched by a `Use` ref.
 - V3-E2: `criterion` non-empty; `outcome` well-formed per status
   (`scored` ⇔ `value` and `scale` present).
 
 **Selection**
-- V3-S1: `considered` non-empty, unique, all existing Candidate ids.
+- V3-S1: `considered` non-empty, unique, each member resolving per the
+  shared rule.
 - V3-S2: `decision == "selected"` ⇒ `outcome.candidates` non-empty, unique,
-  ⊆ `considered`, and the record `Require`s exactly those candidates;
-  `decision == "none"` ⇒ no `Require`.
+  ⊆ `considered`, each `Require`d; every `Require` target is either a
+  selected candidate or an authority record (Capability/Approval) demanded
+  by the rules; `decision == "none"` ⇒ no candidate `Require`s.
 - V3-S3: every `Use`d Evaluation's `candidate` ∈ `considered`.
-- V3-S4 (default rules; knob `selection_requires_evaluation = true`): ≥ 1
-  `Use`d Evaluation when `decision == "selected"`.
-- V3-S5: a `Replace` ref on a Selection, if present, targets a Selection;
-  rules knob `reaffirmation_roles` MAY restrict which authors may reaffirm.
+- V3-S4 (knob `selection_requires_evaluation`, default true): ≥ 1 `Use`d
+  Evaluation when `decision == "selected"`.
+- V3-S5: at most one `Replace` ref (v0.2 rule); if present, the target is a
+  Selection, same space, same `objective`; author satisfies
+  `reaffirmation_roles`.
 
 **New rules knobs**
 - `min_binding` per referencing context (e.g. Selections may only `Require`
   candidates with `manifest` binding).
 - `selection_requires_evaluation` (default true).
-- `reaffirmation_roles` (default: same as Selection authorship).
+- `reaffirmation_roles` (default: Selection's author-role row).
+- `reject_compromised_continuation` (default false; §6.2).
 - Per-kind evidence thresholds and author-role bindings apply to the three
-  kinds exactly as to existing kinds.
+  kinds exactly as to existing kinds, using §4.0's registrations.
+
+**Spec-level changes beyond the battery** (still additive, per C3): the
+`Replace` kind whitelist gains `Selection` (carrier) / `Selection` (target)
+with the V3-S5 compatibility rule; the replay report and receipt gain the
+`standing` section (§6.2); SPEC v0.3 defines the selection approval-binding
+hash (§4.3 "Authority") with its own domain string.
 
 ## 10. Retraction and the flagship scenario
 
 The demonstration this release is built around:
 
-> A benchmark harness is discovered to be broken. Its Evaluations are
-> retracted. Every Selection that `Use`d them is tainted; every continuation
-> Candidate that `Require`d those Selections is tainted; their Evaluations
-> and every subsequent Selection and continuation are tainted transitively.
-> One retraction, and the receipt now shows exactly which surviving lineage
-> still rests on untainted evidence — and which "best" states were chosen on
-> evidence that no longer stands. Repairs and mutations motivated by the
-> broken evaluations remain untainted: their motivation vanished, their
-> content did not. The team then re-runs the surviving evaluations and
-> records a reaffirming Selection (§6.1): forward standing is restored, on
-> the record, without erasing what happened.
+> A benchmark harness is discovered to be broken. Its Evaluations — authored
+> by the Provider (or admin-retractable by configuration; §4.0) — are
+> retracted. Kernel taint reaches every Selection that `Use`d them, exactly
+> as v0.2 defines. The `standing` section of the replay report now shows
+> every descendant candidate of those Selections as compromised,
+> transitively, at any depth — while repairs and mutations merely
+> *motivated* by the broken evaluations remain sound, because motivation is
+> `Cause` and standing follows continuation edges only. Work never stops:
+> the line keeps recording, visibly compromised. The team re-runs the
+> surviving evaluations and commits one reaffirming Selection; the next
+> replay shows the line's standing restored — with the retraction, the
+> taint, the compromise, and the recovery all permanently, verifiably on
+> the record.
 
-Taint here means "rests on retracted evidence," never "the code is wrong" —
-and the reaffirmation step is part of the demo precisely so the cascade
-reads as actionable state, not as a permanent alarm. This requires zero new
-taint machinery — only the ref discipline of §6 — and is the capability that
-distinguishes Bellbook from experiment trackers and Git workflows alike. It
-ships as a worked example plus corpus receipt cases covering: the full
-cascade, the derivation non-cascade, the reaffirmation recovery, and a
-forged "un-tainted" receipt that replay rejects.
+Standing means "rests on decisions that no longer stand," never "the code is
+wrong" — and the one-record recovery is part of the demo precisely so the
+cascade reads as actionable state, not a permanent alarm or a frozen ledger.
+It ships as a worked example plus corpus receipt cases covering: the full
+compromise cascade, the derivation non-cascade, deep reaffirmation recovery,
+a `none`-decision reaffirmation restoring nothing, competing reaffirmations,
+and a forged receipt whose standing section disagrees with re-derivation and
+is rejected.
 
 ## 11. Receipt boundary
 
 A v0.3 receipt proves the recorded **process**: which candidates were
-recorded, what was claimed about them, which evidence and evaluations existed,
-what was selected under what objective, what is retracted, tainted, or
-superseded, and that none of it was altered after the fact. It does **not**
-contain source contents; Git OIDs are pointers whose resolution requires the
-repository. With `manifest` binding, a party holding the tree can
-independently recompute `manifest_hash` and bind the receipt to actual
-contents; with `reported` binding they hold a verifiable record of an
-unverified claim — and the receipt says which, explicitly.
+recorded, what was claimed about them, which evidence and evaluations
+existed, what was selected under what objective, what is retracted, tainted,
+or standing-compromised (and what restored it), and that none of it was
+altered after the fact. It does **not** contain source contents; Git OIDs
+are pointers whose resolution requires the repository. With `manifest`
+binding, a party holding the tree can independently recompute
+`manifest_hash` and bind the receipt to actual contents; with `reported`
+binding they hold a verifiable record of an unverified claim — and the
+receipt says which, explicitly.
 
-One further boundary, stated with the same bluntness: **the lineage and taint
-guarantees are conditional on the producer's recording discipline.** `basis`,
-`parent`, and the choice of refs are producer claims; a host that records
-continuations as derivations escapes the cascade, and no verifier can detect
-that, because intent is not checkable. Bellbook proves the recorded structure
-is internally consistent under its rules — it does not prove the structure
-faithfully mirrors the development process. A receipt consumer trusts the
-embedded `rules_hash` *and* the producer's recording conventions. This is
-v0.2's "consistency, not completeness" boundary extended one level, and it
-must appear in SPEC v0.3 §13 verbatim in spirit.
+One further boundary, stated with the same bluntness: **the lineage,
+standing, and taint guarantees are conditional on the producer's recording
+discipline.** `basis`, `parent`, and the choice of refs are producer claims;
+a host that records continuations as derivations escapes the standing
+cascade, and no verifier can detect that, because intent is not checkable.
+Bellbook proves the recorded structure is internally consistent under its
+rules — it does not prove the structure faithfully mirrors the development
+process. A receipt consumer trusts the embedded `rules_hash` *and* the
+producer's recording conventions. This is v0.2's "consistency, not
+completeness" boundary extended one level, and it must appear in SPEC v0.3
+§13 verbatim in spirit.
 
 ## 12. CLI surface (the wedge's adoption surface)
 
@@ -482,11 +617,12 @@ bellbook eval add       --candidate <id> --criterion <s>
                         (--passed | --failed | --score <value> --scale <n>)
                         [--procedure <s>] [--uses <id> ...]
 bellbook select         --objective <s> --consider <id> ...
-                        (--choose <id> ... | --none)
-                        [--replaces <selection-id>]            # reaffirmation
-                        --uses-eval <id> ... [--rationale <s>]
-bellbook lineage        <id> [--json]      # descent, siblings, taint + superseded status
-bellbook validate       <receipt>          # unchanged from v0.2
+                        (--choose <id> ... --uses-eval <id> ...   # evals required with --choose
+                         | --none)                               # no evals required with --none
+                        [--replaces <selection-id>]              # reaffirmation
+                        [--rationale <s>]
+bellbook lineage        <id> [--json]      # descent, siblings, taint + standing
+bellbook validate       <receipt>          # v0.2 semantics + the standing section
 ```
 
 **Concurrency guidance (normative for the docs, not the verifier):** the
@@ -511,12 +647,16 @@ is updated in lockstep via the corpus, as now.
   vectors.
 - Conformance corpus extended with positive and adversarial cases per new
   invariant in §9 (each rejection reason code gets a triggering case), plus
-  the §10 receipt cases (cascade, non-cascade, reaffirmation, forged
-  un-taint).
-- The Python validator implements the three kinds and the taint flows
-  independently, and the corpus gate in CI holds both implementations to
-  byte-for-decision agreement — same discipline that caught real bugs in the
-  v0.2 cycle.
+  the §10 receipt cases and standing-derivation cases (two implementations
+  must produce identical standing sets).
+- **v0.2 corpus backfill (independent of v0.3):** the audit found that no
+  existing corpus case exercises the `Require` leg of taint propagation,
+  though SPEC.md claims that coverage. A small v0.2-scope corpus addition
+  should close that gap regardless of this RFC's fate.
+- The Python validator implements the three kinds, the standing derivation,
+  and the Replace extension independently, and the corpus gate in CI holds
+  both implementations to byte-for-decision agreement — same discipline that
+  caught real bugs in the v0.2 cycle and in revisions 1–2 of this RFC.
 
 ## 14. Non-goals (binding for v0.3)
 
@@ -525,9 +665,9 @@ engine (lineage traversal only — but see §15's read-side signal, which is the
 designated trigger for revisiting this); no Git plumbing beyond reading OIDs
 and the optional manifest walk; no materialization; no remotes or sync; no
 native source storage; no structured ContextObject system; no `Generation`,
-`Tournament`, or `Repair` kinds; no agent-cognition vocabulary of any sort.
-Each of these is either VISION-scope (gated) or belongs to host systems
-permanently.
+`Tournament`, or `Repair` kinds; no agent-cognition vocabulary of any sort;
+no retroactive clearing of kernel taint under any mechanism. Each of these
+is either VISION-scope (gated) or excluded permanently.
 
 ## 15. Validation and falsification criteria (pre-registered)
 
@@ -539,12 +679,13 @@ Evaluation window: **90 days from shipping v0.3 + the flagship example**.
    this project, in actual use.
 2. Receipts generated by ≥ 3 external users or organizations (observed via
    issues, discussions, or shared receipts — not download counts).
-3. Inbound issues or PRs that engage the *semantics* (binding modes, taint
-   flows, selection invariants) — people argue about semantics they use.
+3. Inbound issues or PRs that engage the *semantics* (binding modes, standing
+   and taint flows, selection invariants) — people argue about semantics they
+   use.
 4. The flagship broken-benchmark scenario independently reproduced or cited
    by an external party.
 5. **Read-side usage**: at least one integration that *queries* — lineage
-   traversal, taint/superseded status, or receipt validation inside its own
+   traversal, standing/taint status, or receipt validation inside its own
    loop — rather than only writing records. This signal specifically gates
    the VISION query-surface stage: write-side adoption justifies more
    recording semantics; only read-side adoption justifies a query engine.
@@ -554,8 +695,8 @@ Evaluation window: **90 days from shipping v0.3 + the flagship example**.
    workflows yields zero adoption, with the stated reason being that ad-hoc
    eval JSON plus branch conventions are sufficient.
 2. Any integrations that do exist use Bellbook as write-only logging — no
-   receipt validation, no taint queries, no selection semantics — for the
-   full window.
+   receipt validation, no standing or taint queries, no selection semantics —
+   for the full window.
 
 **Decision rule:** if falsified, VISION stages 1–4 stay parked indefinitely;
 native storage would not have changed the answer. If neither validated nor
@@ -582,13 +723,18 @@ no second extension without new evidence.
    defined idiom, e.g. a manifest-bound re-record of the same tree that the
    Selection `Require`s instead of the reported one. Does that re-record need
    its own basis/ref rule?
-7. **Superseded-annotation shape** — how the replay report expresses
-   "tainted via S, S `Replace`d by S′" (§6.1); field naming and whether
-   supersession chains longer than one hop are flattened.
-8. **V3-C4 timing** — "Selection not retracted at commit time" mirrors
-   capability revocation; confirm the same replay semantics (validity judged
-   at commit position, taint judged at replay end) reads correctly for
-   selections.
+7. **Standing report shape** — exact field naming for the `standing`
+   section; whether restored lines list the restoring Selection per
+   candidate or per anchor; whether replacement chains are flattened in the
+   report.
+8. **`Verified` pathway for evaluations** — under §4.0's base classes,
+   evaluations top out at `Reported`. Whether and how a key-pinned external
+   attestor's evaluation can reach `Verified` must be settled against
+   v0.2's actual `Verified` mechanism (schema base vs. signature-conditioned
+   grants) — deliberately unresolved here rather than overclaimed.
 9. **`considered` size bound** — population workloads may list thousands of
    ids per Selection; should rules impose a per-record bound consistent with
    the existing resource bounds?
+10. **Selection approval-binding domain** — final form of the
+    selection-approval hash domain string and its interaction with
+    single-use consumption when a Selection is later `Replace`d.

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,9 +1,12 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
-**Status:** Draft for review. Nothing in this RFC is implemented; nothing in
-it changes spec v0.2 or the published crate. The goal is to make the object
-semantics and invariants precise enough to implement without re-litigating
-them mid-build. Kind names and field spellings are tentative until accepted.
+**Status:** Draft, revision 2 — incorporates the adversarial review of
+revision 1 (set-valued selection; reaffirmation; binding-authority,
+discipline, and concurrency honesty). Nothing in this RFC is implemented;
+nothing in it changes spec v0.2 or the published crate. The goal is to make
+the object semantics and invariants precise enough to implement without
+re-litigating them mid-build. Kind names and field spellings are tentative
+until accepted.
 
 **Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
 *verifiable candidate selection and lineage for autonomous coding agents*,
@@ -18,10 +21,13 @@ Spec v0.3 adds three typed record kinds — `Candidate`, `Evaluation`,
 Lineage is derived from existing typed refs (`Cause`, `Use`, `Require`),
 never stored as a parallel structure. Source identity binds to Git (tree
 OID), with an optional Bellbook-computed manifest hash for stronger binding.
-Retraction and transitive taint apply to the new kinds with one carefully
-chosen rule — continuation requires its Selection — that makes a retracted
-evaluation taint the entire descendant line it selected, which is the
-flagship capability of this release.
+Selections are **set-valued** (they may select one candidate or several), so
+best-of-N, population/beam evolution, and single-candidate repair share one
+vocabulary. Retraction and transitive taint apply through one carefully
+chosen rule — continuation requires its Selection — so a retracted evaluation
+taints the entire descendant line it selected; a **forward-only
+reaffirmation** mechanism lets a superseding Selection restore a line's
+standing without retroactively erasing taint.
 
 ## 2. Motivation
 
@@ -33,7 +39,7 @@ state → generate candidate(s) → evaluate → select (or repair and re-evalua
 
 Git can store the file contents at each step but has no native representation
 of the loop itself: which candidates were considered, under what objective,
-on what evidence, why one was selected, and what the surviving lineage
+on what evidence, why some were selected, and what the surviving lineage
 therefore rests on. That knowledge lives in throwaway branches and harness
 logs, unverifiable after the fact.
 
@@ -52,14 +58,15 @@ C1. **One primitive.** No new storage objects. `Candidate`, `Evaluation`,
 C2. **Workload generality.** The semantics must serve, without privileging
     any of them:
     (a) best-of-N — fork N candidates, evaluate, select one;
-    (b) iterative evolution / autoresearch — generations of candidates,
-        repeated evaluate-select-continue, abandoned lines;
+    (b) iterative / population evolution (autoresearch) — generations of
+        candidates, top-k survivors as parents of the next generation,
+        abandoned lines;
     (c) single-candidate development — one candidate, evaluation fails,
         repair produces a successor candidate, re-evaluate, accept.
-    Consequences: selections operate over candidate sets of size **≥ 1**;
-    repair is an ordinary candidate-to-candidate derivation; there is **no**
-    `Generation`, `Tournament`, or `Repair` object — all such structure is
-    derivable (§8).
+    Consequences: selections operate over candidate sets of size **≥ 1** and
+    may select **≥ 1** survivors; repair is an ordinary candidate-to-candidate
+    derivation; there is **no** `Generation`, `Tournament`, or `Repair`
+    object — all such structure is derivable (§8).
 
 C3. **Kernel unchanged.** The evidence lattice, verdict machinery, signature
     scheme, retraction/taint engine, and receipt model of v0.2 are reused,
@@ -97,6 +104,8 @@ development.
     "binding": "reported"          // "reported" | "manifest"
   },
   "basis": "root",                 // "root" | "continuation" | "derivation"
+  "parent": "<record id>",         // REQUIRED iff basis == "continuation":
+                                   //   the selected candidate this continues from
   "note": "<bounded string>"       // OPTIONAL: free-form label
 }
 ```
@@ -105,12 +114,14 @@ development.
 
 | basis          | meaning                                        | ref obligations |
 |----------------|------------------------------------------------|-----------------|
-| `root`         | starts a line (imported / initial state)       | MAY `Cause` a Request |
-| `continuation` | continues from a selected state                | MUST `Require` exactly one `Selection` whose outcome is `selected` |
-| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each of kind `Candidate` or `Evaluation` |
+| `root`         | starts a line (imported / initial state)       | MAY `Cause` a Request; no `parent` |
+| `continuation` | continues from a selected state                | MUST `Require` exactly one `Selection` whose outcome is `selected`, and `parent` MUST name a member of that Selection's selected set |
+| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each of kind `Candidate` or `Evaluation`; no `parent` |
 
 The `continuation`/`derivation` distinction is the taint boundary and is the
-most consequential rule in this RFC; rationale in §6.
+most consequential rule in this RFC; rationale in §6. The `parent` field is
+descriptive lineage (which selected state this builds on); the *epistemic*
+dependency is the `Require` on the Selection.
 
 ### 4.2 `Evaluation`
 
@@ -143,7 +154,11 @@ verifier-derived records. Bellbook never computes or re-runs an evaluation
 
 ### 4.3 `Selection`
 
-A recorded decision over a set of candidates under an objective.
+A recorded decision over a set of candidates under an objective. Selections
+are **set-valued**: the outcome names the surviving candidates — one for
+best-of-N or a repair accept, several for population/beam evolution where the
+top-k jointly become parents of the next generation. A single decision that
+keeps k survivors is one record, not k fragmented ones.
 
 ```jsonc
 {
@@ -151,7 +166,7 @@ A recorded decision over a set of candidates under an objective.
   "considered": ["<id>", "..."],     // REQUIRED: ≥ 1, unique, all Candidate ids
   "outcome": {
     "decision": "selected",          // "selected" | "none"
-    "candidate": "<record id>"       // REQUIRED iff decision == "selected"
+    "candidates": ["<id>", "..."]    // REQUIRED iff selected: ≥ 1, unique, ⊆ considered
   },
   "rationale": "<bounded string>"    // OPTIONAL
 }
@@ -159,14 +174,17 @@ A recorded decision over a set of candidates under an objective.
 
 **Ref obligations:**
 
-- If `decision == "selected"`: MUST `Require` exactly the selected candidate
-  (which MUST appear in `considered`).
+- If `decision == "selected"`: MUST `Require` exactly the members of
+  `outcome.candidates` (each of which MUST appear in `considered`).
 - MUST `Use` ≥ 1 `Evaluation` (default rules; a rules knob MAY relax this,
   see §9), and the `candidate` of every `Use`d Evaluation MUST appear in
   `considered`.
 - `decision == "none"` records that no candidate was acceptable under the
   objective — a legal, meaningful outcome (pruning, backtracking). It carries
   no `Require`.
+- A Selection MAY carry a `Replace` ref to a prior Selection: this is
+  **reaffirmation** (§6.1). If present, the `Replace` target MUST be a
+  Selection.
 
 Losing candidates are listed in `considered` (descriptive) but not referenced
 via `Use`/`Require`; the decision's *epistemic* premises are the evaluations
@@ -175,7 +193,7 @@ evaluations too, and taint then flows through those evaluations — the host
 controls comparative-vs-threshold semantics through what it declares, not
 through special kinds.
 
-A Selection with `considered` of size 1 and `decision: selected` is the
+A Selection with `considered` of size 1 and a selected set of size 1 is the
 formal version of "accept this state under this objective" — the
 single-candidate workflow's terminal step (C2c). Authority composes
 unchanged: rules may demand that Selections be authored by a given role,
@@ -199,14 +217,32 @@ Two binding modes, distinguished explicitly in the payload:
   a content commitment independent of Git's hash algorithm: anyone holding
   the tree can recompute the manifest and compare.
 
+**Authority on disagreement.** Nothing inside a record can prove that
+`manifest_hash` and `git.tree` describe the same contents; a false record can
+carry a tree OID and a manifest that disagree. When both are present, the
+**manifest is the authoritative identity commitment** and the tree OID is an
+interoperability pointer; a disagreement makes the record a false claim,
+detectable only by materializing the tree and recomputing the manifest —
+the same boundary v0.2 draws for `Verified` evidence ("origin verified,
+never the real-world effect"). SPEC v0.3 §13 must state this.
+
+**Adoption reality, stated in advance.** The manifest walk is O(worktree) per
+candidate. High-N workloads will predictably use `reported` for the
+population, which means their receipts commit to claims about SHA-1 hashes,
+not to contents. That is acceptable and must be said plainly, not
+discovered. The intended pattern is cheap `reported` bindings for the
+population and strong binding for the states that matter (the selected
+survivors); since a record's binding is immutable, how a survivor's binding
+gets upgraded (e.g. a manifest-bound re-record of the same tree that the
+Selection then `Require`s) is open question §16.6.
+
 **Deliberate refinement of an earlier framing:** binding strength is carried
 by the explicit `binding` field plus a per-kind rules threshold
 (`min_binding`, §9) — *not* by overloading the evidence-class definitions,
 whose v0.2 meanings stay fixed. The evidence class continues to grade how the
-record's content is known (a self-reported binding is `Reported`; a
-key-pinned external attestation of a manifest is `Verified`), and the two
-mechanisms compose. Rules like "any candidate referenced by a Selection must
-have `manifest` binding" become expressible without touching the lattice.
+record's content is known, and the two mechanisms compose. Rules like "any
+candidate a Selection `Require`s must have `manifest` binding" become
+expressible without touching the lattice.
 
 ### 5.1 Canonical manifest v1 (proposal)
 
@@ -239,8 +275,8 @@ Applied:
   evaluations. Correct: the judgments were about content whose binding no
   longer stands.
 - A **Selection** `Use`s the evaluations it relied on and `Require`s its
-  winner → retracting a relied-on evaluation taints the selection. Correct:
-  the decision's premises are gone.
+  selected candidates → retracting a relied-on evaluation, or any selected
+  candidate, taints the selection. Correct: the decision's premises are gone.
 - A **continuation Candidate** `Require`s its Selection → a tainted selection
   taints every candidate that continued from it, and (via their evaluations
   and subsequent selections) the entire descendant line. This is the rule
@@ -252,21 +288,64 @@ Applied:
   is later retracted, the repaired artifact is not thereby wrong; only its
   motivation evaporated. Retraction poisons conclusions, not code.
 
-This asymmetry — continuation `Require`s, derivation `Cause`s — is the single
-most consequential decision in this RFC and should be challenged hardest in
-review.
+Two acknowledged consequences, both deliberate:
+
+1. **The cascade can be over-broad.** A Selection may be over-determined
+   (the survivors stand on four evaluations even after a fifth is
+   retracted), and taint through a multi-winner Selection reaches *all* its
+   continuation lines even if only one winner's premises collapsed. Taint
+   means "rests on something retracted," never "is wrong" — the recovery
+   path is reaffirmation (§6.1), not weaker taint.
+2. **This asymmetry — continuation `Require`s, derivation `Cause`s — is the
+   single most consequential decision in this RFC** and should be challenged
+   hardest in review.
+
+### 6.1 Reaffirmation: forward-only taint recovery
+
+Without a recovery mechanism, one retracted evaluation permanently taints an
+entire active line, and the only exit is re-recording the chain. Large,
+mostly-recoverable cascades would teach users to ignore taint — destroying
+the flagship capability through alarm fatigue. v0.3 therefore defines
+**reaffirmation**:
+
+- A new Selection S′ MAY carry a `Replace` ref to a prior Selection S
+  (typically tainted, not necessarily). S′ is an ordinary Selection in every
+  respect: its own `considered`, its own `Use`d evaluations (the surviving
+  and/or newly produced evidence), its own selected set, the full rules
+  battery, and whatever role/approval requirements the rules impose on
+  Selections — rules MAY impose *stricter* requirements when `Replace` is
+  present (knob: `reaffirmation_roles`).
+- **Effect is forward-only.** Continuations recorded after S′ `Require` S′
+  and are untainted. Records that `Require`d S remain tainted — taint is
+  never retroactively cleared. The replay report SHOULD annotate such
+  records as *superseded* (tainted via S, where S is `Replace`d by S′), so a
+  consumer can distinguish "rests on retracted evidence, standing restored
+  downstream" from "rests on retracted evidence, abandoned." Exact report
+  shape is open question §16.7.
+- **Retroactive clearing is explicitly rejected.** If a later record could
+  un-taint earlier ones, a producer could launder history: retract
+  inconvenient evidence, reaffirm, and present a clean receipt. Taint must
+  be monotone with respect to committed history; recovery happens only by
+  extending history, in the open, with the reaffirmation itself on the
+  record.
+- **Last resort:** a host abandoning a long-tainted line entirely may start
+  a new `root` candidate with a provenance `note`. This deliberately severs
+  verifiable lineage continuity, and the receipt shows the break — that is
+  the honest cost of a re-baseline.
 
 ## 7. Derived lineage
 
 No lineage is stored. Defined queries over the ref graph:
 
-- **line of descent**: from any Candidate, follow `Require` → Selection →
-  members of `considered` / its own `Require`d winner’s ancestry, and
-  `Cause` edges between candidates, back to a `root`.
+- **line of descent**: from any Candidate, follow its `Require`d Selection
+  and `parent` field (continuations) and `Cause` edges (derivations) back to
+  a `root`.
 - **siblings / a "generation"**: candidates sharing the same `Require`d
   Selection (continuations) or the same `Cause` targets (derivations).
 - **frontier**: candidates that are not in any Selection's `considered`, plus
   selected candidates with no continuation yet.
+- **standing**: for any record, its taint status plus any superseding
+  reaffirmation chain (§6.1).
 
 These are traversals the CLI exposes (§12); a general query engine is a
 non-goal (§14).
@@ -274,20 +353,25 @@ non-goal (§14).
 ## 8. Workload walkthroughs (generality check, C2)
 
 **Best-of-N.** Selection S₀ selects state A. N candidates, each
-`basis: continuation`, `Require` S₀. Each gets one or more Evaluations.
-One Selection considers all N, `Use`s their evaluations, `Require`s the
-winner. Continue.
+`basis: continuation`, `parent: A`, `Require` S₀. Each gets one or more
+Evaluations. One Selection considers all N, `Use`s their evaluations, selects
+one. Continue.
 
-**Iterative evolution / autoresearch.** As above, repeated: generation k+1's
-candidates `Require` the generation-k Selection. Mutations *within* a
-generation are `basis: derivation` candidates `Cause`-ing a sibling.
+**Population / beam evolution (autoresearch).** A Selection selects the
+top-k survivors {A, B} in one record. Generation k+1 candidates each name
+`parent: A` or `parent: B` and `Require` that Selection. Mutations *within*
+a generation are `basis: derivation` candidates `Cause`-ing a sibling.
 Abandoned lines simply have no continuation; recorded pruning is a Selection
-with `decision: none` over the line's frontier. No new kinds needed.
+with `decision: none` over the line's frontier. If an evaluation behind the
+top-k decision is later retracted, the Selection and both lines taint; a
+reaffirmation S′ (`Replace` → S) re-selecting {A} on surviving evidence
+restores forward standing for A's line while B's line remains visibly
+tainted-and-not-reaffirmed. No new kinds needed.
 
 **Single-candidate repair.** C₁ (`root` or `continuation`) → Evaluation E₁
 fails → C₂ `basis: derivation`, `Cause` [C₁, E₁] → Evaluation E₂ passes →
 Selection with `considered: [C₂]` (or `[C₁, C₂]` if the host wants the
-comparison on record), `Use` [E₂ (, E₁)], `Require` C₂. The accept step is
+comparison on record), `Use` [E₂ (, E₁)], selecting [C₂]. The accept step is
 the same object best-of-N uses; nothing is privileged.
 
 ## 9. Verifier rules (additions to the per-record battery)
@@ -307,6 +391,8 @@ rejection reason code and a triggering corpus case:
 - V3-C4: a `Require`d Selection must not be retracted at commit time
   (retracted authority stops authorizing — same principle as v0.2 capability
   revocation).
+- V3-C5: `parent` present iff `basis == "continuation"`, and it names a
+  member of the `Require`d Selection's selected set.
 
 **Evaluation**
 - V3-E1: `candidate` names an existing Candidate record and is matched by a
@@ -316,16 +402,20 @@ rejection reason code and a triggering corpus case:
 
 **Selection**
 - V3-S1: `considered` non-empty, unique, all existing Candidate ids.
-- V3-S2: `decision == "selected"` ⇒ `outcome.candidate` ∈ `considered` and is
-  `Require`d; `decision == "none"` ⇒ no `Require`.
+- V3-S2: `decision == "selected"` ⇒ `outcome.candidates` non-empty, unique,
+  ⊆ `considered`, and the record `Require`s exactly those candidates;
+  `decision == "none"` ⇒ no `Require`.
 - V3-S3: every `Use`d Evaluation's `candidate` ∈ `considered`.
 - V3-S4 (default rules; knob `selection_requires_evaluation = true`): ≥ 1
   `Use`d Evaluation when `decision == "selected"`.
+- V3-S5: a `Replace` ref on a Selection, if present, targets a Selection;
+  rules knob `reaffirmation_roles` MAY restrict which authors may reaffirm.
 
 **New rules knobs**
 - `min_binding` per referencing context (e.g. Selections may only `Require`
   candidates with `manifest` binding).
 - `selection_requires_evaluation` (default true).
+- `reaffirmation_roles` (default: same as Selection authorship).
 - Per-kind evidence thresholds and author-role bindings apply to the three
   kinds exactly as to existing kinds.
 
@@ -341,28 +431,41 @@ The demonstration this release is built around:
 > still rests on untainted evidence — and which "best" states were chosen on
 > evidence that no longer stands. Repairs and mutations motivated by the
 > broken evaluations remain untainted: their motivation vanished, their
-> content did not.
+> content did not. The team then re-runs the surviving evaluations and
+> records a reaffirming Selection (§6.1): forward standing is restored, on
+> the record, without erasing what happened.
 
-This requires zero new taint machinery — only the ref discipline of §6 — and
-is the capability that distinguishes Bellbook from experiment trackers and
-Git workflows alike. It ships as a worked example plus corpus receipt cases
-covering: the full cascade, the derivation non-cascade, and a forged
-"un-tainted" receipt that replay rejects.
+Taint here means "rests on retracted evidence," never "the code is wrong" —
+and the reaffirmation step is part of the demo precisely so the cascade
+reads as actionable state, not as a permanent alarm. This requires zero new
+taint machinery — only the ref discipline of §6 — and is the capability that
+distinguishes Bellbook from experiment trackers and Git workflows alike. It
+ships as a worked example plus corpus receipt cases covering: the full
+cascade, the derivation non-cascade, the reaffirmation recovery, and a
+forged "un-tainted" receipt that replay rejects.
 
 ## 11. Receipt boundary
 
 A v0.3 receipt proves the recorded **process**: which candidates were
 recorded, what was claimed about them, which evidence and evaluations existed,
-what was selected under what objective, what is retracted or tainted, and
-that none of it was altered after the fact. It does **not** contain source
-contents; Git OIDs are pointers whose resolution requires the repository.
-With `manifest` binding, a party holding the tree can independently recompute
-`manifest_hash` and bind the receipt to actual contents; with `reported`
-binding they hold a verifiable record of an unverified claim — and the
-receipt says which, explicitly.
+what was selected under what objective, what is retracted, tainted, or
+superseded, and that none of it was altered after the fact. It does **not**
+contain source contents; Git OIDs are pointers whose resolution requires the
+repository. With `manifest` binding, a party holding the tree can
+independently recompute `manifest_hash` and bind the receipt to actual
+contents; with `reported` binding they hold a verifiable record of an
+unverified claim — and the receipt says which, explicitly.
 
-This is v0.2's "consistency, not completeness" boundary extended one level,
-and it must be stated with the same bluntness in SPEC v0.3 §13.
+One further boundary, stated with the same bluntness: **the lineage and taint
+guarantees are conditional on the producer's recording discipline.** `basis`,
+`parent`, and the choice of refs are producer claims; a host that records
+continuations as derivations escapes the cascade, and no verifier can detect
+that, because intent is not checkable. Bellbook proves the recorded structure
+is internally consistent under its rules — it does not prove the structure
+faithfully mirrors the development process. A receipt consumer trusts the
+embedded `rules_hash` *and* the producer's recording conventions. This is
+v0.2's "consistency, not completeness" boundary extended one level, and it
+must appear in SPEC v0.3 §13 verbatim in spirit.
 
 ## 12. CLI surface (the wedge's adoption surface)
 
@@ -372,17 +475,28 @@ record id; harnesses in any language integrate by shelling out.
 ```
 bellbook candidate add  --git-tree <oid> [--git-commit <oid>] [--algo sha1|sha256]
                         [--manifest <path-to-worktree>]        # computes manifest binding
-                        [--continues <selection-id> | --derives-from <id> ...]
+                        [--continues <selection-id> --parent <candidate-id>
+                         | --derives-from <id> ...]
                         [--note <s>]
 bellbook eval add       --candidate <id> --criterion <s>
                         (--passed | --failed | --score <value> --scale <n>)
                         [--procedure <s>] [--uses <id> ...]
 bellbook select         --objective <s> --consider <id> ...
-                        (--choose <id> | --none)
+                        (--choose <id> ... | --none)
+                        [--replaces <selection-id>]            # reaffirmation
                         --uses-eval <id> ... [--rationale <s>]
-bellbook lineage        <id> [--json]      # line of descent, siblings, taint status
+bellbook lineage        <id> [--json]      # descent, siblings, taint + superseded status
 bellbook validate       <receipt>          # unchanged from v0.2
 ```
+
+**Concurrency guidance (normative for the docs, not the verifier):** the
+persistent log is deliberately single-writer (`LogWriter` holds an exclusive
+lock, exactly as in v0.2). Parallel candidate *generation* is the workload;
+parallel *recording* is not the mechanism. Hosts generate candidates
+concurrently and record them serially afterward — one process, in a batch
+(`checked_batch_commit` for retry-safe batches) or a loop. The CLI is not a
+coordination layer, and integration docs must say so before integrators
+discover the lock by contention.
 
 Signing, roles, and receipt export use existing mechanisms. Python bindings
 remain out of scope (README open-work list); the independent Python validator
@@ -397,7 +511,8 @@ is updated in lockstep via the corpus, as now.
   vectors.
 - Conformance corpus extended with positive and adversarial cases per new
   invariant in §9 (each rejection reason code gets a triggering case), plus
-  the §10 receipt cases.
+  the §10 receipt cases (cascade, non-cascade, reaffirmation, forged
+  un-taint).
 - The Python validator implements the three kinds and the taint flows
   independently, and the corpus gate in CI holds both implementations to
   byte-for-decision agreement — same discipline that caught real bugs in the
@@ -406,9 +521,10 @@ is updated in lockstep via the corpus, as now.
 ## 14. Non-goals (binding for v0.3)
 
 No ranking or scoring computation; no evaluation execution; no general query
-engine (lineage traversal only); no Git plumbing beyond reading OIDs and the
-optional manifest walk; no materialization; no remotes or sync; no native
-source storage; no structured ContextObject system; no `Generation`,
+engine (lineage traversal only — but see §15's read-side signal, which is the
+designated trigger for revisiting this); no Git plumbing beyond reading OIDs
+and the optional manifest walk; no materialization; no remotes or sync; no
+native source storage; no structured ContextObject system; no `Generation`,
 `Tournament`, or `Repair` kinds; no agent-cognition vocabulary of any sort.
 Each of these is either VISION-scope (gated) or belongs to host systems
 permanently.
@@ -427,6 +543,11 @@ Evaluation window: **90 days from shipping v0.3 + the flagship example**.
    flows, selection invariants) — people argue about semantics they use.
 4. The flagship broken-benchmark scenario independently reproduced or cited
    by an external party.
+5. **Read-side usage**: at least one integration that *queries* — lineage
+   traversal, taint/superseded status, or receipt validation inside its own
+   loop — rather than only writing records. This signal specifically gates
+   the VISION query-surface stage: write-side adoption justifies more
+   recording semantics; only read-side adoption justifies a query engine.
 
 **Falsification — the thesis fails at this layer if both hold:**
 1. Direct exposure to ≥ 5 teams running best-of-N or iterative-evolution
@@ -446,16 +567,28 @@ no second extension without new evidence.
 1. **Score representation** — is `{value, scale}` integer fixed-point
    sufficient, or do hosts need multi-metric outcomes per Evaluation (vs. one
    Evaluation per metric, the current proposal)?
-2. **Manifest v1** — submodules; whether `mode` belongs in v1 or only
+2. **Comparative evaluations** — pairwise judgments ("A preferred over B",
+   Elo-style) currently have no direct form; they must be encoded as unary
+   evaluations. Is a two-subject Evaluation variant warranted, or is unary
+   encoding acceptable for the wedge?
+3. **Manifest v1** — submodules; whether `mode` belongs in v1 or only
    `sha256`; large-file cost and whether a size bound is needed.
-3. **Allowed `Cause` targets for `derivation`** — currently Candidate and
+4. **Allowed `Cause` targets for `derivation`** — currently Candidate and
    Evaluation; should Requests and Results be admitted?
-4. **`decision: "none"`** — outcome variant (current proposal) vs. a distinct
-   kind; the variant keeps the kind count down but overloads Selection's
-   verdict rules slightly.
 5. **SHA-256 Git repositories** — `algo` field is included; is dual-hash
    (tree in both algorithms) worth supporting for migration-era repos?
-6. **V3-C4 timing** — "Selection not retracted at commit time" mirrors
+6. **Late binding upgrade** — a record's binding is immutable; the intended
+   pattern (reported for the population, manifest for survivors) needs a
+   defined idiom, e.g. a manifest-bound re-record of the same tree that the
+   Selection `Require`s instead of the reported one. Does that re-record need
+   its own basis/ref rule?
+7. **Superseded-annotation shape** — how the replay report expresses
+   "tainted via S, S `Replace`d by S′" (§6.1); field naming and whether
+   supersession chains longer than one hop are flattened.
+8. **V3-C4 timing** — "Selection not retracted at commit time" mirrors
    capability revocation; confirm the same replay semantics (validity judged
    at commit position, taint judged at replay end) reads correctly for
    selections.
+9. **`considered` size bound** — population workloads may list thousands of
+   ids per Selection; should rules impose a per-record bound consistent with
+   the existing resource bounds?

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,0 +1,461 @@
+# RFC-0001: Software-evolution semantics (spec v0.3)
+
+**Status:** Draft for review. Nothing in this RFC is implemented; nothing in
+it changes spec v0.2 or the published crate. The goal is to make the object
+semantics and invariants precise enough to implement without re-litigating
+them mid-build. Kind names and field spellings are tentative until accepted.
+
+**Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
+*verifiable candidate selection and lineage for autonomous coding agents*,
+on top of Git, reusing the v0.2 trust kernel unchanged.
+
+---
+
+## 1. Summary
+
+Spec v0.3 adds three typed record kinds — `Candidate`, `Evaluation`,
+`Selection` — to the existing twelve. The record remains the only primitive.
+Lineage is derived from existing typed refs (`Cause`, `Use`, `Require`),
+never stored as a parallel structure. Source identity binds to Git (tree
+OID), with an optional Bellbook-computed manifest hash for stronger binding.
+Retraction and transitive taint apply to the new kinds with one carefully
+chosen rule — continuation requires its Selection — that makes a retracted
+evaluation taint the entire descendant line it selected, which is the
+flagship capability of this release.
+
+## 2. Motivation
+
+Autonomous coding systems already run this loop today:
+
+```
+state → generate candidate(s) → evaluate → select (or repair and re-evaluate) → continue
+```
+
+Git can store the file contents at each step but has no native representation
+of the loop itself: which candidates were considered, under what objective,
+on what evidence, why one was selected, and what the surviving lineage
+therefore rests on. That knowledge lives in throwaway branches and harness
+logs, unverifiable after the fact.
+
+v0.2 already provides the hard part — content-addressed records, deterministic
+re-derivable verdicts, an evidence lattice that cannot be inflated,
+signatures with key pinning, retraction with transitive taint, and portable
+offline-verifiable receipts. v0.3 adds the missing vocabulary on top of that
+kernel, and nothing else.
+
+## 3. Design constraints
+
+C1. **One primitive.** No new storage objects. `Candidate`, `Evaluation`,
+    `Selection` are record kinds; a "software state" is a *pattern*: a
+    Candidate plus the records that reference it.
+
+C2. **Workload generality.** The semantics must serve, without privileging
+    any of them:
+    (a) best-of-N — fork N candidates, evaluate, select one;
+    (b) iterative evolution / autoresearch — generations of candidates,
+        repeated evaluate-select-continue, abandoned lines;
+    (c) single-candidate development — one candidate, evaluation fails,
+        repair produces a successor candidate, re-evaluate, accept.
+    Consequences: selections operate over candidate sets of size **≥ 1**;
+    repair is an ordinary candidate-to-candidate derivation; there is **no**
+    `Generation`, `Tournament`, or `Repair` object — all such structure is
+    derivable (§8).
+
+C3. **Kernel unchanged.** The evidence lattice, verdict machinery, signature
+    scheme, retraction/taint engine, and receipt model of v0.2 are reused,
+    not modified. v0.3 defines how the new kinds *participate* in them.
+
+C4. **Git is the substrate, not the model.** v0.3 reads Git object ids and
+    optionally walks a worktree to compute a manifest. It performs no other
+    Git operations: no materialization, no remotes, no history rewriting.
+
+C5. **No agent cognition.** Objectives, criteria, and rationales are bounded
+    strings supplied by the host. Bellbook records them; it never interprets
+    them. Structured context objects are VISION-scope, not v0.3.
+
+## 4. New record kinds
+
+All three kinds are ordinary records: content-addressed via JCS + SHA-256,
+subject to author-role rules, signable, judged by an immediate deterministic
+Verdict, and referenced through typed refs. Numbers in payloads are integers
+only, per the v0.2 wire format.
+
+### 4.1 `Candidate`
+
+Asserts that a specific source state exists as a candidate in some line of
+development.
+
+```jsonc
+{
+  "source": {
+    "git": {
+      "algo": "sha1",              // "sha1" | "sha256" (repo object format)
+      "tree": "<40- or 64-hex>",   // REQUIRED: content identity
+      "commit": "<40- or 64-hex>"  // OPTIONAL: provenance only, never identity
+    },
+    "manifest_hash": "<64-hex>",   // OPTIONAL: Bellbook canonical manifest (§5)
+    "binding": "reported"          // "reported" | "manifest"
+  },
+  "basis": "root",                 // "root" | "continuation" | "derivation"
+  "note": "<bounded string>"       // OPTIONAL: free-form label
+}
+```
+
+**Basis semantics and required refs:**
+
+| basis          | meaning                                        | ref obligations |
+|----------------|------------------------------------------------|-----------------|
+| `root`         | starts a line (imported / initial state)       | MAY `Cause` a Request |
+| `continuation` | continues from a selected state                | MUST `Require` exactly one `Selection` whose outcome is `selected` |
+| `derivation`   | derived from sibling material (repair, mutation)| MUST `Cause` ≥ 1 record, each of kind `Candidate` or `Evaluation` |
+
+The `continuation`/`derivation` distinction is the taint boundary and is the
+most consequential rule in this RFC; rationale in §6.
+
+### 4.2 `Evaluation`
+
+A judgment about exactly one candidate under an explicit criterion.
+
+```jsonc
+{
+  "candidate": "<record id>",      // REQUIRED: the subject
+  "criterion": "<bounded string>", // REQUIRED, non-empty (e.g. "unit-tests")
+  "procedure": "<bounded string>", // OPTIONAL: how it was run (command, harness, version)
+  "outcome": {
+    "status": "passed",            // "passed" | "failed" | "scored"
+    "value": 930,                  // REQUIRED iff status == "scored"; integer
+    "scale": 3                     // REQUIRED iff status == "scored"; value/10^scale
+  }
+}
+```
+
+**Ref obligations:** MUST `Use` the record named in `candidate`; MAY `Use`
+additional evidence records (e.g. Results, Usage, traces). The subject
+dependency is `Use`, not `Cause`, because the evaluation's content
+epistemically rests on the candidate binding: if the candidate is retracted,
+every evaluation of it is correctly tainted.
+
+Evidence class follows the unchanged v0.2 lattice: a harness reporting its
+own results is at most `Reported`; a signed attestation from a key-pinned
+external party is `Verified`; `Deterministic` remains reserved for
+verifier-derived records. Bellbook never computes or re-runs an evaluation
+(C5); it records and grades how the result is known.
+
+### 4.3 `Selection`
+
+A recorded decision over a set of candidates under an objective.
+
+```jsonc
+{
+  "objective": "<bounded string>",   // REQUIRED, non-empty
+  "considered": ["<id>", "..."],     // REQUIRED: ≥ 1, unique, all Candidate ids
+  "outcome": {
+    "decision": "selected",          // "selected" | "none"
+    "candidate": "<record id>"       // REQUIRED iff decision == "selected"
+  },
+  "rationale": "<bounded string>"    // OPTIONAL
+}
+```
+
+**Ref obligations:**
+
+- If `decision == "selected"`: MUST `Require` exactly the selected candidate
+  (which MUST appear in `considered`).
+- MUST `Use` ≥ 1 `Evaluation` (default rules; a rules knob MAY relax this,
+  see §9), and the `candidate` of every `Use`d Evaluation MUST appear in
+  `considered`.
+- `decision == "none"` records that no candidate was acceptable under the
+  objective — a legal, meaningful outcome (pruning, backtracking). It carries
+  no `Require`.
+
+Losing candidates are listed in `considered` (descriptive) but not referenced
+via `Use`/`Require`; the decision's *epistemic* premises are the evaluations
+it declares it `Use`d. A comparative selection naturally `Use`s the losers'
+evaluations too, and taint then flows through those evaluations — the host
+controls comparative-vs-threshold semantics through what it declares, not
+through special kinds.
+
+A Selection with `considered` of size 1 and `decision: selected` is the
+formal version of "accept this state under this objective" — the
+single-candidate workflow's terminal step (C2c). Authority composes
+unchanged: rules may demand that Selections be authored by a given role,
+carry an exact approval, or meet evidence thresholds, using existing v0.2
+machinery.
+
+## 5. Source binding model
+
+Identity binds to the **Git tree**, not the commit: two commits with the same
+tree are the same software state. The commit OID, when present, is
+provenance.
+
+Two binding modes, distinguished explicitly in the payload:
+
+- **`reported`** — the host asserts the Git OIDs. Cheap (no I/O). Bellbook
+  proves the *claim was recorded*, not that the OIDs match any file contents.
+  Inherits Git's hash properties (SHA-1 for classic repos).
+- **`manifest`** — `manifest_hash` is additionally present: a SHA-256 over
+  the Bellbook canonical manifest of the materialized tree (§5.1), computed
+  by the recording process. Costs one worktree walk; upgrades the receipt to
+  a content commitment independent of Git's hash algorithm: anyone holding
+  the tree can recompute the manifest and compare.
+
+**Deliberate refinement of an earlier framing:** binding strength is carried
+by the explicit `binding` field plus a per-kind rules threshold
+(`min_binding`, §9) — *not* by overloading the evidence-class definitions,
+whose v0.2 meanings stay fixed. The evidence class continues to grade how the
+record's content is known (a self-reported binding is `Reported`; a
+key-pinned external attestation of a manifest is `Verified`), and the two
+mechanisms compose. Rules like "any candidate referenced by a Selection must
+have `manifest` binding" become expressible without touching the lattice.
+
+### 5.1 Canonical manifest v1 (proposal)
+
+A JCS-canonicalized JSON object mapping repo-relative POSIX paths (sorted by
+JCS rules) to entries:
+
+```jsonc
+{ "<path>": { "mode": "100644", "sha256": "<64-hex of file bytes>" }, ... }
+```
+
+- Modes: `100644`, `100755`, `120000` (symlink; `sha256` is over the target
+  string). Directories are implicit; empty directories are unrepresented.
+- `.git` is excluded. Bytes are hashed as materialized on disk — no EOL or
+  attribute normalization.
+- `manifest_hash` = SHA-256 over the JCS bytes of that object.
+- Submodules: **out of scope for v1** (open question §16).
+
+## 6. Reference and taint semantics
+
+v0.2's rule is preserved exactly: **taint follows `Use` and `Require`, never
+`Cause`** (this is an existing corpus case). v0.3 adds one principle for
+choosing between them:
+
+> **Artifacts descend by `Cause`; judgments and standing depend by
+> `Use`/`Require`.**
+
+Applied:
+
+- An **Evaluation** `Use`s its candidate → retracting a candidate taints its
+  evaluations. Correct: the judgments were about content whose binding no
+  longer stands.
+- A **Selection** `Use`s the evaluations it relied on and `Require`s its
+  winner → retracting a relied-on evaluation taints the selection. Correct:
+  the decision's premises are gone.
+- A **continuation Candidate** `Require`s its Selection → a tainted selection
+  taints every candidate that continued from it, and (via their evaluations
+  and subsequent selections) the entire descendant line. This is the rule
+  that makes the flagship scenario (§10) true, and it is epistemically
+  honest: a continuation's claim is not "these files exist" but "this is the
+  chosen line's successor" — standing that genuinely rests on the decision.
+- A **derivation Candidate** (repair, mutation) `Cause`s its origins → taint
+  does *not* flow. Correct: if the failing evaluation that motivated a repair
+  is later retracted, the repaired artifact is not thereby wrong; only its
+  motivation evaporated. Retraction poisons conclusions, not code.
+
+This asymmetry — continuation `Require`s, derivation `Cause`s — is the single
+most consequential decision in this RFC and should be challenged hardest in
+review.
+
+## 7. Derived lineage
+
+No lineage is stored. Defined queries over the ref graph:
+
+- **line of descent**: from any Candidate, follow `Require` → Selection →
+  members of `considered` / its own `Require`d winner’s ancestry, and
+  `Cause` edges between candidates, back to a `root`.
+- **siblings / a "generation"**: candidates sharing the same `Require`d
+  Selection (continuations) or the same `Cause` targets (derivations).
+- **frontier**: candidates that are not in any Selection's `considered`, plus
+  selected candidates with no continuation yet.
+
+These are traversals the CLI exposes (§12); a general query engine is a
+non-goal (§14).
+
+## 8. Workload walkthroughs (generality check, C2)
+
+**Best-of-N.** Selection S₀ selects state A. N candidates, each
+`basis: continuation`, `Require` S₀. Each gets one or more Evaluations.
+One Selection considers all N, `Use`s their evaluations, `Require`s the
+winner. Continue.
+
+**Iterative evolution / autoresearch.** As above, repeated: generation k+1's
+candidates `Require` the generation-k Selection. Mutations *within* a
+generation are `basis: derivation` candidates `Cause`-ing a sibling.
+Abandoned lines simply have no continuation; recorded pruning is a Selection
+with `decision: none` over the line's frontier. No new kinds needed.
+
+**Single-candidate repair.** C₁ (`root` or `continuation`) → Evaluation E₁
+fails → C₂ `basis: derivation`, `Cause` [C₁, E₁] → Evaluation E₂ passes →
+Selection with `considered: [C₂]` (or `[C₁, C₂]` if the host wants the
+comparison on record), `Use` [E₂ (, E₁)], `Require` C₂. The accept step is
+the same object best-of-N uses; nothing is privileged.
+
+## 9. Verifier rules (additions to the per-record battery)
+
+All existing v0.2 checks (author roles, identity-to-role binding, signatures,
+canonical payloads with typed decode, evidence thresholds, retraction
+ownership) apply to the new kinds unchanged. New checks, each with a distinct
+rejection reason code and a triggering corpus case:
+
+**Candidate**
+- V3-C1: `source.git.tree` present, hex, length matching `algo`.
+- V3-C2: `binding == "manifest"` ⇒ `manifest_hash` present (64-hex);
+  `binding == "reported"` ⇒ `manifest_hash` absent.
+- V3-C3: basis/ref obligations of §4.1 hold (continuation ⇒ exactly one
+  `Require`d Selection with outcome `selected`; derivation ⇒ ≥ 1 `Cause` of
+  allowed kinds; root ⇒ no `Require`).
+- V3-C4: a `Require`d Selection must not be retracted at commit time
+  (retracted authority stops authorizing — same principle as v0.2 capability
+  revocation).
+
+**Evaluation**
+- V3-E1: `candidate` names an existing Candidate record and is matched by a
+  `Use` ref.
+- V3-E2: `criterion` non-empty; `outcome` well-formed per status
+  (`scored` ⇔ `value` and `scale` present).
+
+**Selection**
+- V3-S1: `considered` non-empty, unique, all existing Candidate ids.
+- V3-S2: `decision == "selected"` ⇒ `outcome.candidate` ∈ `considered` and is
+  `Require`d; `decision == "none"` ⇒ no `Require`.
+- V3-S3: every `Use`d Evaluation's `candidate` ∈ `considered`.
+- V3-S4 (default rules; knob `selection_requires_evaluation = true`): ≥ 1
+  `Use`d Evaluation when `decision == "selected"`.
+
+**New rules knobs**
+- `min_binding` per referencing context (e.g. Selections may only `Require`
+  candidates with `manifest` binding).
+- `selection_requires_evaluation` (default true).
+- Per-kind evidence thresholds and author-role bindings apply to the three
+  kinds exactly as to existing kinds.
+
+## 10. Retraction and the flagship scenario
+
+The demonstration this release is built around:
+
+> A benchmark harness is discovered to be broken. Its Evaluations are
+> retracted. Every Selection that `Use`d them is tainted; every continuation
+> Candidate that `Require`d those Selections is tainted; their Evaluations
+> and every subsequent Selection and continuation are tainted transitively.
+> One retraction, and the receipt now shows exactly which surviving lineage
+> still rests on untainted evidence — and which "best" states were chosen on
+> evidence that no longer stands. Repairs and mutations motivated by the
+> broken evaluations remain untainted: their motivation vanished, their
+> content did not.
+
+This requires zero new taint machinery — only the ref discipline of §6 — and
+is the capability that distinguishes Bellbook from experiment trackers and
+Git workflows alike. It ships as a worked example plus corpus receipt cases
+covering: the full cascade, the derivation non-cascade, and a forged
+"un-tainted" receipt that replay rejects.
+
+## 11. Receipt boundary
+
+A v0.3 receipt proves the recorded **process**: which candidates were
+recorded, what was claimed about them, which evidence and evaluations existed,
+what was selected under what objective, what is retracted or tainted, and
+that none of it was altered after the fact. It does **not** contain source
+contents; Git OIDs are pointers whose resolution requires the repository.
+With `manifest` binding, a party holding the tree can independently recompute
+`manifest_hash` and bind the receipt to actual contents; with `reported`
+binding they hold a verifiable record of an unverified claim — and the
+receipt says which, explicitly.
+
+This is v0.2's "consistency, not completeness" boundary extended one level,
+and it must be stated with the same bluntness in SPEC v0.3 §13.
+
+## 12. CLI surface (the wedge's adoption surface)
+
+Thin wrappers over the crate; JSON in/out; every command prints the committed
+record id; harnesses in any language integrate by shelling out.
+
+```
+bellbook candidate add  --git-tree <oid> [--git-commit <oid>] [--algo sha1|sha256]
+                        [--manifest <path-to-worktree>]        # computes manifest binding
+                        [--continues <selection-id> | --derives-from <id> ...]
+                        [--note <s>]
+bellbook eval add       --candidate <id> --criterion <s>
+                        (--passed | --failed | --score <value> --scale <n>)
+                        [--procedure <s>] [--uses <id> ...]
+bellbook select         --objective <s> --consider <id> ...
+                        (--choose <id> | --none)
+                        --uses-eval <id> ... [--rationale <s>]
+bellbook lineage        <id> [--json]      # line of descent, siblings, taint status
+bellbook validate       <receipt>          # unchanged from v0.2
+```
+
+Signing, roles, and receipt export use existing mechanisms. Python bindings
+remain out of scope (README open-work list); the independent Python validator
+is updated in lockstep via the corpus, as now.
+
+## 13. Compatibility and conformance plan
+
+- v0.3 is a new compatibility epoch: twelve kinds become fifteen; signing
+  domain becomes `bellbook.record-signature.v0.3`; v0.2 logs and receipts
+  remain valid under v0.2 rules (no migration of committed history).
+- Test vectors regenerated and extended per new kind, including signed
+  vectors.
+- Conformance corpus extended with positive and adversarial cases per new
+  invariant in §9 (each rejection reason code gets a triggering case), plus
+  the §10 receipt cases.
+- The Python validator implements the three kinds and the taint flows
+  independently, and the corpus gate in CI holds both implementations to
+  byte-for-decision agreement — same discipline that caught real bugs in the
+  v0.2 cycle.
+
+## 14. Non-goals (binding for v0.3)
+
+No ranking or scoring computation; no evaluation execution; no general query
+engine (lineage traversal only); no Git plumbing beyond reading OIDs and the
+optional manifest walk; no materialization; no remotes or sync; no native
+source storage; no structured ContextObject system; no `Generation`,
+`Tournament`, or `Repair` kinds; no agent-cognition vocabulary of any sort.
+Each of these is either VISION-scope (gated) or belongs to host systems
+permanently.
+
+## 15. Validation and falsification criteria (pre-registered)
+
+Recorded before implementation so the outcome cannot be rationalized later.
+Evaluation window: **90 days from shipping v0.3 + the flagship example**.
+
+**Validation — proceed to the next VISION gate only if ≥ 2 hold:**
+1. At least one harness integration authored by someone with no connection to
+   this project, in actual use.
+2. Receipts generated by ≥ 3 external users or organizations (observed via
+   issues, discussions, or shared receipts — not download counts).
+3. Inbound issues or PRs that engage the *semantics* (binding modes, taint
+   flows, selection invariants) — people argue about semantics they use.
+4. The flagship broken-benchmark scenario independently reproduced or cited
+   by an external party.
+
+**Falsification — the thesis fails at this layer if both hold:**
+1. Direct exposure to ≥ 5 teams running best-of-N or iterative-evolution
+   workflows yields zero adoption, with the stated reason being that ad-hoc
+   eval JSON plus branch conventions are sufficient.
+2. Any integrations that do exist use Bellbook as write-only logging — no
+   receipt validation, no taint queries, no selection semantics — for the
+   full window.
+
+**Decision rule:** if falsified, VISION stages 1–4 stay parked indefinitely;
+native storage would not have changed the answer. If neither validated nor
+falsified, extend once by 90 days with a written note on what changed;
+no second extension without new evidence.
+
+## 16. Open questions for review
+
+1. **Score representation** — is `{value, scale}` integer fixed-point
+   sufficient, or do hosts need multi-metric outcomes per Evaluation (vs. one
+   Evaluation per metric, the current proposal)?
+2. **Manifest v1** — submodules; whether `mode` belongs in v1 or only
+   `sha256`; large-file cost and whether a size bound is needed.
+3. **Allowed `Cause` targets for `derivation`** — currently Candidate and
+   Evaluation; should Requests and Results be admitted?
+4. **`decision: "none"`** — outcome variant (current proposal) vs. a distinct
+   kind; the variant keeps the kind count down but overloads Selection's
+   verdict rules slightly.
+5. **SHA-256 Git repositories** — `algo` field is included; is dual-hash
+   (tree in both algorithms) worth supporting for migration-era repos?
+6. **V3-C4 timing** — "Selection not retracted at commit time" mirrors
+   capability revocation; confirm the same replay semantics (validity judged
+   at commit position, taint judged at replay end) reads correctly for
+   selections.


### PR DESCRIPTION
Design artifacts for #19. Docs only: no spec, code, or vector changes; v0.2 is untouched and SPEC.md/README's present-tense positioning stays authoritative.

## `docs/VISION.md`

The long-term direction: Bellbook as the native state, lineage, and trust substrate for autonomous software evolution, explicitly marked as direction rather than current scope (SPEC.md is the tiebreaker for the present). Structured as gated stages: v0.2 evidence kernel (shipped), v0.3 wedge (under design, links the RFC), then query surface, native storage, distribution, and runtime, each gated on adoption of the stage before it.

## `docs/rfcs/0001-evolution-semantics.md` (revision 5)

The complete design for the wedge: verifiable candidate selection and lineage for autonomous coding agents. All formerly open questions are resolved in §16; the document is ready for acceptance review.

- Three new record kinds (`Candidate`, `Evaluation`, `Selection`) over the unchanged v0.2 kernel, with author-role rows and base evidence classes registered (§4.0). The record stays the only primitive; lineage is derived, never stored.
- Knowledge and standing are split: evaluations `Use` candidates and selections `Use` evaluations / `Require` winners (kernel evidence and taint unchanged), while lineage standing is a replay-derived dimension over `Cause` + `parent` edges, living in the replay report only, with normative content and encoding (§6.2). Every `Cause` target of a Candidate must be accepted; a retracted Candidate has compromised, unrestorable standing.
- Set-valued Selections with an explicit `parent` on continuations; best-of-N, population evolution, and single-candidate repair share one vocabulary (§8).
- Reaffirmation (§6.3): one record restores a descendant subtree's standing at any depth for decision-level compromise; forward-only; the default trust posture is stated plainly with `reaffirmation_actors` and approval binding as the guards; retracted states are unrestorable by design.
- Git-tree binding with `reported`/`manifest` modes, manifest authority on conflict, gitlink-aware canonical manifest, and a safe binding-upgrade idiom (§5).
- Selection approval binding with the Replace target inside the subject hash (§4.3, V3-S6); `max_considered` with the receipt ref-limit interplay stated (§9); payload-aware reachability pre-committed for future tooling (§9).
- Pre-registered validation and falsification criteria with a read-side signal (§15).
- v0.2 corpus backfill for the `Require` taint leg tracked in #21.

## Review focus

1. §6.2: the standing derivation, including the retracted-Candidate base case and the acceptance-based anchor rule.
2. §6.3: the restoration/retraction ownership asymmetry and its guards.
3. §4.0 and §4.3: registrations and the approval binding.
4. §15: the numbers we are held to.