### PR TITLE
docs: README/CHANGELOG/SPEC cross-consistency for 0.3.0 (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Bellbook is an evidence layer, not an identity provider or runtime
 policy engine. Identity systems establish who an agent is and what
 access it holds. Policy engines decide whether an action may execute.
 Bellbook preserves captured requests, authority, actions, and results as a
-portable receipt that another party can verify independently. Spec v0.2 does
+portable receipt that another party can verify independently. The spec does
 not include a record for an external policy engine's decision. Bellbook's own
 `Verdict` records are its deterministic
 judgment that the *ledger followed its rules*; they are never a
 substitute for an external policy engine's permit/deny decision, and
-the separately scoped `PolicyDecision` work is not implemented in v0.2.
+the separately scoped `PolicyDecision` work is not implemented.
 See [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) for how surrounding systems
 relate to Bellbook and
 [docs/INTEROPERABILITY.md](docs/INTEROPERABILITY.md) for the boundary
@@ -102,6 +102,21 @@ embeds.
   epistemically depended on it (via `Use`/`Require` refs) are marked
   tainted; a tainted chain still replays and verifies, and the report
   surfaces exactly which claims no longer rest on anything.
+- **Evolution semantics (spec v0.3).** Three more record kinds capture how
+  work evolves: a `Candidate` binds a source state (a Git tree, `reported`
+  or committed to a canonical `manifest`), an `Evaluation` records one
+  criterion's judgment of one candidate, and a set-valued `Selection`
+  chooses among considered candidates under an objective, grounded on
+  evaluations. A `Replace` on a Selection reaffirms an earlier decision.
+  On top of these, the replay report gains a **standing** section: a
+  purely replay-derived lineage dimension that marks which candidates rest
+  on decisions and states that no longer stand. When a benchmark's
+  evaluations are retracted, taint reaches the selections that used them
+  and standing marks the descendant line compromised at any depth; one
+  reaffirming selection on surviving evidence restores it. Standing is
+  re-derived by every validator like the taint set, never embedded in a
+  receipt, and never merged into kernel taint or evidence
+  ([SPEC §7.2](SPEC.md); run `cargo run --example broken_benchmark`).
 - **Honest threat model.** Tamper-*evident*, not tamper-proof: replay
   detects any interior edit to committed history, but the ledger's owner
   can rewrite the whole log from genesis. SPEC §11 states this plainly and
@@ -172,11 +187,16 @@ bellbook validate receipt.json --json   # same report as JSON
 ```
 
 Exit codes: `0` clean, `1` invalid, `2` valid-but-tainted. See SPEC §12
-for the receipt format and the normative truth rules. One honesty note:
+for the receipt format and the normative truth rules. Two honesty notes.
 **Clean is relative to the rules embedded in the receipt** (compare the
 reported `rules_hash` against a rule set you trust) - under default rules
 it means "internally consistent", not "meets a shared security
-baseline".
+baseline". And a receipt proves the recorded *process*, not source
+contents: a `Candidate`'s Git OIDs are pointers the repository resolves,
+and the **lineage, standing, and taint guarantees are conditional on the
+producer's recording discipline** - `basis`, `parent`, and refs are
+producer claims a verifier cannot check against intent
+([SPEC §13](SPEC.md#13-known-limitations)).
 
 ## Recording evolution (CLI)
 
@@ -222,36 +242,40 @@ restored (with the retraction and taint permanently on the record).
 
 ## Status
 
-**This branch develops spec v0.3 (evolution semantics: Candidate,
-Evaluation, and Selection records with replay-derived lineage standing);
-the published release remains 0.2.0, implementing spec v0.2.** The v0.3
-design is in [`spec/v0.3-delta.md`](spec/v0.3-delta.md); progress is
-tracked in issue #19.
+**`main` implements spec v0.3 (evolution semantics: Candidate, Evaluation,
+and Selection records with replay-derived lineage standing), fully tested
+but not yet published as a crate release; the last published epoch is
+0.2.0, implementing spec v0.2.** SPEC.md is the authority for what v0.3
+means (design notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)); the
+v0.3 milestone is tracked in issue #19. The v0.2 artifacts stay frozen and
+valid under v0.2 rules forever, and the published 0.2.x release is their
+validator.
 
-**Bellbook 0.2 is an early release. Its implemented compatibility contract is
-defined by the SPEC.md shipped with the 0.2.0 release (this `main` now
-develops spec 0.3) and the committed v0.2 test vectors.**
 It ships exactly what is implemented and tested today: the
 content-addressed (JCS-canonical) record model, the deterministic verifier
 with replayable `verify_log` (identity-to-role binding, authority binding
 and revocation, single-use exact approvals, explicit request lifecycle,
-advisory plan consistency checks), Ed25519
-signatures, retraction with taint, derived state with
-incremental/full-build equivalence, checkpoints, the crash-safe writer
-with idempotent compare-and-append, and portable receipts with the
-offline `bellbook validate` CLI - fully tested (every rejection reason
-code has a triggering test), clippy-clean, no `unsafe`, no panics in
-library code.
+advisory plan consistency checks), Ed25519 signatures, retraction with
+taint, the v0.3 evolution kinds (Candidate / Evaluation / Selection) with
+source binding, the selection and reaffirmation rule battery, and the
+replay-derived standing section, derived state with incremental/full-build
+equivalence, checkpoints, the crash-safe writer with idempotent
+compare-and-append, and portable receipts with the offline `bellbook
+validate` CLI and the `candidate`/`eval`/`select`/`lineage` recording
+commands - fully tested (every rejection reason code has a triggering
+test), clippy-clean, no `unsafe`, no panics in library code.
 
 The repository also carries a language-neutral **conformance corpus**
-(`spec/conformance/v0.2/`: record, malformed, and receipt-replay cases,
-run by `tests/conformance.rs`) and an **independent Python implementation**
-of the verifier (`conformance/python/`) that shares no code with this crate,
-recomputes every record id, and re-derives every verdict across the corpus,
-agreeing with this reference on every case - including the deliberately
-malformed and forged inputs it must reject.
+(`spec/conformance/v0.3/`: record, malformed, receipt-replay, and standing
+cases, run by `tests/conformance.rs`; the frozen `spec/conformance/v0.2/`
+corpus stays valid under v0.2 rules) and an **independent Python
+implementation** of the verifier (`conformance/python/`) that shares no
+code with this crate, recomputes every record id, and re-derives every
+verdict and standing section across the corpus, agreeing with this
+reference on every case - including the deliberately malformed and forged
+inputs it must reject.
 
-Open work, **not implemented in v0.2**:
+Open work, **not implemented**:
 
 1. **`bellbook-core-v1` baseline profile** - a fixed minimum rule set
    (required signatures, pinned keys, evidence thresholds) for comparing

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ embeds.
   reaffirming selection on surviving evidence restores it. Standing is
   re-derived by every validator like the taint set, never embedded in a
   receipt, and never merged into kernel taint or evidence
-  ([SPEC §7.2](SPEC.md); run `cargo run --example broken_benchmark`).
+  ([SPEC §7.2](SPEC.md#72-standing); run `cargo run --example
+  broken_benchmark`).
 - **Honest threat model.** Tamper-*evident*, not tamper-proof: replay
   detects any interior edit to committed history, but the ledger's owner
   can rewrite the whole log from genesis. SPEC §11 states this plainly and
@@ -192,8 +193,11 @@ for the receipt format and the normative truth rules. Two honesty notes.
 reported `rules_hash` against a rule set you trust) - under default rules
 it means "internally consistent", not "meets a shared security
 baseline". And a receipt proves the recorded *process*, not source
-contents: a `Candidate`'s Git OIDs are pointers the repository resolves,
-and the **lineage, standing, and taint guarantees are conditional on the
+contents: a `Candidate`'s Git OIDs are pointers the repository resolves
+(under `manifest` binding a party holding the tree can recompute the hash
+and bind the receipt to actual contents; under `reported` binding it is a
+verifiable record of an unverified claim, and the receipt says which), and
+the **lineage, standing, and taint guarantees are conditional on the
 producer's recording discipline** - `basis`, `parent`, and refs are
 producer claims a verifier cannot check against intent
 ([SPEC §13](SPEC.md#13-known-limitations)).
@@ -215,6 +219,11 @@ bellbook select        --log <dir> --rules <file> --author <id> --objective <s> 
          --consider <id>... (--choose <id>... --uses-eval <id>... | --none) [--replaces <sel>]
 bellbook lineage       --log <dir> --rules <file> <id> [--json]
 ```
+
+The grammar above shows the load-bearing flags; optional ones
+(`--git-commit`, `--algo`, `--manifest`, `--note`, `--procedure`,
+`--uses`, `--rationale`, and `--json` on every command) are omitted for
+brevity. Run `bellbook` with no arguments for the full usage.
 
 **The log is single-writer by design.** `LogWriter` takes an exclusive
 lock on the directory for the life of the process, so exactly one
@@ -289,7 +298,7 @@ Open work, **not implemented**:
    the validator reports per-profile conformance instead of trusting
    the declaration.
 4. **Python bindings** - PyO3/maturin wheels wrapping this same core
-   (validation-first), once the v0.2 format is frozen by a release.
+   (validation-first), once the current spec epoch is frozen by a release.
 5. **Interop mapping** - a short document mapping Bellbook records
    outward to OpenTelemetry logs, W3C PROV, in-toto statements, and
    SCITT receipts, rather than inventing adjacent layers (the boundary

--- a/SPEC.md
+++ b/SPEC.md
@@ -376,7 +376,7 @@ payload lookup.
   uses `Cause`, not `Require`, deliberately: a candidate's evidence reflects
   its own content and a tainted history must never block recording ongoing
   work; the lineage consequence of the anchor's health is carried by
-  standing (§7.2, not yet implemented);
+  standing (§7.2);
 - an `Evaluation` must `Use` the record named in its `candidate` field (the
   epistemic subject edge, so a retracted candidate taints its evaluations),
   else `EvaluationInvalid`; `criterion` non-empty and `outcome` within the
@@ -1043,9 +1043,9 @@ Future receipt profiles should prevent silence from being mistaken for
 evidence. In particular, a profile that introduces required claims or
 verification attempts should define explicit representations for
 conflicting evidence, checks that did not run or failed open, and values
-that were not measured. The v0.2 core has no `Inconclusive` result,
+that were not measured. The current core has no `Inconclusive` result,
 Requirement record, or verification-attempt record, so these principles
-are intentionally not part of v0.2 conformance.
+are intentionally not part of core conformance.
 
 Existing core mechanisms still preserve useful facts without erasure:
 refusals record work that was not performed, rejected records remain in

--- a/SPEC.md
+++ b/SPEC.md
@@ -1111,6 +1111,28 @@ reference implementation's own test suite exercises instead.
   integration instruments its runtime, which is outside this spec.
   (External anchoring, §11.1, bounds *when* history could have been
   edited; it cannot conjure records that were never written.)
+- **A receipt carries no source contents.** A `Candidate`'s Git OIDs are
+  pointers whose resolution requires the repository; the receipt proves the
+  recorded process (which candidates, evaluations, and selections existed,
+  under what objective, and what is retracted, tainted, or
+  standing-compromised), not the bytes of any tree. Under `manifest`
+  binding a party holding the tree can recompute `manifest_hash` and bind
+  the receipt to actual contents; under `reported` binding they hold a
+  verifiable record of an unverified claim, and the receipt says which,
+  explicitly.
+- **Lineage, standing, and taint are conditional on the producer's
+  recording discipline.** A candidate's `basis`, `parent`, and choice of
+  refs are producer claims. A host that records what is really a
+  continuation as a derivation escapes the standing cascade, and no
+  verifier can detect that, because intent is not checkable. Bellbook proves
+  the recorded structure is internally consistent under its rules; it does
+  not prove the structure faithfully mirrors the development process. A
+  receipt consumer trusts the embedded `rules_hash` *and* the producer's
+  recording conventions - this is the "consistency, not completeness"
+  boundary above, extended one level to the lineage graph. Standing is a
+  replay-derived advisory over that recorded structure, reported alongside
+  kernel taint and never merged into it: it never gates a commit by default
+  and never changes a record's evidence.
 - Author identity is cryptographically bound only for actors pinned in
   `author_keys` on records that carry signatures; unsigned records (and
   unpinned actors) remain claims. Key management and rotation are host

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,9 +1,10 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
-**Status:** Draft, revision 5. This document specifies the design for spec
-v0.3. Nothing in it is implemented; nothing in it changes spec v0.2 or the
-published crate. Kind names and field spellings are tentative until
-accepted.
+**Status:** Accepted (revision 5). This document specifies the design for
+spec v0.3, which is implemented on `main` and normatively described by
+[SPEC.md](../../SPEC.md); it does not change spec v0.2 or the last published
+crate (0.2.0), and spec v0.3 remains unreleased as a crate. Where this
+design and SPEC.md differ, SPEC.md is authoritative.
 
 **Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
 *verifiable candidate selection and lineage for autonomous coding agents*,


### PR DESCRIPTION
Documentation consistency pass for the v0.3 evolution release. Brings
README, SPEC, and RFC-0001 into agreement about the present, and states the
receipt boundary and producer-discipline conditionality that RFC-0001 §11
mandates for SPEC §13.

## README

- New "Evolution semantics" entry in *How it works*: the three kinds
  (Candidate, Evaluation, Selection), source binding, and the replay-derived
  standing section.
- Receipt-validation honesty note extended: a receipt proves the recorded
  *process*, not source contents (reported vs manifest binding), and
  lineage/standing/taint are conditional on the producer's recording
  discipline.
- Status rewritten to match SPEC's framing: `main` implements spec v0.3,
  fully tested but not yet published; last published epoch is 0.2.0; v0.2
  artifacts frozen. Shipped-features list now includes the evolution kinds,
  the selection/reaffirmation rules, standing, and the recording CLI; corpus
  reference points at `spec/conformance/v0.3/`.
- Dropped stale present-tense v0.2 phrasing; CLI grammar marked as
  abbreviated with a pointer to full usage.

## SPEC

- §13 gains the two evolution boundaries required by RFC §11: a receipt
  carries no source contents (reported vs manifest binding), and lineage /
  standing / taint are conditional on producer recording discipline -
  extending "consistency, not completeness" one level to the lineage graph.
- Removed a stale "(§7.2, not yet implemented)" aside; standing is
  implemented. Made a present-tense "v0.2 core / v0.2 conformance" passage
  version-neutral.

## RFC-0001

- Status block corrected from "Draft ... nothing in it is implemented" to
  Accepted and implemented on `main` (SPEC.md authoritative), still
  unreleased as a crate.

## Consistency check

A cross-document read (the issue's acceptance test) confirms: no document
contradicts another about the present; the three kinds, standing, and the
CLI are covered without over-claiming; the receipt-boundary and
producer-discipline conditionality appear in both README and SPEC §13; the
honesty sections match SPEC §13; and every internal cross-reference
resolves.

No code or spec-artifact changes; the library test suite, `cargo fmt
--check`, and the em-dash/style checks pass.

Closes #33