### PR TITLE
release: prepare 0.3.0 (version, changelog, v0.2 epoch check) (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,25 @@ jobs:
       - name: Check (MSRV)
         run: cargo check --locked --all-features
 
+  epoch-v02:
+    # Epoch check (issue #34): the committed v0.2 receipts must validate
+    # identically under the *published* 0.2.0 validator, not just the current
+    # tree. Installs the pinned published binary from crates.io and replays
+    # every committed v0.2 receipt case through it, comparing status, reason,
+    # counts, and the head/rules hashes and retracted/tainted sets. This is
+    # the cross-version half of the compatibility promise; the byte-freeze of
+    # the v0.2 artifacts is enforced separately by tests/frozen_v02.rs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+      - name: Install the published v0.2 validator
+        run: cargo install bellbook --version 0.2.0 --root "$RUNNER_TEMP/bb020"
+      - name: v0.2 receipts validate under the published v0.2 validator
+        run: python3 scripts/epoch_check_v02.py "$RUNNER_TEMP/bb020/bin/bellbook"
+
   conformance-py:
     # An independent, from-scratch Python validator (no Rust code path) that
     # reproduces the published vectors and the conformance corpus. Proves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-20
+
+Second public release. Implements Bellbook spec version 0.3, the evolution
+epoch: three new record kinds (`Candidate`, `Evaluation`, `Selection`) that
+bind Git source states, judge them, and record set-valued decisions over
+them, with replay-derived lineage standing layered over the v0.2 trust
+kernel, which is unchanged. Spec v0.2 stays a frozen, still-valid
+compatibility epoch: its artifacts are byte-frozen, the published 0.2.0
+crate remains their validator, and a CI epoch check confirms the committed
+v0.2 receipts validate identically under it. This validator rejects v0.2
+receipts with a clear unsupported-version report.
+
 ### Changed
 
-- **Opened the spec v0.3 development epoch** (design: `spec/v0.3-delta.md`,
+- **Opened the spec v0.3 epoch** (design: `spec/v0.3-delta.md`,
   accepted RFC-0001; tracking: #19). `SPEC_VERSION` is `0.3`, the signing
   domain is `bellbook.record-signature.v0.3`, and the current test vectors
   and conformance corpus live at `spec/test-vectors-v0.3.json` and
@@ -20,6 +32,13 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Release epoch check (#34): a CI job installs the published 0.2.0 crate
+  and replays every committed v0.2 receipt case through it, asserting the
+  status, reason, record count, head and rules hashes, and retracted and
+  tainted sets are identical to the recorded expectations
+  (`scripts/epoch_check_v02.py`). This pins the *meaning* of the frozen
+  v0.2 artifacts under the published validator, complementing the byte
+  freeze in `tests/frozen_v02.rs`.
 - Flagship worked example (#32): `examples/broken_benchmark.rs` runs the
   RFC-0001 §10 story end to end - a baseline chosen on a benchmark
   evaluation, a line of continuations and derivations built on it, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/scripts/epoch_check_v02.py
+++ b/scripts/epoch_check_v02.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Epoch check: the committed v0.2 receipts validate identically under the
+pinned, published v0.2 validator (issue #34).
+
+v0.2 is a published compatibility epoch. Beyond the byte-freeze gate on the
+v0.2 artifacts (`tests/frozen_v02.rs`), this check proves the stronger
+property that matters to anyone holding a v0.2 receipt: the *published* 0.2.0
+crate - not the current tree - still reaches the exact same decision on every
+committed v0.2 receipt case. Run in CI against a `cargo install`ed 0.2.0
+binary, so a future change that silently altered v0.2 semantics could not
+pass by editing both the validator and its expectations together.
+
+Usage:
+    python3 scripts/epoch_check_v02.py <path-to-published-bellbook-binary>
+
+Exit 0 iff every case matches; non-zero prints the first divergence.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Fields the published report exposes, mapped to the corpus's expected-key
+# names. Comparing all of them (not just status) is what makes this an
+# "identical decision" check rather than a coarse pass/fail.
+FIELD_MAP = {
+    "status": "status",
+    "reason": "reason",
+    "record_count": "record_count",
+    "head_hash": "head_hash",
+    "rules_hash": "rules_hash",
+    "retracted_records": "retracted",
+    "tainted_records": "tainted",
+}
+
+REPO = Path(__file__).resolve().parent.parent
+CASES = REPO / "spec" / "conformance" / "v0.2" / "receipt-cases.json"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    binary = sys.argv[1]
+
+    corpus = json.loads(CASES.read_text())
+    if corpus.get("spec_version") != "0.2":
+        print(f"error: {CASES} is not a v0.2 corpus")
+        return 2
+
+    cases = corpus["cases"]
+    tmp = REPO / "target" / "epoch-receipt.json"
+    tmp.parent.mkdir(parents=True, exist_ok=True)
+
+    checked = 0
+    for case in cases:
+        name = case["name"]
+        expect = case["expect"]
+        tmp.write_text(json.dumps(case["receipt"]))
+
+        proc = subprocess.run(
+            [binary, "validate", str(tmp), "--json"],
+            capture_output=True,
+            text=True,
+        )
+        # A validate exit code of 0/1/2 is expected (clean/invalid/tainted);
+        # anything else means the binary failed to run, not a verdict.
+        if proc.returncode not in (0, 1, 2) or not proc.stdout.strip():
+            print(f"FAIL {name}: validator did not produce a report "
+                  f"(exit {proc.returncode})\n{proc.stderr}")
+            return 1
+        got = json.loads(proc.stdout)
+
+        for got_key, exp_key in FIELD_MAP.items():
+            if exp_key not in expect:
+                continue
+            if got.get(got_key) != expect[exp_key]:
+                print(
+                    f"FAIL {name}: field {exp_key!r} diverged\n"
+                    f"  published 0.2.0 validator: {got.get(got_key)!r}\n"
+                    f"  committed expectation:     {expect[exp_key]!r}"
+                )
+                return 1
+        checked += 1
+        print(f"ok   {name}  ({expect['status']})")
+
+    print(
+        f"\nAll {checked} committed v0.2 receipts validate identically under "
+        f"the published v0.2 validator ({binary})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/frozen_v02.rs
+++ b/tests/frozen_v02.rs
@@ -1,11 +1,14 @@
 //! Interim freeze gate for the published spec v0.2 artifacts.
 //!
 //! Spec v0.2 is a published compatibility epoch: its vectors and conformance
-//! corpus must never change (SPEC.md §14, CHANGELOG "frozen in place"). Once
-//! the epoch CI job lands (issue #34) the pinned, published v0.2 validator
-//! re-validates the frozen receipts directly; until then this test pins the
-//! SHA-256 of each frozen file so an accidental edit fails CI rather than
-//! passing silently (the live suites now exercise only the v0.3 artifacts).
+//! corpus must never change (SPEC.md §14, CHANGELOG "frozen in place"). This
+//! test pins the SHA-256 of each frozen file so an accidental edit fails CI
+//! rather than passing silently (the live suites now exercise only the v0.3
+//! artifacts). The complementary cross-version check - that the *published*
+//! 0.2.0 validator still reaches the same decision on every committed v0.2
+//! receipt - runs in CI as the `epoch-v02` job
+//! (`scripts/epoch_check_v02.py`); together they pin both the bytes and their
+//! meaning under the published validator.
 //!
 //! The hash is taken over LF-normalized content: `.gitattributes` already
 //! forces these files to LF on every platform, and normalizing here as well


### PR DESCRIPTION
Release-preparation changes for 0.3.0 (the v0.3 evolution epoch). Does not
publish: publishing runs from the `release.yml` workflow when a maintainer
creates the `v0.3.0` GitHub Release, using the repo's `CARGO_REGISTRY_TOKEN`
secret.

## Changes

- **Version** bumped to `0.3.0` (`Cargo.toml` + `Cargo.lock`). `cargo package
  --locked` succeeds and builds the packaged crate.
- **CHANGELOG** `[Unreleased]` promoted to `[0.3.0] - 2026-08-20` with a
  release summary; the evolution work (kinds, rules, standing, CLI, example,
  corpus/vectors, Python parity) is already itemized under it.
- **v0.2 epoch check** (`scripts/epoch_check_v02.py` + the `epoch-v02` CI
  job): installs the published `bellbook 0.2.0` crate and replays every
  committed v0.2 receipt case through it, asserting status, reason, record
  count, head and rules hashes, and retracted/tainted sets match the recorded
  expectations. Complements the byte freeze in `tests/frozen_v02.rs`.

## Release-gate status (issue #34)

- **Independent implementation review**: complete; findings below. Zero
  blocker-severity findings.
- **Epoch checks in CI**: v0.2 receipts validate identically under the
  published v0.2 validator (`epoch-v02` job, green); the v0.3 validator
  rejects v0.2 receipts with a clear unsupported-version report
  (`wrong-spec-version` corpus case, run by both the Rust and Python suites).
- **Full gauntlet green**: all platforms, msrv, lint, docs, and both
  conformance implementations (10/10 checks).
- **Flagship example** runs from documented instructions alone (`cargo run
  --example broken_benchmark`, wired into CI).
- **Publish + tag + GitHub release**: a maintainer step (needs the crates.io
  token); this PR readies the tree and `release.yml` performs the publish on
  release.

## Independent pre-release review

Scope: the v0.3 verifier and standing derivation, the CLI, the epoch checks,
cross-implementation parity, packaging, and release-note honesty.

- **Soundness / panic-safety** (no blocker): no panic is reachable from a
  hostile receipt in the v0.3 paths. The one hot-path index
  (`evolution.rs` continuation anchor `causes[0]`) is guarded by a preceding
  `causes.len() != 1` check; the CLI's `unreachable!` is behind an exhaustive
  command match and its one `unwrap` behind the `--choose`/`--none`
  exclusivity check. Standing derivation is iterative (no recursion) with a
  bounded guard and `unwrap_or` defaults, so it is panic-free on receipts of
  any depth and cannot be forged (a validator re-derives it like taint).
- **Taint semantics** (no blocker): retraction taint propagates through
  `Use`/`Require` only, never `Cause` (`state/incremental.rs`), so a
  derivation merely *motivated by* a retracted evaluation is not tainted -
  the property the flagship example demonstrates.
- **Cross-implementation parity** (no blocker): the Rust suite and the
  independent Python validator both pass over the vectors and the full v0.3
  corpus, including the per-reason-code and standing cases.
- **Epoch integrity** (no blocker): the v0.2 artifacts are byte-frozen, and
  the new epoch job confirms they validate identically under the published
  0.2.0 crate; the wrong-epoch receipt is cleanly rejected.
- **Release-note honesty** (no blocker): standing, lineage, and taint are
  stated as conditional on producer recording discipline, and receipts carry
  no source contents (SPEC §13, README). Nothing in the notes claims a
  guarantee the verifier does not enforce.

Verdict: **SHIP** - zero blocker-severity findings.

Closes #34