### PR TITLE
ci: make crates.io publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,21 @@ jobs:
       - name: Verify package contents
         run: cargo package --locked
       - name: Publish
-        run: cargo publish --locked
+        run: |
+          set +e
+          out="$(cargo publish --locked 2>&1)"
+          code=$?
+          echo "$out"
+          if [ $code -eq 0 ]; then
+            exit 0
+          fi
+          # Idempotent: a re-run for a version already on crates.io (e.g. when
+          # a tag or GitHub Release is created after a manual publish) is not a
+          # failure. Any other error still fails the job.
+          if echo "$out" | grep -qiE "already (uploaded|exists)|is already uploaded"; then
+            echo "::notice::crate version already published; treating as success"
+            exit 0
+          fi
+          exit $code
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Treats a publish of a version already on crates.io as success rather than a
job failure. Re-triggering the release workflow — for example creating the
`v0.3.0` tag or GitHub Release after the version was already published via a
manual dispatch — otherwise shows a spurious red run when `cargo publish`
errors on the duplicate. Any other `cargo publish` error still fails the
job.

No code changes.