### PR TITLE
docs: reflect the 0.3.0 release in status/preamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,12 @@ restored (with the retraction and taint permanently on the record).
 
 ## Status
 
-**`main` implements spec v0.3 (evolution semantics: Candidate, Evaluation,
-and Selection records with replay-derived lineage standing), fully tested
-but not yet published as a crate release; the last published epoch is
-0.2.0, implementing spec v0.2.** SPEC.md is the authority for what v0.3
-means (design notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)); the
-v0.3 milestone is tracked in issue #19. The v0.2 artifacts stay frozen and
-valid under v0.2 rules forever, and the published 0.2.x release is their
+**The published release is 0.3.0, implementing spec v0.3 (evolution
+semantics: Candidate, Evaluation, and Selection records with replay-derived
+lineage standing).** SPEC.md is the authority for what v0.3 means (design
+notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)). The previous epoch,
+0.2.0 implementing spec v0.2, stays published and frozen: its artifacts
+remain valid under v0.2 rules forever, and the 0.2.x release is their
 validator.
 
 It ships exactly what is implemented and tested today: the

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,14 +1,12 @@
 # Bellbook specification
 
-**Spec version: 0.3 (in development, unreleased).** The last published
-epoch is 0.2; its artifacts remain valid under v0.2 rules forever, and the
+**Spec version: 0.3 (published as `bellbook` 0.3.0).** The previous epoch
+is 0.2; its artifacts remain valid under v0.2 rules forever, and the
 published 0.2.x release is their validator (§14). This document is
 versioned independently of the `bellbook` crate; the crate's CHANGELOG
-states which spec version each release implements (see §14). The remaining
-v0.3 rules land section by section from
-[`spec/v0.3-delta.md`](spec/v0.3-delta.md), each together with its
-implementation, so this document always describes what the implementation
-does.
+states which spec version each release implements (see §14). The v0.3
+design notes are in [`spec/v0.3-delta.md`](spec/v0.3-delta.md); this
+document is the normative description of what the implementation does.
 
 This document is **normative**: conformance is defined by this
 specification, not by any implementation. Where the reference

--- a/docs/rfcs/0001-evolution-semantics.md
+++ b/docs/rfcs/0001-evolution-semantics.md
@@ -1,10 +1,10 @@
 # RFC-0001: Software-evolution semantics (spec v0.3)
 
 **Status:** Accepted (revision 5). This document specifies the design for
-spec v0.3, which is implemented on `main` and normatively described by
-[SPEC.md](../../SPEC.md); it does not change spec v0.2 or the last published
-crate (0.2.0), and spec v0.3 remains unreleased as a crate. Where this
-design and SPEC.md differ, SPEC.md is authoritative.
+spec v0.3, which is implemented and normatively described by
+[SPEC.md](../../SPEC.md) and released as `bellbook` 0.3.0; it does not
+change spec v0.2 or the 0.2.0 crate. Where this design and SPEC.md differ,
+SPEC.md is authoritative.
 
 **Scope anchor:** the wedge defined in [VISION.md](../VISION.md#next--v03-the-wedge-under-design):
 *verifiable candidate selection and lineage for autonomous coding agents*,


### PR DESCRIPTION
Now that 0.3.0 is published to crates.io, three places still described spec
v0.3 as unreleased. This corrects them:

- **README Status** — 0.3.0 is the published release implementing spec v0.3;
  the previous epoch (0.2.0 / spec v0.2) stays published and frozen as the
  v0.2 validator. Removes the pointer to the now-closed #19 milestone.
- **SPEC preamble** — "Spec version: 0.3 (published as `bellbook` 0.3.0)"
  instead of "in development, unreleased", and drops the "remaining v0.3
  rules land section by section" framing now that the epoch is complete.
- **RFC-0001 status** — spec v0.3 is released as 0.3.0, not "unreleased as a
  crate".

Docs only; no code or spec-artifact changes.