### PR TITLE
spec: draft the v0.3 evolution semantics delta

### DIFF
--- a/spec/v0.3-delta.md
+++ b/spec/v0.3-delta.md
@@ -1,0 +1,471 @@
+# SPEC v0.3 delta: evolution semantics
+
+**Status: reviewed changeset, not yet applied.** This document is the
+normative text for spec v0.3, written as amendments to `SPEC.md` (spec
+v0.2) and derived from the accepted
+[RFC-0001](../docs/rfcs/0001-evolution-semantics.md). `SPEC.md` on `main`
+always describes what the implementation does; each implementation pull
+request applies its slice of this delta to `SPEC.md` together with the
+code and conformance corpus, so the repository stays coherent at every
+commit. When every slice has landed, `SPEC.md` reads "Spec version: 0.3"
+and this file is deleted in the release pull request.
+
+**Application map** (which issue applies which sections):
+
+| Delta section | Applied by |
+|---|---|
+| D1 kinds, author rows, schemas, base evidence | #23 core |
+| D2 source binding and canonical manifest | #27 binding (payload checks in #23/#24) |
+| D3 per-kind verification rules, reason codes, knobs | #24 verifier |
+| D4 Replace extension and reaffirmation | #24 verifier |
+| D5 Selection approval binding | #25 verifier |
+| D6 standing | #26 replay |
+| D7 report and receipt text | #26 replay |
+| D8 limitations, reachability, epoch text | #33 docs, #34 release |
+
+Wording below is SPEC-ready: sections say where in `SPEC.md` they land.
+
+---
+
+## D1. Kinds, author roles, schemas, base evidence
+
+**SPEC §2, kind list.** Twelve kinds become fifteen: add `Candidate`,
+`Evaluation`, `Selection`.
+
+**SPEC §2, kind-to-author-type table**, three new rows:
+
+| Kind | Allowed author types |
+|------|----------------------|
+| `Candidate` | `User`, `Provider`, `Executor`, `System` |
+| `Evaluation` | `User`, `Provider`, `Executor`, `System` |
+| `Selection` | `User`, `Provider`, `System` |
+
+Rationale to append to the existing rationale paragraph: candidates and
+evaluations are things any actor may honestly report producing or
+observing; selections are decisions, so `Executor`, the role that
+performs work, may not author them. Note the retraction consequence
+(existing §2 rules unchanged): `Executor` may never author a
+`Retraction`, so Executor-authored evaluations are retractable only via
+`admin_retraction_actors`. Hosts that need the broken-benchmark recovery
+flow author evaluations as `Provider` or `System`, or configure admin
+retraction; this is a deployment decision, not an accident.
+
+**Payload schemas** (frozen names; canonical-payload rule of §3 applies;
+integers stay in the I-JSON safe range):
+
+`bellbook.candidate.v1`:
+
+```
+CandidateData {
+  source: SourceBinding        // D2
+  basis:  Root | Continuation | Derivation
+  parent: Option<RecordId>     // present iff basis == Continuation
+  note:   Option<String>       // bounded free-form label
+}
+```
+
+`bellbook.evaluation.v1`:
+
+```
+EvaluationData {
+  candidate: RecordId          // the subject
+  criterion: String            // non-empty, e.g. "unit-tests"
+  procedure: Option<String>    // how it was run
+  outcome:   Passed | Failed | Scored { value: i64, scale: u8 }
+                               // scale in 0..=12; value/10^scale
+}
+```
+
+Exactly one criterion per Evaluation. Retraction is record-granular, so
+per-metric evaluations are the only shape that lets one broken metric be
+retracted without erasing the others. Comparative (pairwise) judgments
+have no direct form in v0.3 and are encoded as unary evaluations by host
+convention.
+
+`bellbook.selection.v1`:
+
+```
+SelectionData {
+  objective:  String           // non-empty
+  considered: [RecordId]       // >= 1, unique, all Candidate ids
+  outcome:    Selected { candidates: [RecordId] }  // >= 1, unique, subset of considered
+            | None
+  rationale:  Option<String>
+}
+```
+
+Selections are set-valued: one survivor for best-of-N or a repair
+accept, several for population evolution where the top-k jointly become
+parents of the next generation.
+
+**SPEC §7, base evidence by schema**, three additions:
+
+- `bellbook.candidate.v1` → `Reported`
+- `bellbook.evaluation.v1` → `Reported`
+- `bellbook.selection.v1` → `Inferred`
+
+Consequences, appended to §7: under these bases and the ref discipline
+of D3, evaluations derive at most `Reported` and selections at most
+`Inferred`; per-kind thresholds at those levels are meaningful because
+any retracted or tainted dependency drags derivation to the `Assumed`
+floor. Because continuation edges are `Cause` (D3), evidence does not
+compound across generations. A `Verified` pathway for these kinds (a
+gated schema pair in the style of `bellbook.result.external_receipt.v1`,
+required as a pair because weakest-link derivation caps an evaluation at
+its candidate's class, and sufficient only when every other `Use` target
+is also at least `Verified`) is not part of v0.3; the schema set is
+frozen per epoch, so it is a v0.4 candidate, not a mid-epoch addition.
+
+## D2. Source binding and canonical manifest
+
+New subsection under SPEC §2 (after the payload-structs paragraph),
+titled **Source bindings**:
+
+```
+SourceBinding {
+  git: { algo: Sha1 | Sha256, tree: Hash, commit: Option<Hash> }
+  manifest_hash: Option<Hash256>
+  binding: Reported | Manifest
+}
+```
+
+- Identity binds to the Git **tree** (two commits with the same tree are
+  the same software state); `commit` is provenance, never identity.
+  `tree`/`commit` are hex of the length `algo` dictates.
+- `binding == Manifest` iff `manifest_hash` is present.
+- `Reported`: the host asserts the Git OIDs; Bellbook proves the claim
+  was recorded, not that the OIDs match any contents. Inherits Git's
+  hash properties.
+- `Manifest`: `manifest_hash` is a SHA-256 over the canonical manifest
+  below, computed by the recording process; a party holding the tree can
+  independently recompute and compare.
+- **Authority on disagreement**: when both are present the manifest is
+  the authoritative identity commitment and the tree OID is an
+  interoperability pointer; a disagreement makes the record a false
+  claim, detectable only by materializing the tree, the same boundary §7
+  draws for `Verified` ("origin verified, never the real-world effect").
+- Dual-hash bindings are not supported: a record cannot prove two tree
+  OIDs describe the same contents. For SHA-1 to SHA-256 migration eras
+  the manifest is the algorithm-independent commitment, qualified below
+  for submodules.
+
+**Canonical manifest v1.** A JCS-canonical JSON object mapping
+repo-relative POSIX paths to entries
+`{ "mode": <string>, "sha256": <64-hex> }`:
+
+- Modes `100644` and `100755` hash the file bytes as materialized, with
+  no EOL or attribute normalization. Mode `120000` hashes the symlink
+  target string. Mode `160000` (gitlink) hashes the submodule commit OID
+  as a lowercase-hex ASCII string with no trailing newline, sourced from
+  the **Git tree object and never worktree state**, so initialized and
+  uninitialized submodule checkouts of the same tree yield the same
+  manifest; a gitlink commits to the pointer only, never to submodule
+  contents (this is the submodule qualification of the
+  algorithm-independence claim).
+- Directories are implicit; empty directories are unrepresented; `.git`
+  is excluded.
+- `manifest_hash = SHA-256(JCS bytes of the object)`. The manifest is
+  never stored or embedded; only the hash rides in the payload.
+
+**Binding upgrade idiom** (documented next to the binding definition): a
+record's binding is immutable, so a survivor's binding is upgraded by a
+new Candidate with the same `source.git.tree`, `binding: Manifest`, and
+`basis: Derivation` with a single `Cause` ref to the reported-binding
+Candidate. Standing (D6) makes this safe: the upgrade inherits the
+original's standing, and a retracted Candidate has compromised,
+unrestorable standing, so the idiom cannot launder a retracted state.
+The verifier does not compare trees between the two records (that is the
+§13 recording-discipline boundary); the CLI MUST refuse to build an
+upgrade whose tree differs from its target's.
+
+## D3. Per-kind verification rules, reason codes, knobs
+
+**SPEC §2, ref types.** The `Replace` sentence changes: replaceable
+kinds become `Summary`, `Capability`, `Approval`, `Plan`, and
+`Selection` (compatibility for Selection in D4). No other ref-type text
+changes; `Cause` remains free of taint and evidence effects, which is
+what the lineage rules below rely on.
+
+**SPEC §4.1, new per-kind rules** (appended to the per-kind list):
+
+Shared payload-id resolution: `CandidateData.parent`, every member of
+`SelectionData.considered`, and `EvaluationData.candidate` are payload
+ids, not refs. Each MUST resolve, in the same space, to a previously
+**accepted** `Candidate` record. Retracted or tainted targets resolve
+(those conditions surface through refs, evidence, and standing, never
+through payload lookup). Unresolvable, cross-space, or wrong-kind
+payload ids reject with `PayloadRefUnresolved`.
+
+- a `Candidate`'s `source` must be well-formed (`tree` hex length
+  matching `algo`; `manifest_hash` present iff `binding == Manifest`),
+  else `SourceBindingInvalid`. Its basis obligations must hold,
+  **including acceptance of every `Cause` target at commit position**
+  (acceptance is permanent, so this holds forever after; without it a
+  continuation could anchor to a rejected Selection and a `Clean`
+  receipt could carry a compromised lineage):
+  `Root` ⇒ at most one `Cause`, targeting an accepted `Request`, no
+  other `Cause` targets, no `parent`;
+  `Continuation` ⇒ exactly one `Cause`, targeting an accepted
+  `Selection` whose outcome is `Selected`, and `parent` names a member
+  of that Selection's selected set;
+  `Derivation` ⇒ at least one `Cause`, each an accepted `Candidate` or
+  `Evaluation`, none a `Selection`, no `parent`.
+  Violations reject with `LineageInvalid`. Continuation deliberately
+  uses `Cause`, not `Require`: a candidate's evidence must reflect its
+  own content, and a tainted history must never block recording ongoing
+  work; the lineage consequence of the anchor's health is standing (D6);
+- an `Evaluation` must `Use` the record named in `candidate` (the
+  epistemic subject edge; a retracted candidate then correctly taints
+  its evaluations), else `EvaluationInvalid`; `criterion` non-empty and
+  `outcome` well-formed per the D1 bounds are enforced by the canonical
+  payload decode (`InvalidPayload`);
+- a `Selection` must have `considered` non-empty, unique, of length at
+  most `max_considered`; when `Selected`, `outcome.candidates` non-empty,
+  unique, a subset of `considered`, each referenced by a `Require` ref;
+  every `Require` target must be either a selected candidate or an
+  authority record demanded by the rules (D5); a `None` decision carries
+  no candidate `Require`s; every `Use`d Evaluation's `candidate` must
+  appear in `considered`; when `Selected` and
+  `selection_requires_evaluation` is set (default true), at least one
+  Evaluation must be `Use`d. Violations reject with `SelectionInvalid`.
+  The winner `Require` refs are epistemically honest (the decision rests
+  on the winners' integrity) and give commit-time teeth under the
+  unchanged generic rule: a Selection whose winner is retracted or
+  tainted at commit position rejects with `RefUnresolved`;
+- a `Selection` carrying a `Replace` ref is a **reaffirmation** (D4):
+  the target must be a `Selection` with the same `objective`, and when
+  `reaffirmation_actors` is set the author must be listed; violations
+  reject with `ReaffirmationInvalid`.
+
+**Reason codes.** §4.1's code list gains `SourceBindingInvalid`,
+`LineageInvalid`, `PayloadRefUnresolved`, `EvaluationInvalid`,
+`SelectionInvalid`, `ReaffirmationInvalid` (D5 reuses
+`ApprovalMissing`/`ApprovalExpired`). As in v0.2, one code may cover
+several related checks; the conformance corpus carries a triggering case
+per check, so implementations are held to each check individually.
+
+**Rules knobs** (documented with the existing `VerifierRules` fields):
+
+- `min_binding`: minimum `binding` mode for candidates referenced by a
+  Selection's `Require` refs.
+- `selection_requires_evaluation` (default true).
+- `reaffirmation_actors`: identity allowlist for Replace-carrying
+  Selections; unset means the Selection author-role row alone governs.
+- `reject_compromised_continuation` (default false; D6).
+- `max_considered` (default 4096). Interplay stated normatively:
+  `considered` members are payload ids and carry no refs, but a
+  comparative Selection that `Use`s one evaluation per considered
+  candidate plus its `Require`d winners can exceed the receipt ref
+  limit (`ValidationLimits.max_refs_per_record`, default also 4096)
+  even though the verifier accepted the record; the effective bound on
+  `Use`d evaluations is the receipt ref limit. A corpus case pins a
+  Selection near both bounds.
+
+## D4. Replace extension and reaffirmation
+
+**SPEC §2 / §7.1.** The Replace whitelist gains `Selection` (carrier and
+target). Compatibility for Selections: same space, same `objective`
+string (this makes objective strings de facto immutable identifiers;
+hosts treat them as keys, not prose). All existing Replace semantics are
+unchanged: at most one Replace ref, same-kind accepted target, target
+enters `replaced_records` and leaves context construction, no taint or
+evidence effects, multiple records may Replace one target.
+
+Reaffirmation semantics (new §7.1 text, after the retraction rules): a
+Selection S2 with `Replace` to S is a new decision over the same
+objective on evidence that currently stands. Because standing carries
+the lineage consequence (D6), S2 is committable at any depth: its
+`Require`d winners and `Use`d evaluations are ordinary untainted records
+(a candidate is never kernel-tainted by its line's compromise). One
+committed reaffirmation whose selected set contains the relevant parents
+restores standing for the entire descendant subtree at the next replay.
+
+Properties, all normative:
+
+- Forward-only. The retraction, the tainted Selection, and the
+  reaffirmation remain permanently in the log and its receipts; standing
+  is derived over them, never an edit of them. Kernel taint is never
+  cleared, retroactively or otherwise.
+- A reaffirmation with a `None` decision restores nothing (the standing
+  walk requires the parent in a *selected* set); it records deliberate
+  abandonment. Competing reaffirmations each restore exactly the parents
+  they name.
+- Replacing a sound Selection is legal (a state-dependent Replace rule
+  would be new machinery): standing is unaffected, but the target still
+  leaves context construction. Hosts should not Replace healthy
+  Selections casually.
+- Retracted states are unrestorable at every level: a retracted
+  candidate is compromised by the D6 base case, its descendants stay
+  compromised through the parent and derivation legs, and any Selection
+  re-selecting it rejects (`Require` of retracted). The only path
+  forward is a new `Root`; the receipt shows the break.
+- Default trust posture, stated plainly: under default rules,
+  restoration is producible in two records by any actor in the Selection
+  author-role row (one self-authored Evaluation of the old parent, one
+  reaffirming Selection). Restoration is ownership-unbound while
+  retraction is ownership-bound. Everything stays visible and a consumer
+  can judge the restoring evidence; deployments that need restoration as
+  guarded as compromise MUST set `reaffirmation_actors` and/or require
+  Selection approvals (D5). The default favors recordability; the knobs
+  supply the guarantees.
+
+## D5. Selection approval binding
+
+**SPEC §4.1** (next to the Action exact-approval rules). When rules
+require approvals for `Selection`, the approval's subject hash is
+
+```
+SHA-256(canonical((
+  "bellbook.selection-approval.v0.3",
+  selection_author_id,
+  replace_target_id_or_null,
+  SelectionData
+)))
+```
+
+the approving record is referenced by `Require`, the matched approval's
+`actor_id` must equal the selecting author, and consumption is
+single-use on Selection accept, through a consumption step parallel to
+the Action path. The Replace target (or explicit null) is inside the
+hash so an approval granted for a fresh decision cannot be spent on a
+reaffirmation with identical `SelectionData`: approving a decision and
+approving the restoration of a compromised line are different acts and
+require different approvals. Consumption is an event and is never
+refunded, including by a later `Replace` or retraction of the consuming
+Selection (matching the Action path, which never un-consumes). Missing
+or expired approvals reject with `ApprovalMissing`/`ApprovalExpired`.
+
+## D6. Standing
+
+New section **§7.2 Standing** in `SPEC.md`:
+
+Standing answers: does this candidate's membership in a chosen line
+still rest on states and decisions that stand? It is derived at replay
+end, from accepted records only, as a pure function of the log, exactly
+as deterministic and forgery-resistant as the taint sets. It is not
+kernel taint: it does not affect evidence derivation, does not gate
+commits by default, and is reported alongside taint, never merged with
+it.
+
+A Selection is **unsound** at replay end iff it is retracted or tainted.
+(A rejected Selection can never be an anchor: the `LineageInvalid` rule
+requires every `Cause` target of a Candidate to be accepted at commit,
+and acceptance is permanent, so an anchor becomes unsound only later,
+via retraction or taint.)
+
+**Anchor soundness** for a continuation candidate C with `Cause` to S
+and `parent` P: S itself is sound, or some accepted, sound Selection S2
+exists with a `Replace` chain to S (one or more hops, every intermediate
+accepted) whose selected set contains P. Any sound replacement suffices
+(an existential over the fixed replay-end set, so the result is
+deterministic and order-independent). Intermediates need only be
+accepted, not sound: requiring soundness would recreate a frozen-chain
+pathology while granting nothing, since a host can always Replace S
+directly.
+
+**Standing recursion** (well-founded: all edges point to earlier
+records):
+
+- A **retracted Candidate is compromised, unconditionally and
+  unrestorably**; no anchor rule, parent rule, or reaffirmation applies
+  to it. Retracting a candidate asserts the state itself was wrong, and
+  a state that was wrong has no legitimate membership in any line.
+  Without this base case a same-tree derivation of a retracted candidate
+  would re-enter the line with sound standing, defeating retraction.
+- A `Root` candidate (not retracted) is sound.
+- A `Continuation` candidate (not retracted) is sound iff its anchor is
+  sound and standing(parent) is sound.
+- A `Derivation` candidate (not retracted) is sound iff every `Cause`d
+  Candidate has sound standing; Evaluation targets carry no standing,
+  so a derivation with only Evaluation targets is sound.
+
+Whenever any candidate is compromised, some record is necessarily
+retracted or tainted (the candidate itself, or a retracted or tainted
+Selection on its lineage path), so the report status is already
+`Tainted` under the unchanged v0.2 status mapping; standing adds which
+lineage is affected and what restored it, never a status v0.2 would not
+report.
+
+What standing deliberately does not do: it does not reject new
+continuations of an unsound Selection. They commit and are born
+compromised, because a ledger that cannot record ongoing work stops
+being a ledger, and rejection would create the perverse incentive to
+mislabel continuations as derivations. Rules MAY opt into commit-time
+strictness with `reject_compromised_continuation` (default false), which
+rejects a continuation whose anchor is unsound at commit position with
+`LineageInvalid`.
+
+**Reachability pre-commitment.** `parent`, `considered`, and
+`EvaluationData.candidate` are edges that ref-walking tools cannot see.
+Reachability over v0.3 kinds is therefore payload-aware: any future
+garbage collection, synchronization, or checkpoint tooling MUST treat
+these payload ids as reachability edges, or it would silently sever the
+standing spine. Recorded now, before any such tooling exists, so no
+later stage inherits ref-only reachability as a hidden default.
+
+## D7. Report and receipt text
+
+**SPEC §12.** Receipts are unchanged in shape:
+`{spec_version, rules, records}`, nothing derived embedded. The
+**Report** gains a `standing` section, re-derived on every validation
+exactly like the retracted and tainted sets; a validator that derives a
+different standing section from the same records is nonconforming,
+which the corpus detects the same way it detects taint disagreement.
+
+Normative content and encoding:
+
+- `compromised`: the set of standing-compromised Candidate ids;
+- `unsound`: the set of unsound Selection ids;
+- `restorations`: for each unsound Selection with at least one sound
+  replacement chain, the set of sound replacing Selection ids.
+
+Sets are id-byte-ordered, matching the existing report sets;
+`restorations` encodes as pairs sorted by key id with each value set
+id-byte-ordered, so conforming implementations produce byte-identical
+sections. Restored lines are visible as: candidates absent from
+`compromised`, their anchor present in `unsound`, the restoring
+Selection listed in `restorations`.
+
+**§12.3 conformance corpus** grows: a triggering case per new check in
+D3/D4/D5; standing receipt cases (full compromise cascade; derivation
+non-cascade with evaluation-only motivation and derivation cascade
+through a compromised candidate; deep reaffirmation recovery;
+`None`-decision reaffirmation restoring nothing; competing
+reaffirmations; a replacement chain through an accepted-but-unsound
+intermediate; retracted-parent and retracted-candidate unrestorable
+cases including the binding-upgrade idiom before and after retraction of
+its original; a Selection near both the `max_considered` and receipt
+ref bounds); and expected-standing agreement cases pinning the
+`standing` section byte for byte.
+
+## D8. Limitations, epoch, versioning
+
+**SPEC §13**, two additions:
+
+- The lineage, standing, and taint guarantees are conditional on the
+  producer's recording discipline. `basis`, `parent`, and the choice of
+  refs are producer claims; a host that records continuations as
+  derivations escapes the standing cascade, and no verifier can detect
+  that, because intent is not checkable. Bellbook proves the recorded
+  structure is internally consistent under its rules; it does not prove
+  the structure faithfully mirrors the development process. A receipt
+  consumer trusts the embedded `rules_hash` and the producer's recording
+  conventions.
+- Source bindings prove what was claimed, not what the tree contains:
+  `Reported` bindings commit to claims about Git hashes; `Manifest`
+  bindings become content commitments only for a party who materializes
+  the tree and recomputes the manifest. High-N workloads will
+  predictably use `Reported` for the population; the intended pattern is
+  cheap `Reported` bindings for the population and `Manifest` for the
+  survivors via the upgrade idiom (D2).
+
+**SPEC header and §14.** Spec version becomes 0.3; the signing domain
+becomes `bellbook.record-signature.v0.3` (§3.2), and the selection
+approval domain is `bellbook.selection-approval.v0.3` (D5). Backward
+validity holds: a v0.2 ledger or receipt remains verifiable under v0.2
+rules forever; the v0.3 validator rejects a v0.2 receipt as `Invalid`
+with a clear unsupported-version report (a corpus case pins this), and
+CI validates the committed v0.2 receipts with the pinned, published
+v0.2 validator so "unchanged under v0.2 rules" is continuously verified
+rather than assumed. Spec 0.3 is the second published compatibility
+epoch.


### PR DESCRIPTION
Closes #22. Second work item of the v0.3.0 milestone (#19).

## What

Adds `spec/v0.3-delta.md`: the normative changeset for spec v0.3, written as amendments to SPEC.md and derived from the accepted RFC-0001.

**Why a delta document instead of editing SPEC.md:** SPEC.md on `main` must always describe what the implementation actually does. Flipping it to v0.3 before the code exists would make the repository claim more than it enforces. Each implementation PR (#23 through #27) applies its slice of the delta to SPEC.md together with the code and corpus, so `main` stays coherent at every commit; the release PR (#34) removes the delta once SPEC.md is fully at 0.3. An application map at the top of the document assigns each section to its milestone issue.

## Contents

- **D1** kinds, author-role rows, payload schemas (`bellbook.candidate.v1`, `bellbook.evaluation.v1`, `bellbook.selection.v1`), base evidence classes and their consequences
- **D2** source bindings and canonical manifest v1 (gitlink entries sourced from the tree object, manifest authority on conflict, the binding-upgrade idiom with its CLI guard)
- **D3** the per-kind rule battery, six new reason codes, five rules knobs including the `max_considered` and receipt ref-limit interplay
- **D4** Replace whitelist extension, reaffirmation semantics, and the stated default trust posture
- **D5** Selection approval binding with the Replace target inside the subject hash and never-refunded consumption
- **D6** standing: unsoundness, anchor soundness with replacement chains, the recursion including the retracted-candidate base case, and the payload-aware reachability statement
- **D7** report `standing` section content and encoding; receipts unchanged in shape; the conformance corpus growth list
- **D8** limitations, epoch, and versioning amendments (spec 0.3, both v0.3 domain strings, backward validity, the pinned-v0.2-validator CI check)

## Acceptance check

Every normative rule in RFC-0001 has exactly one home in the delta, and no delta claim exceeds what the planned verifier will enforce. SPEC.md, code, vectors, and corpus are untouched; CI runs unchanged.