### PR TITLE
ci: allow manual release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  # Manual publish: run the workflow from a branch (used when the release
+  # cannot be cut by pushing a tag). Publishes the version in Cargo.toml.
+  workflow_dispatch:
+  # Tag or GitHub Release: publish the tagged version, with a tag/version guard.
   push:
     tags:
       - "v*.*.*"
@@ -19,14 +23,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: stable
-      - name: Verify tag matches crate version
+      - name: Verify version
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
           CRATE="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
-          echo "release tag: $TAG   crate version: $CRATE"
-          if [ "$TAG" != "$CRATE" ]; then
-            echo "::error::Release tag ($TAG) does not match Cargo.toml version ($CRATE)"
-            exit 1
+          echo "crate version: $CRATE"
+          # For a tag push or a published release, the ref is the tag; require
+          # it to match the crate version so a mistaken tag never publishes.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            echo "release tag: $TAG"
+            if [ "$TAG" != "$CRATE" ]; then
+              echo "::error::Release tag ($TAG) does not match Cargo.toml version ($CRATE)"
+              exit 1
+            fi
+          else
+            echo "manual dispatch on ${GITHUB_REF_NAME}: publishing crate version $CRATE"
           fi
       - name: Verify package contents
         run: cargo package --locked


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the release workflow so a publish can
be run from a branch when cutting a release by pushing a tag or creating a
GitHub Release is not available in the current environment.

The version guard now branches on `GITHUB_REF_TYPE`: a tag push or a
published release must still match `Cargo.toml`'s version (unchanged
behavior), while a manual dispatch publishes the committed crate version and
logs it. `cargo publish` still refuses to overwrite an existing version, so
a duplicate dispatch is a clean no-op.

No code changes.