### PR TITLE
cli: candidate, eval, select, and lineage subcommands (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Evolution CLI (#31): the `bellbook` binary gains `candidate add`,
+  `eval add`, `select`, and `lineage` subcommands over a persistent log
+  (behind the `persist` feature; `validate` stays feature-independent).
+  Every mutating command commits one record and prints its id; `--json`
+  emits `{ id, result, reason? }` that round-trips. `candidate --upgrades`
+  refuses a binding upgrade whose `--git-tree` differs from its target's,
+  so a rebinding never silently changes the source identity. `lineage`
+  reports a record's ancestors, children, siblings, considering and
+  selecting Selections, taint, and standing. The README documents the
+  single-writer recording pattern (the log takes an exclusive lock) before
+  the commands.
 - Conformance corpus completeness for the evolution rules (#29): with the
   per-reason-code triggering cases (#24/#25), the standing receipt cases and
   byte-for-byte `standing`-section agreement (#26), this adds the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ required-features = ["persist"]
 [[test]]
 name = "conformance"
 required-features = ["persist"]
+
+[[test]]
+name = "cli"
+required-features = ["persist"]

--- a/README.md
+++ b/README.md
@@ -178,6 +178,35 @@ reported `rules_hash` against a rule set you trust) - under default rules
 it means "internally consistent", not "meets a shared security
 baseline".
 
+## Recording evolution (CLI)
+
+The same binary records the v0.3 evolution kinds against a persistent log.
+Each command commits one record and prints its id; `--json` prints
+`{ id, result, reason? }` that round-trips, so pipelines can chain ids
+without scraping text.
+
+```
+bellbook candidate add --log <dir> --rules <file> --author <id> \
+         --git-tree <oid> [--continues <sel> --parent <cand>
+                           | --derives-from <id>... | --upgrades <cand>]
+bellbook eval add      --log <dir> --rules <file> --author <id> \
+         --candidate <id> --criterion <s> (--passed | --failed | --score <v> --scale <n>)
+bellbook select        --log <dir> --rules <file> --author <id> --objective <s> \
+         --consider <id>... (--choose <id>... --uses-eval <id>... | --none) [--replaces <sel>]
+bellbook lineage       --log <dir> --rules <file> <id> [--json]
+```
+
+**The log is single-writer by design.** `LogWriter` takes an exclusive
+lock on the directory for the life of the process, so exactly one
+recording process may hold a log at a time; a second concurrent writer
+fails to open rather than corrupting the log. This is deliberate: parallel
+candidate *generation* is the intended workload, parallel *recording* is
+not. Generate candidates concurrently, then record them serially from one
+process (a loop over the commands above, or `checked_batch_commit` for
+retry-safe batches). The CLI is not a coordination layer, and `--upgrades`
+refuses to record a binding upgrade whose `--git-tree` differs from its
+target's, so a rebinding never silently changes the source identity.
+
 ## Status
 
 **This branch develops spec v0.3 (evolution semantics: Candidate,

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -203,12 +203,29 @@ mod persist_cmds {
         positionals: Vec<String>,
     }
 
-    fn parse(rest: &[String], multi: &[&str], bools: &[&str]) -> Result<Parsed, String> {
+    /// Parse `--flag` arguments against the declared flag names for a
+    /// subcommand. `singles` take one value, `multi` repeat/consume a run of
+    /// values, `bools` take none. An unrecognized `--flag` is an error (so a
+    /// typo like `--auther` is caught, not silently treated as a value slot),
+    /// a single-value flag whose next token is itself a declared flag is a
+    /// missing-value error (so `--procedure --passed` cannot silently swallow
+    /// `--passed`), and a single-value flag given twice is an error rather
+    /// than silently last-wins.
+    fn parse(
+        rest: &[String],
+        singles: &[&str],
+        multi: &[&str],
+        bools: &[&str],
+    ) -> Result<Parsed, String> {
         let mut p = Parsed {
             singles: BTreeMap::new(),
             multis: BTreeMap::new(),
             bools: BTreeSet::new(),
             positionals: Vec::new(),
+        };
+        let is_flag = |t: &str| {
+            t.strip_prefix("--")
+                .is_some_and(|n| singles.contains(&n) || multi.contains(&n) || bools.contains(&n))
         };
         let mut i = 0;
         while i < rest.len() {
@@ -228,12 +245,19 @@ mod persist_cmds {
                         return Err(format!("--{name} requires at least one value"));
                     }
                     p.multis.entry(name.to_string()).or_default().extend(vals);
-                } else {
+                } else if singles.contains(&name) {
                     let Some(v) = rest.get(i + 1) else {
                         return Err(format!("--{name} requires a value"));
                     };
-                    p.singles.insert(name.to_string(), v.clone());
+                    if is_flag(v) {
+                        return Err(format!("--{name} requires a value (found flag {v})"));
+                    }
+                    if p.singles.insert(name.to_string(), v.clone()).is_some() {
+                        return Err(format!("--{name} specified more than once"));
+                    }
                     i += 2;
+                } else {
+                    return Err(format!("unknown flag --{name}"));
                 }
             } else {
                 p.positionals.push(tok.clone());
@@ -297,6 +321,22 @@ mod persist_cmds {
         manifest_hash(&entries).ok_or_else(|| "manifest has duplicate paths".to_string())
     }
 
+    /// Encode a payload, then decode it back to run the same invariant checks
+    /// the verifier applies (score bounds, non-empty criterion/objective, ...).
+    /// This turns a statically-knowable payload violation into a clean
+    /// pre-commit error instead of a durable rejected record with an opaque
+    /// reason: `encode` is a bare serialization and never runs the `TryFrom`
+    /// bound checks, so without this round-trip a `--scale 13` would serialize,
+    /// commit, and only then reject.
+    fn checked_encode<T>(value: &T) -> Result<Vec<u8>, String>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let bytes = encode(value).map_err(|e| format!("{e}"))?;
+        decode::<T>(&bytes).map_err(|e| format!("invalid payload: {e}"))?;
+        Ok(bytes)
+    }
+
     #[derive(serde::Serialize)]
     struct CommitOutput {
         id: String,
@@ -330,7 +370,8 @@ mod persist_cmds {
         } else if accepted {
             println!("{}", out.id);
         } else {
-            println!(
+            // A rejection is a diagnostic, not the command's data output.
+            eprintln!(
                 "{} rejected: {}",
                 out.id,
                 out.reason.as_deref().unwrap_or("?")
@@ -354,7 +395,24 @@ mod persist_cmds {
                 "unknown candidate subcommand {sub:?} (expected add)"
             ));
         }
-        let p = parse(rest, &["derives-from"], &["json"])?;
+        let p = parse(
+            rest,
+            &[
+                "log",
+                "rules",
+                "author",
+                "git-tree",
+                "git-commit",
+                "algo",
+                "note",
+                "manifest",
+                "continues",
+                "parent",
+                "upgrades",
+            ],
+            &["derives-from"],
+            &["json"],
+        )?;
         let rules = load_rules(&p)?;
         let (writer, state) = open(&p, &rules)?;
         let author = author(&rules, &p)?;
@@ -380,6 +438,12 @@ mod persist_cmds {
             return Err(
                 "--continues, --derives-from, and --upgrades are mutually exclusive".into(),
             );
+        }
+        // `--parent` names the continued-from candidate and is meaningful only
+        // for a continuation; silently dropping it elsewhere would lose stated
+        // intent, so reject it instead.
+        if continues.is_none() && p.singles.contains_key("parent") {
+            return Err("--parent is only valid with --continues".into());
         }
 
         let (basis, parent, refs) = if let Some(sel) = continues {
@@ -410,8 +474,21 @@ mod persist_cmds {
             // target's (SPEC §2 recording discipline).
             let target = parse_id(target_hex)?;
             let target_data = find_candidate(writer.records(), target).ok_or_else(|| {
-                format!("--upgrades target {target_hex:?} is not an accepted Candidate")
+                format!("--upgrades target {target_hex:?} is not a Candidate in this log")
             })?;
+            // A Derivation's Cause target must be an accepted, live candidate;
+            // upgrading onto a rejected or retracted one only mints a record
+            // the verifier will reject, so refuse before the write.
+            if !state.accepted_records.contains(&target) {
+                return Err(format!(
+                    "--upgrades target {target_hex:?} is not an accepted Candidate"
+                ));
+            }
+            if state.retracted_records.contains(&target) {
+                return Err(format!(
+                    "--upgrades target {target_hex:?} is retracted; upgrade a live candidate"
+                ));
+            }
             if target_data.source.git.tree != tree {
                 return Err(format!(
                     "refusing upgrade: --git-tree {tree:?} differs from the target candidate's tree {:?}",
@@ -436,7 +513,7 @@ mod persist_cmds {
             None => (None, BindingMode::Reported),
         };
 
-        let data = encode(&CandidateData {
+        let data = checked_encode(&CandidateData {
             source: SourceBinding {
                 git: GitSource { algo, tree, commit },
                 manifest_hash: manifest_hash_val,
@@ -445,8 +522,7 @@ mod persist_cmds {
             basis,
             parent,
             note,
-        })
-        .map_err(|e| format!("{e}"))?;
+        })?;
 
         let proposal = Proposal {
             space: rules.space,
@@ -469,7 +545,21 @@ mod persist_cmds {
         if sub != "add" {
             return Err(format!("unknown eval subcommand {sub:?} (expected add)"));
         }
-        let p = parse(rest, &["uses"], &["json", "passed", "failed"])?;
+        let p = parse(
+            rest,
+            &[
+                "log",
+                "rules",
+                "author",
+                "candidate",
+                "criterion",
+                "procedure",
+                "score",
+                "scale",
+            ],
+            &["uses"],
+            &["json", "passed", "failed"],
+        )?;
         let rules = load_rules(&p)?;
         let (writer, state) = open(&p, &rules)?;
         let author = author(&rules, &p)?;
@@ -511,13 +601,12 @@ mod persist_cmds {
             }
         }
 
-        let data = encode(&EvaluationData {
+        let data = checked_encode(&EvaluationData {
             candidate,
             criterion,
             procedure,
             outcome,
-        })
-        .map_err(|e| format!("{e}"))?;
+        })?;
 
         let proposal = Proposal {
             space: rules.space,
@@ -536,6 +625,14 @@ mod persist_cmds {
     pub fn select(rest: &[String]) -> Result<ExitCode, String> {
         let p = parse(
             rest,
+            &[
+                "log",
+                "rules",
+                "author",
+                "objective",
+                "rationale",
+                "replaces",
+            ],
             &["consider", "choose", "uses-eval"],
             &["json", "none"],
         )?;
@@ -597,13 +694,12 @@ mod persist_cmds {
             });
         }
 
-        let data = encode(&SelectionData {
+        let data = checked_encode(&SelectionData {
             objective,
             considered,
             outcome,
             rationale,
-        })
-        .map_err(|e| format!("{e}"))?;
+        })?;
 
         let proposal = Proposal {
             space: rules.space,
@@ -636,7 +732,7 @@ mod persist_cmds {
     }
 
     pub fn lineage(rest: &[String]) -> Result<ExitCode, String> {
-        let p = parse(rest, &[], &["json"])?;
+        let p = parse(rest, &["log", "rules"], &[], &["json"])?;
         let rules = load_rules(&p)?;
         let dir = require(&p, "log")?;
         let target_hex = p

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -1,14 +1,26 @@
-//! `bellbook validate <file>` - offline receipt validation for auditors.
+//! `bellbook` - accountability-ledger CLI.
 //!
-//! Exit codes: 0 = clean, 1 = invalid, 2 = valid but contains
-//! retracted/tainted claims, 64 = usage error, 66 = unreadable input.
+//! `validate <receipt>` verifies a receipt offline (feature-independent). The
+//! evolution subcommands (`candidate`, `eval`, `select`, `lineage`) are thin
+//! wrappers over the crate that operate on a persistent log and therefore need
+//! the `persist` feature; JSON in/out, and every mutating command prints the
+//! committed record id.
+//!
+//! **Concurrency (SPEC §5.1):** the persistent log is deliberately
+//! single-writer - `LogWriter` holds an exclusive lock. Parallel candidate
+//! *generation* is the intended workload; parallel *recording* is not. Generate
+//! candidates concurrently, then record them serially in one process (a loop,
+//! or `checked_batch_commit` for retry-safe batches). The CLI is not a
+//! coordination layer.
+//!
+//! Exit codes: 0 = success/clean, 1 = invalid receipt, 2 = valid but
+//! retracted/tainted, 64 = usage error, 65 = command failed (e.g. a rejected
+//! record), 66 = unreadable input, 70 = internal error.
 
-use bellbook::receipt::{validate_with_limits, ValidationLimits, ValidationStatus};
+use bellbook::*;
 use std::process::ExitCode;
 
-/// Default cap on receipt file size: 64 MiB. Far above any realistic
-/// honest receipt; prevents a hostile file from demanding unbounded
-/// memory. Override with --max-size (0 = unlimited).
+/// Default cap on receipt file size: 64 MiB.
 const DEFAULT_MAX_SIZE: u64 = 64 << 20;
 
 const USAGE: &str = "\
@@ -16,62 +28,78 @@ bellbook - accountability-ledger tools
 
 USAGE:
     bellbook validate <receipt-file> [--json] [--max-size <bytes>]
+    bellbook candidate add --log <dir> --rules <file> --author <id>
+                           --git-tree <oid> [--git-commit <oid>] [--algo sha1|sha256]
+                           [--manifest <path-to-tree>]
+                           [--continues <selection-id> --parent <candidate-id>
+                            | --derives-from <id> ...
+                            | --upgrades <candidate-id>]
+                           [--note <s>] [--json]
+    bellbook eval add      --log <dir> --rules <file> --author <id>
+                           --candidate <id> --criterion <s>
+                           (--passed | --failed | --score <value> --scale <n>)
+                           [--procedure <s>] [--uses <id> ...] [--json]
+    bellbook select        --log <dir> --rules <file> --author <id>
+                           --objective <s> --consider <id> ...
+                           (--choose <id> ... --uses-eval <id> ... | --none)
+                           [--replaces <selection-id>] [--rationale <s>] [--json]
+    bellbook lineage       --log <dir> --rules <file> <id> [--json]
 
 COMMANDS:
     validate    Verify a receipt offline: ids (RFC 8785 canonical form),
                 gap-free logical time, verdict re-derivation, signatures,
-                evidence derivation, and taint status.
-
-OPTIONS:
-    --json               Emit the full report as JSON instead of
-                         human-readable text.
-    --max-size <bytes>   Refuse receipt files larger than this before
-                         reading them (default 67108864 = 64 MiB;
-                         0 = unlimited). The CLI is the trust boundary
-                         for untrusted receipts, so the bound is applied
-                         here, not upstream.
+                evidence derivation, taint, and the standing section.
+    candidate   Record a Candidate (a proposed source state).
+    eval        Record an Evaluation of a candidate.
+    select      Record a Selection over candidates (or a reaffirmation).
+    lineage     Show a candidate's descent, siblings, taint, and standing.
 
 EXIT CODES:
-    0    clean - the log verified and contains no retracted/tainted claims
-    1    invalid - the receipt failed verification (details in the report)
-    2    tainted - valid history, but some claims are retracted or tainted
-    64   usage error
-    66   input file unreadable
-    70   internal error (report serialization failed)\
+    0 clean/success   1 invalid   2 tainted   64 usage   65 command failed
+    66 unreadable input   70 internal error\
 ";
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
-
     let (command, rest) = match args.split_first() {
-        Some((c, rest)) => (c.as_str(), rest),
+        Some((c, rest)) => (c.as_str(), rest.to_vec()),
         None => {
             eprintln!("{USAGE}");
             return ExitCode::from(64);
         }
     };
-    if command != "validate" {
-        eprintln!("unknown command {command:?}\n\n{USAGE}");
-        return ExitCode::from(64);
+    match command {
+        "validate" => cmd_validate(&rest),
+        "candidate" | "eval" | "select" | "lineage" => cmd_evolution(command, &rest),
+        other => {
+            eprintln!("unknown command {other:?}\n\n{USAGE}");
+            ExitCode::from(64)
+        }
     }
+}
 
+// ---------------------------------------------------------------------------
+// validate (feature-independent)
+// ---------------------------------------------------------------------------
+
+fn cmd_validate(rest: &[String]) -> ExitCode {
     let mut file: Option<&str> = None;
     let mut json = false;
     let mut max_size = DEFAULT_MAX_SIZE;
-    let mut args_iter = rest.iter();
-    while let Some(arg) = args_iter.next() {
+    let mut it = rest.iter();
+    while let Some(arg) = it.next() {
         match arg.as_str() {
             "--json" => json = true,
             "--max-size" => {
-                let Some(value) = args_iter.next() else {
+                let Some(v) = it.next() else {
                     eprintln!("--max-size requires a value\n\n{USAGE}");
                     return ExitCode::from(64);
                 };
-                match value.parse::<u64>() {
+                match v.parse::<u64>() {
                     Ok(0) => max_size = u64::MAX,
                     Ok(n) => max_size = n,
                     Err(_) => {
-                        eprintln!("invalid --max-size value {value:?}\n\n{USAGE}");
+                        eprintln!("invalid --max-size value {v:?}");
                         return ExitCode::from(64);
                     }
                 }
@@ -88,10 +116,6 @@ fn main() -> ExitCode {
         return ExitCode::from(64);
     };
 
-    // Bounded read: the file is untrusted input and this process is the
-    // trust boundary. Reading through `take(max_size + 1)` enforces the
-    // bound on the bytes actually read - a size check on metadata alone
-    // would race against the file growing between check and read.
     let bytes = {
         use std::io::Read;
         let file = match std::fs::File::open(path) {
@@ -136,5 +160,629 @@ fn main() -> ExitCode {
         ValidationStatus::Clean => ExitCode::SUCCESS,
         ValidationStatus::Invalid => ExitCode::from(1),
         ValidationStatus::Tainted => ExitCode::from(2),
+    }
+}
+
+#[cfg(not(feature = "persist"))]
+fn cmd_evolution(command: &str, _rest: &[String]) -> ExitCode {
+    eprintln!("the {command:?} command requires the `persist` feature (build without --no-default-features)");
+    ExitCode::from(64)
+}
+
+#[cfg(feature = "persist")]
+fn cmd_evolution(command: &str, rest: &[String]) -> ExitCode {
+    let result = match command {
+        "candidate" => persist_cmds::candidate(rest),
+        "eval" => persist_cmds::eval(rest),
+        "select" => persist_cmds::select(rest),
+        "lineage" => persist_cmds::lineage(rest),
+        _ => unreachable!(),
+    };
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::from(65)
+        }
+    }
+}
+
+#[cfg(feature = "persist")]
+mod persist_cmds {
+    use bellbook::*;
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::process::ExitCode;
+
+    /// A parsed flag set: single-value flags, repeatable multi-value flags,
+    /// boolean flags, and bare positionals. Multi-value flags consume every
+    /// following token up to the next `--flag`.
+    struct Parsed {
+        singles: BTreeMap<String, String>,
+        multis: BTreeMap<String, Vec<String>>,
+        bools: BTreeSet<String>,
+        positionals: Vec<String>,
+    }
+
+    fn parse(rest: &[String], multi: &[&str], bools: &[&str]) -> Result<Parsed, String> {
+        let mut p = Parsed {
+            singles: BTreeMap::new(),
+            multis: BTreeMap::new(),
+            bools: BTreeSet::new(),
+            positionals: Vec::new(),
+        };
+        let mut i = 0;
+        while i < rest.len() {
+            let tok = &rest[i];
+            if let Some(name) = tok.strip_prefix("--") {
+                if bools.contains(&name) {
+                    p.bools.insert(name.to_string());
+                    i += 1;
+                } else if multi.contains(&name) {
+                    let mut vals = Vec::new();
+                    i += 1;
+                    while i < rest.len() && !rest[i].starts_with("--") {
+                        vals.push(rest[i].clone());
+                        i += 1;
+                    }
+                    if vals.is_empty() {
+                        return Err(format!("--{name} requires at least one value"));
+                    }
+                    p.multis.entry(name.to_string()).or_default().extend(vals);
+                } else {
+                    let Some(v) = rest.get(i + 1) else {
+                        return Err(format!("--{name} requires a value"));
+                    };
+                    p.singles.insert(name.to_string(), v.clone());
+                    i += 2;
+                }
+            } else {
+                p.positionals.push(tok.clone());
+                i += 1;
+            }
+        }
+        Ok(p)
+    }
+
+    fn require<'a>(p: &'a Parsed, key: &str) -> Result<&'a str, String> {
+        p.singles
+            .get(key)
+            .map(String::as_str)
+            .ok_or_else(|| format!("missing required --{key}"))
+    }
+
+    fn load_rules(p: &Parsed) -> Result<VerifierRules, String> {
+        let path = require(p, "rules")?;
+        let bytes = std::fs::read(path).map_err(|e| format!("cannot read rules {path}: {e}"))?;
+        serde_json::from_slice(&bytes).map_err(|e| format!("cannot parse rules {path}: {e}"))
+    }
+
+    /// Open the log and rebuild verified state from its committed records.
+    fn open(p: &Parsed, rules: &VerifierRules) -> Result<(LogWriter, State), String> {
+        let dir = require(p, "log")?;
+        let writer =
+            LogWriter::open(std::path::Path::new(dir), rules).map_err(|e| format!("{e:?}"))?;
+        let state = verify_and_build_state(writer.records(), rules)
+            .map_err(|_| "the existing log does not verify under these rules".to_string())?;
+        Ok((writer, state))
+    }
+
+    fn author(rules: &VerifierRules, p: &Parsed) -> Result<Author, String> {
+        let id = require(p, "author")?;
+        let type_ =
+            rules.author_roles.get(id).copied().ok_or_else(|| {
+                format!("author {id:?} is not registered in the rules' author_roles")
+            })?;
+        Ok(Author {
+            id: id.to_string(),
+            type_,
+            signature: None,
+        })
+    }
+
+    fn parse_id(hex: &str) -> Result<RecordId, String> {
+        hex_decode(hex).ok_or_else(|| format!("invalid record id {hex:?}"))
+    }
+
+    /// Look up an accepted Candidate by id and decode its payload.
+    fn find_candidate(records: &[Record], id: RecordId) -> Option<CandidateData> {
+        records
+            .iter()
+            .find(|r| r.id == id && r.kind == Kind::Candidate)
+            .and_then(|r| decode::<CandidateData>(&r.data).ok())
+    }
+
+    fn manifest_binding(path: &str) -> Result<Hash256, String> {
+        let entries = manifest_from_dir(std::path::Path::new(path), &BTreeMap::new())
+            .map_err(|e| format!("cannot walk tree {path}: {e}"))?;
+        manifest_hash(&entries).ok_or_else(|| "manifest has duplicate paths".to_string())
+    }
+
+    #[derive(serde::Serialize)]
+    struct CommitOutput {
+        id: String,
+        result: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    }
+
+    /// Commit a proposal, print its id, and map the verdict to an exit code.
+    fn commit_and_print(
+        mut writer: LogWriter,
+        rules: &VerifierRules,
+        mut state: State,
+        proposal: Proposal,
+        json: bool,
+    ) -> Result<ExitCode, String> {
+        let (id, verdict) = writer
+            .commit(proposal, rules, &mut state)
+            .map_err(|e| format!("commit failed: {e:?}"))?;
+        let accepted = verdict.result == VerdictResult::Accept;
+        let out = CommitOutput {
+            id: hex_encode(&id),
+            result: if accepted { "accept" } else { "reject" }.to_string(),
+            reason: verdict.reason.map(|r| format!("{r:?}")),
+        };
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&out).map_err(|e| format!("{e}"))?
+            );
+        } else if accepted {
+            println!("{}", out.id);
+        } else {
+            println!(
+                "{} rejected: {}",
+                out.id,
+                out.reason.as_deref().unwrap_or("?")
+            );
+        }
+        Ok(if accepted {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(65)
+        })
+    }
+
+    // --- candidate add -----------------------------------------------------
+
+    pub fn candidate(rest: &[String]) -> Result<ExitCode, String> {
+        let (sub, rest) = rest
+            .split_first()
+            .ok_or_else(|| "candidate needs a subcommand (add)".to_string())?;
+        if sub != "add" {
+            return Err(format!(
+                "unknown candidate subcommand {sub:?} (expected add)"
+            ));
+        }
+        let p = parse(rest, &["derives-from"], &["json"])?;
+        let rules = load_rules(&p)?;
+        let (writer, state) = open(&p, &rules)?;
+        let author = author(&rules, &p)?;
+
+        let algo = match p.singles.get("algo").map(String::as_str) {
+            None | Some("sha1") => SourceAlgo::Sha1,
+            Some("sha256") => SourceAlgo::Sha256,
+            Some(other) => return Err(format!("invalid --algo {other:?}")),
+        };
+        let tree = require(&p, "git-tree")?.to_string();
+        let commit = p.singles.get("git-commit").cloned();
+        let note = p.singles.get("note").cloned();
+
+        // Basis selection is mutually exclusive.
+        let continues = p.singles.get("continues");
+        let derives = p.multis.get("derives-from");
+        let upgrades = p.singles.get("upgrades");
+        let n_basis = [continues.is_some(), derives.is_some(), upgrades.is_some()]
+            .iter()
+            .filter(|b| **b)
+            .count();
+        if n_basis > 1 {
+            return Err(
+                "--continues, --derives-from, and --upgrades are mutually exclusive".into(),
+            );
+        }
+
+        let (basis, parent, refs) = if let Some(sel) = continues {
+            let parent = parse_id(require(&p, "parent")?)?;
+            let sel = parse_id(sel)?;
+            (
+                CandidateBasis::Continuation,
+                Some(parent),
+                vec![Ref {
+                    type_: RefType::Cause,
+                    target: sel,
+                }],
+            )
+        } else if let Some(ids) = derives {
+            let refs = ids
+                .iter()
+                .map(|s| {
+                    parse_id(s).map(|t| Ref {
+                        type_: RefType::Cause,
+                        target: t,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            (CandidateBasis::Derivation, None, refs)
+        } else if let Some(target_hex) = upgrades {
+            // Binding upgrade: a Derivation over the target with the SAME tree.
+            // The CLI refuses to build an upgrade whose tree differs from its
+            // target's (SPEC §2 recording discipline).
+            let target = parse_id(target_hex)?;
+            let target_data = find_candidate(writer.records(), target).ok_or_else(|| {
+                format!("--upgrades target {target_hex:?} is not an accepted Candidate")
+            })?;
+            if target_data.source.git.tree != tree {
+                return Err(format!(
+                    "refusing upgrade: --git-tree {tree:?} differs from the target candidate's tree {:?}",
+                    target_data.source.git.tree
+                ));
+            }
+            (
+                CandidateBasis::Derivation,
+                None,
+                vec![Ref {
+                    type_: RefType::Cause,
+                    target,
+                }],
+            )
+        } else {
+            (CandidateBasis::Root, None, Vec::new())
+        };
+
+        // A manifest binding when --manifest is given; reported otherwise.
+        let (manifest_hash_val, binding) = match p.singles.get("manifest") {
+            Some(path) => (Some(manifest_binding(path)?), BindingMode::Manifest),
+            None => (None, BindingMode::Reported),
+        };
+
+        let data = encode(&CandidateData {
+            source: SourceBinding {
+                git: GitSource { algo, tree, commit },
+                manifest_hash: manifest_hash_val,
+                binding,
+            },
+            basis,
+            parent,
+            note,
+        })
+        .map_err(|e| format!("{e}"))?;
+
+        let proposal = Proposal {
+            space: rules.space,
+            thread: rules.space, // single-thread CLI: thread == space id
+            author,
+            kind: Kind::Candidate,
+            schema: schema_id(SCHEMA_CANDIDATE),
+            data,
+            refs,
+        };
+        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+    }
+
+    // --- eval add ----------------------------------------------------------
+
+    pub fn eval(rest: &[String]) -> Result<ExitCode, String> {
+        let (sub, rest) = rest
+            .split_first()
+            .ok_or_else(|| "eval needs a subcommand (add)".to_string())?;
+        if sub != "add" {
+            return Err(format!("unknown eval subcommand {sub:?} (expected add)"));
+        }
+        let p = parse(rest, &["uses"], &["json", "passed", "failed"])?;
+        let rules = load_rules(&p)?;
+        let (writer, state) = open(&p, &rules)?;
+        let author = author(&rules, &p)?;
+
+        let candidate = parse_id(require(&p, "candidate")?)?;
+        let criterion = require(&p, "criterion")?.to_string();
+        let procedure = p.singles.get("procedure").cloned();
+
+        let outcome = match (
+            p.bools.contains("passed"),
+            p.bools.contains("failed"),
+            p.singles.get("score"),
+        ) {
+            (true, false, None) => EvaluationOutcome::Passed,
+            (false, true, None) => EvaluationOutcome::Failed,
+            (false, false, Some(score)) => {
+                let value = score
+                    .parse::<i64>()
+                    .map_err(|_| "invalid --score".to_string())?;
+                let scale = require(&p, "scale")?
+                    .parse::<u8>()
+                    .map_err(|_| "invalid --scale".to_string())?;
+                EvaluationOutcome::Scored(ScoredValue { value, scale })
+            }
+            _ => return Err("exactly one of --passed, --failed, or --score is required".into()),
+        };
+
+        // The evaluation must Use its candidate, plus any extra --uses refs.
+        let mut refs = vec![Ref {
+            type_: RefType::Use,
+            target: candidate,
+        }];
+        if let Some(extra) = p.multis.get("uses") {
+            for s in extra {
+                refs.push(Ref {
+                    type_: RefType::Use,
+                    target: parse_id(s)?,
+                });
+            }
+        }
+
+        let data = encode(&EvaluationData {
+            candidate,
+            criterion,
+            procedure,
+            outcome,
+        })
+        .map_err(|e| format!("{e}"))?;
+
+        let proposal = Proposal {
+            space: rules.space,
+            thread: rules.space,
+            author,
+            kind: Kind::Evaluation,
+            schema: schema_id(SCHEMA_EVALUATION),
+            data,
+            refs,
+        };
+        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+    }
+
+    // --- select ------------------------------------------------------------
+
+    pub fn select(rest: &[String]) -> Result<ExitCode, String> {
+        let p = parse(
+            rest,
+            &["consider", "choose", "uses-eval"],
+            &["json", "none"],
+        )?;
+        let rules = load_rules(&p)?;
+        let (writer, state) = open(&p, &rules)?;
+        let author = author(&rules, &p)?;
+
+        let objective = require(&p, "objective")?.to_string();
+        let considered = p
+            .multis
+            .get("consider")
+            .ok_or_else(|| "--consider requires at least one candidate id".to_string())?
+            .iter()
+            .map(|s| parse_id(s))
+            .collect::<Result<Vec<_>, _>>()?;
+        let rationale = p.singles.get("rationale").cloned();
+
+        let none = p.bools.contains("none");
+        let choose = p.multis.get("choose");
+        if none == choose.is_some() {
+            return Err("exactly one of --choose or --none is required".into());
+        }
+
+        let mut refs = Vec::new();
+        let outcome = if none {
+            SelectionOutcome::None
+        } else {
+            let winners = choose
+                .unwrap()
+                .iter()
+                .map(|s| parse_id(s))
+                .collect::<Result<Vec<_>, _>>()?;
+            for w in &winners {
+                refs.push(Ref {
+                    type_: RefType::Require,
+                    target: *w,
+                });
+            }
+            // Evaluations are required with --choose.
+            let evals = p.multis.get("uses-eval").ok_or_else(|| {
+                "--choose requires --uses-eval with at least one evaluation".to_string()
+            })?;
+            for s in evals {
+                refs.push(Ref {
+                    type_: RefType::Use,
+                    target: parse_id(s)?,
+                });
+            }
+            SelectionOutcome::Selected {
+                candidates: winners,
+            }
+        };
+
+        // Reaffirmation: --replaces adds a Replace ref to a prior Selection.
+        if let Some(sel) = p.singles.get("replaces") {
+            refs.push(Ref {
+                type_: RefType::Replace,
+                target: parse_id(sel)?,
+            });
+        }
+
+        let data = encode(&SelectionData {
+            objective,
+            considered,
+            outcome,
+            rationale,
+        })
+        .map_err(|e| format!("{e}"))?;
+
+        let proposal = Proposal {
+            space: rules.space,
+            thread: rules.space,
+            author,
+            kind: Kind::Selection,
+            schema: schema_id(SCHEMA_SELECTION),
+            data,
+            refs,
+        };
+        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+    }
+
+    // --- lineage -----------------------------------------------------------
+
+    #[derive(serde::Serialize)]
+    struct LineageReport {
+        id: String,
+        kind: String,
+        basis: Option<String>,
+        parent: Option<String>,
+        note: Option<String>,
+        tainted: bool,
+        standing: String,
+        ancestors: Vec<String>,
+        children: Vec<String>,
+        siblings: Vec<String>,
+        considered_by: Vec<String>,
+        selected_by: Vec<String>,
+    }
+
+    pub fn lineage(rest: &[String]) -> Result<ExitCode, String> {
+        let p = parse(rest, &[], &["json"])?;
+        let rules = load_rules(&p)?;
+        let dir = require(&p, "log")?;
+        let target_hex = p
+            .positionals
+            .first()
+            .ok_or_else(|| "lineage requires a record id".to_string())?;
+        let target = parse_id(target_hex)?;
+
+        let writer =
+            LogWriter::open(std::path::Path::new(dir), &rules).map_err(|e| format!("{e:?}"))?;
+        let records = writer.records();
+        let verdict = verify_log(records, &rules, None);
+        if verdict.result != VerdictResult::Accept {
+            return Err("the log does not verify under these rules".into());
+        }
+
+        let rec = records
+            .iter()
+            .find(|r| r.id == target)
+            .ok_or_else(|| format!("record {target_hex:?} not found in the log"))?;
+
+        // Candidate lineage facts (if the target is a candidate).
+        let cand = decode::<CandidateData>(&rec.data)
+            .ok()
+            .filter(|_| rec.kind == Kind::Candidate);
+
+        // Ancestors: walk the parent chain (continuations) upward.
+        let mut ancestors = Vec::new();
+        {
+            let mut cur = cand.as_ref().and_then(|c| c.parent);
+            while let Some(pid) = cur {
+                ancestors.push(hex_encode(&pid));
+                cur = find_candidate(records, pid).and_then(|c| c.parent);
+            }
+        }
+
+        // Children: candidates whose parent is the target, or whose Cause
+        // targets include it (derivations). Siblings: candidates sharing the
+        // target's parent.
+        let mut children = Vec::new();
+        let mut siblings = Vec::new();
+        let target_parent = cand.as_ref().and_then(|c| c.parent);
+        for r in records {
+            if r.kind != Kind::Candidate {
+                continue;
+            }
+            let Ok(cd) = decode::<CandidateData>(&r.data) else {
+                continue;
+            };
+            let is_child = cd.parent == Some(target)
+                || r.refs
+                    .iter()
+                    .any(|rf| rf.type_ == RefType::Cause && rf.target == target);
+            if is_child && r.id != target {
+                children.push(hex_encode(&r.id));
+            }
+            if r.id != target && target_parent.is_some() && cd.parent == target_parent {
+                siblings.push(hex_encode(&r.id));
+            }
+        }
+
+        // Selections that considered or selected the target.
+        let mut considered_by = Vec::new();
+        let mut selected_by = Vec::new();
+        for r in records {
+            if r.kind != Kind::Selection {
+                continue;
+            }
+            let Ok(sd) = decode::<SelectionData>(&r.data) else {
+                continue;
+            };
+            if sd.considered.contains(&target) {
+                considered_by.push(hex_encode(&r.id));
+            }
+            if let SelectionOutcome::Selected { candidates } = &sd.outcome {
+                if candidates.contains(&target) {
+                    selected_by.push(hex_encode(&r.id));
+                }
+            }
+        }
+
+        let standing = if rec.kind == Kind::Candidate {
+            if verdict.standing.compromised.contains(&target) {
+                "compromised"
+            } else {
+                "sound"
+            }
+        } else if rec.kind == Kind::Selection {
+            if verdict.standing.unsound.contains(&target) {
+                "unsound"
+            } else {
+                "sound"
+            }
+        } else {
+            "n/a"
+        }
+        .to_string();
+
+        let report = LineageReport {
+            id: hex_encode(&target),
+            kind: format!("{:?}", rec.kind),
+            basis: cand.as_ref().map(|c| format!("{:?}", c.basis)),
+            parent: cand.as_ref().and_then(|c| c.parent).map(|p| hex_encode(&p)),
+            note: cand.as_ref().and_then(|c| c.note.clone()),
+            tainted: verdict.tainted_records.contains(&target),
+            standing,
+            ancestors,
+            children,
+            siblings,
+            considered_by,
+            selected_by,
+        };
+
+        if p.bools.contains("json") {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report).map_err(|e| format!("{e}"))?
+            );
+        } else {
+            println!("id:          {}", report.id);
+            println!("kind:        {}", report.kind);
+            if let Some(b) = &report.basis {
+                println!("basis:       {b}");
+            }
+            if let Some(pt) = &report.parent {
+                println!("parent:      {pt}");
+            }
+            if let Some(n) = &report.note {
+                println!("note:        {n}");
+            }
+            println!("tainted:     {}", report.tainted);
+            println!("standing:    {}", report.standing);
+            let list = |label: &str, v: &[String]| {
+                if !v.is_empty() {
+                    println!("{label} ({}):", v.len());
+                    for x in v {
+                        println!("  {x}");
+                    }
+                }
+            };
+            list("ancestors", &report.ancestors);
+            list("children", &report.children);
+            list("siblings", &report.siblings);
+            list("considered-by", &report.considered_by);
+            list("selected-by", &report.selected_by);
+        }
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -285,6 +285,189 @@ fn unknown_author_is_rejected() {
 }
 
 #[test]
+fn out_of_range_score_is_caught_before_commit() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    // scale 13 exceeds the payload's 0..=12 bound. This is statically knowable,
+    // so it must be a clean pre-commit error, not a durable rejected record.
+    let out = run(
+        &env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            "agent",
+            "--candidate",
+            &root,
+            "--criterion",
+            "x",
+            "--score",
+            "5",
+            "--scale",
+            "13",
+        ],
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid payload"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn empty_criterion_is_caught_before_commit() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    let out = run(
+        &env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            "agent",
+            "--candidate",
+            &root,
+            "--criterion",
+            "",
+            "--passed",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("invalid payload"));
+}
+
+#[test]
+fn rejected_record_exits_nonzero_with_verdict_json() {
+    let env = setup();
+    // An invalid (non-hex) tree passes payload decoding but the verifier
+    // rejects it (SourceBindingInvalid) at commit: this exercises the reject
+    // branch end to end - valid JSON with result "reject" and a nonzero exit.
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            "not-hex",
+            "--json",
+        ],
+    );
+    assert!(!out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["result"], "reject");
+    assert!(v["reason"].is_string());
+    assert_eq!(v["id"].as_str().unwrap().len(), 64);
+}
+
+#[test]
+fn unknown_flag_is_rejected() {
+    let env = setup();
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--auther",
+            "oops",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("unknown flag --auther"));
+}
+
+#[test]
+fn single_value_flag_does_not_swallow_following_flag() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    // `--procedure` immediately followed by `--passed` must not consume it.
+    let out = run(
+        &env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            "agent",
+            "--candidate",
+            &root,
+            "--procedure",
+            "--passed",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("requires a value"));
+}
+
+#[test]
+fn duplicate_single_flag_is_rejected() {
+    let env = setup();
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--author",
+            "stranger",
+            "--git-tree",
+            TREE_A,
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("specified more than once"));
+}
+
+#[test]
+fn parent_without_continues_is_rejected() {
+    let env = setup();
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--parent",
+            "00000000000000000000000000000000000000000000000000000000000000ab",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("--parent is only valid with --continues")
+    );
+}
+
+#[test]
+fn upgrade_missing_target_is_rejected() {
+    let env = setup();
+    // A well-formed id that is not in the log at all.
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--upgrades",
+            "00000000000000000000000000000000000000000000000000000000000000ff",
+        ],
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not a Candidate in this log"));
+}
+
+#[test]
 fn validate_is_feature_independent() {
     // `validate` needs no log; a missing file is an unreadable-input error (66),
     // proving the command dispatches without touching the persist path.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,296 @@
+//! End-to-end tests for the `bellbook` evolution CLI (`candidate`, `eval`,
+//! `select`, `lineage`). Each test drives the real compiled binary against a
+//! throwaway log directory, so it exercises the whole path: argument parsing,
+//! rules loading, verified open, commit, and JSON output. The binary is
+//! single-writer by design, so every command runs as its own process and the
+//! log is opened fresh each time - the intended serial recording pattern.
+
+#![cfg(feature = "persist")]
+
+use bellbook::*;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+const SPACE: [u8; 32] = [7u8; 32];
+// The canonical empty-tree SHA-1 OID; a valid 40-hex tree.
+const TREE_A: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+// A distinct, still-valid 40-hex tree OID.
+const TREE_B: &str = "1111111111111111111111111111111111111111";
+
+fn rules_json() -> String {
+    // "agent" is a Provider - allowed to author Candidate, Evaluation, and
+    // Selection - so one identity drives the whole flow.
+    let rules = VerifierRules::new(SPACE, 200).with_author_role("agent", AuthorType::Provider);
+    serde_json::to_string_pretty(&rules).unwrap()
+}
+
+/// A scratch working area: a log dir and a written rules file.
+struct Env {
+    _dir: tempfile::TempDir,
+    log: PathBuf,
+    rules: PathBuf,
+}
+
+fn setup() -> Env {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("log");
+    let rules = dir.path().join("rules.json");
+    std::fs::write(&rules, rules_json()).unwrap();
+    Env {
+        _dir: dir,
+        log,
+        rules,
+    }
+}
+
+fn bellbook() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_bellbook"))
+}
+
+/// Run a subcommand and capture its output. `--log`/`--rules` are appended
+/// last so any `add` subcommand keyword stays adjacent to its command word.
+fn run(env: &Env, args: &[&str]) -> Output {
+    let mut cmd = bellbook();
+    cmd.args(args);
+    cmd.arg("--log").arg(&env.log);
+    cmd.arg("--rules").arg(&env.rules);
+    cmd.output().unwrap()
+}
+
+/// Parse the `id` field from a `--json` commit output.
+fn committed_id(out: &Output) -> String {
+    assert!(
+        out.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["result"], "accept");
+    v["id"].as_str().unwrap().to_string()
+}
+
+fn add_root(env: &Env, tree: &str) -> String {
+    let out = run(
+        env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            tree,
+            "--json",
+        ],
+    );
+    committed_id(&out)
+}
+
+#[test]
+fn root_candidate_prints_its_id() {
+    let env = setup();
+    let id = add_root(&env, TREE_A);
+    // A record id is 32 bytes of lowercase hex.
+    assert_eq!(id.len(), 64);
+    assert!(id
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+}
+
+#[test]
+fn upgrade_tree_mismatch_is_refused() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    // Upgrading with a DIFFERENT tree must be refused before it is committed.
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_B,
+            "--upgrades",
+            &root,
+        ],
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("refusing upgrade"),
+        "unexpected stderr: {stderr}"
+    );
+    // The refused upgrade committed nothing: only the root is in the log.
+    let out = run(&env, &["lineage", &root, "--json"]);
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(v["children"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn upgrade_same_tree_is_accepted() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    // Same tree: the guard allows it and it commits as a derivation child.
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--upgrades",
+            &root,
+            "--json",
+        ],
+    );
+    let upgraded = committed_id(&out);
+    assert_ne!(upgraded, root);
+
+    let out = run(&env, &["lineage", &root, "--json"]);
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let children: Vec<&str> = v["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c.as_str().unwrap())
+        .collect();
+    assert_eq!(children, vec![upgraded.as_str()]);
+}
+
+#[test]
+fn full_flow_and_lineage_json_round_trips() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+
+    // Evaluate the candidate.
+    let out = run(
+        &env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            "agent",
+            "--candidate",
+            &root,
+            "--criterion",
+            "unit-tests",
+            "--passed",
+            "--json",
+        ],
+    );
+    let eval = committed_id(&out);
+
+    // Select it, grounded on the evaluation.
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &root,
+            "--choose",
+            &root,
+            "--uses-eval",
+            &eval,
+            "--json",
+        ],
+    );
+    let selection = committed_id(&out);
+
+    // Lineage JSON must round-trip and reflect the recorded relationships.
+    let out = run(&env, &["lineage", &root, "--json"]);
+    assert!(out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["id"], root);
+    assert_eq!(v["kind"], "Candidate");
+    assert_eq!(v["basis"], "Root");
+    assert_eq!(v["standing"], "sound");
+    assert_eq!(v["tainted"], false);
+    let considered_by: Vec<&str> = v["considered_by"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c.as_str().unwrap())
+        .collect();
+    assert_eq!(considered_by, vec![selection.as_str()]);
+    let selected_by: Vec<&str> = v["selected_by"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c.as_str().unwrap())
+        .collect();
+    assert_eq!(selected_by, vec![selection.as_str()]);
+
+    // The human-readable rendering carries the same facts.
+    let out = run(&env, &["lineage", &root]);
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains(&format!("id:          {root}")),
+        "text: {text}"
+    );
+    assert!(text.contains("basis:       Root"), "text: {text}");
+    assert!(text.contains("standing:    sound"), "text: {text}");
+    assert!(text.contains(&selection), "text: {text}");
+}
+
+#[test]
+fn none_selection_records() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    // A None selection prunes without choosing; it needs no evaluation.
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "prune",
+            "--consider",
+            &root,
+            "--none",
+            "--json",
+        ],
+    );
+    let _ = committed_id(&out);
+}
+
+#[test]
+fn unknown_author_is_rejected() {
+    let env = setup();
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "stranger",
+            "--git-tree",
+            TREE_A,
+        ],
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("author_roles"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn validate_is_feature_independent() {
+    // `validate` needs no log; a missing file is an unreadable-input error (66),
+    // proving the command dispatches without touching the persist path.
+    let out = bellbook()
+        .args(["validate", "/nonexistent/receipt.json"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(66));
+}


### PR DESCRIPTION
Adds the v0.3 evolution recording commands to the `bellbook` binary. The
write commands live behind the `persist` feature so `validate` stays
feature-independent and the `--no-default-features` build still compiles.

## Commands

- `candidate add` - Root, `--continues`/`--parent`, `--derives-from`, and
  `--upgrades` bases; reported or `--manifest` source binding. `--upgrades`
  refuses a binding upgrade whose `--git-tree` differs from its target's,
  so a rebinding never silently changes the source identity.
- `eval add` - `--passed`/`--failed`/`--score`+`--scale` over a candidate.
- `select` - `--consider` with `--choose`+`--uses-eval` or `--none`, plus
  `--replaces` for reaffirmation.
- `lineage` - ancestors, children, siblings, considering and selecting
  Selections, taint, and standing, as text or `--json`.

## Contract

- Every mutating command commits one record and prints its id.
- `--json` emits `{ id, result, reason? }` that round-trips; a rejected
  record exits non-zero while still printing its verdict.
- Payload invariants (score bounds, non-empty criterion/objective) are
  checked before commit, so a statically-invalid value is a clean error,
  not a durable rejected record.
- The log is single-writer: `LogWriter` holds an exclusive lock, so
  exactly one recording process may hold a log at a time. The README
  documents this pattern before the commands.

## Tests

`tests/cli.rs` drives the compiled binary end to end: root candidate id
output, both sides of the `--upgrades` tree-equality guard (refuse on a
differing tree, accept on the same tree), the full candidate/eval/select
flow with lineage JSON and text round-trip, a `--none` selection, the
reject path, and the argument-parsing guards (unknown flag, flag-swallow,
duplicate flag, `--parent` misuse).

## Checks

`cargo test --all-features`, `cargo fmt --check`, `cargo clippy
--all-targets` (all-features and no-default-features), `cargo doc -D
warnings`, the independent Python conformance runner, and the frozen v0.2
gate all pass. No spec artifacts change.

Closes #31