### PR TITLE
ci: publish on a pushed v* tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*.*.*"
   release:
     types: [published]
 


### PR DESCRIPTION
Lets the release workflow run when a semver tag (`v*.*.*`) is pushed, in
addition to when a GitHub Release is published. This makes it possible to
cut the `0.3.0` release by pushing the `v0.3.0` tag alone.

The existing tag-vs-crate-version guard is unchanged and works for both
triggers: `GITHUB_REF_NAME` is the tag name whether the event is a tag push
or a published release, so a mismatched tag still fails the job before any
publish.

No code changes; CI is unaffected.