### PR TITLE
bindings(python): stage 2 - receipt reading (#13)

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -13,12 +13,12 @@ to cross-check the specification.)
 
 ## Status
 
-Stage 1: validation only. `validate(bytes) -> Report` reaches the same
-Clean / Tainted / Invalid decision as the `bellbook validate` CLI, over the
-same core. Receipt reading and the writer API land in later stages (issue
-#13).
+Validation and reading. The writer API lands in a later stage (issue #13).
 
-## Use
+## Validate
+
+`validate(bytes) -> Report` reaches the same Clean / Tainted / Invalid
+decision as the `bellbook validate` CLI, over the same core.
 
 ```python
 import bellbook
@@ -39,6 +39,31 @@ Validation never raises for a bad receipt: an unparseable or failing receipt
 returns a `Report` with `status == "invalid"` and a `problem` or `reason`
 set. As with the CLI, **Clean is relative to the rules embedded in the
 receipt** - compare `rules_hash` against a rule set you trust.
+
+## Read
+
+`read(bytes) -> Receipt` parses a receipt for inspection. Reading does not
+verify - call `validate` for the decision.
+
+```python
+import json
+
+receipt = bellbook.read(open("receipt.json", "rb").read())
+
+print(receipt.spec_version, len(receipt))
+for r in receipt.records:
+    print(r.kind, r.time, r.author_id, r.author_type, r.evidence)
+    for ref in r.refs:
+        print("  ", ref["type"], "->", ref["target"])
+    payload = json.loads(r.payload_json)
+```
+
+A `Record` exposes `id`, `kind`, `time`, `author_id`, `author_type`,
+`signed`, `evidence`, `schema`, `refs`, and `payload_json`. The enum-valued
+fields (`kind`, `author_type`, `evidence`, and each ref's `type`) are the
+record's Rust variant names, e.g. `"Candidate"`, `"Provider"`, `"Reported"`,
+`"Use"`. `read` raises `ValueError` on bytes that are not a parseable
+receipt.
 
 ## Build from source
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,14 +1,25 @@
-//! Python bindings for Bellbook, Stage 1 (issue #13): offline receipt
-//! validation from Python.
+//! Python bindings for Bellbook (issue #13): offline receipt validation and
+//! reading from Python.
 //!
-//! `bellbook.validate(data: bytes) -> Report` wraps the crate's `validate`,
-//! so Python reaches the exact same Clean / Tainted / Invalid decision the
-//! Rust CLI does, over the same core. The writer API and receipt reading land
-//! in later stages; this stage is validation only.
+//! - `bellbook.validate(data: bytes) -> Report` wraps the crate's `validate`,
+//!   so Python reaches the exact same Clean / Tainted / Invalid decision the
+//!   Rust CLI does, over the same core.
+//! - `bellbook.read(data: bytes) -> Receipt` parses a receipt for inspection
+//!   (records, kinds, authors, evidence, refs, payloads). Reading does not
+//!   verify; call `validate` for the decision.
+//!
+//! The writer API lands in a later stage.
+
+// `#[pyfunction]` generates a result conversion that clippy reads as a
+// useless `PyErr -> PyErr` conversion for any `PyResult`-returning function.
+// It is a macro artifact, not our code, so allow it crate-wide.
+#![allow(clippy::useless_conversion)]
 
 use bellbook_core::{
-    hex_encode, validate as core_validate, Report as CoreReport, ValidationStatus,
+    hex_encode, validate as core_validate, Receipt as CoreReceipt, Record as CoreRecord,
+    Report as CoreReport, ValidationStatus,
 };
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -145,10 +156,156 @@ fn validate(data: &[u8]) -> Report {
     }
 }
 
+/// A parsed receipt, for inspection. Reading does not verify: call
+/// [`validate`] for the Clean / Tainted / Invalid decision. A record's fields
+/// are as recorded; only replay confirms they are consistent.
+#[pyclass(frozen, name = "Receipt", module = "bellbook")]
+struct Receipt {
+    inner: CoreReceipt,
+}
+
+#[pymethods]
+impl Receipt {
+    /// Spec version the receipt declares (e.g. `"0.3"`).
+    #[getter]
+    fn spec_version(&self) -> String {
+        self.inner.spec_version.clone()
+    }
+
+    /// The records in order, from genesis (subjects and verdicts).
+    #[getter]
+    fn records(&self) -> Vec<Record> {
+        self.inner
+            .records
+            .iter()
+            .cloned()
+            .map(|inner| Record { inner })
+            .collect()
+    }
+
+    /// Number of records (subjects and verdicts).
+    fn __len__(&self) -> usize {
+        self.inner.records.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Receipt(spec_version={:?}, records={})",
+            self.inner.spec_version,
+            self.inner.records.len()
+        )
+    }
+}
+
+/// One record in a receipt. A read-only view; strings for the enum-valued
+/// fields are the record's Rust variant names (`kind`, `author_type`,
+/// `evidence`, and each ref's `type`).
+#[pyclass(frozen, name = "Record", module = "bellbook")]
+struct Record {
+    inner: CoreRecord,
+}
+
+#[pymethods]
+impl Record {
+    /// Content-address id, lowercase hex.
+    #[getter]
+    fn id(&self) -> String {
+        hex_encode(&self.inner.id)
+    }
+
+    /// Record kind (e.g. `"Candidate"`, `"Selection"`, `"Verdict"`).
+    #[getter]
+    fn kind(&self) -> String {
+        format!("{:?}", self.inner.kind)
+    }
+
+    /// Logical time (1-based commit counter).
+    #[getter]
+    fn time(&self) -> u64 {
+        self.inner.time
+    }
+
+    /// Author actor id.
+    #[getter]
+    fn author_id(&self) -> String {
+        self.inner.author.id.clone()
+    }
+
+    /// Author role (`"User"`, `"Provider"`, `"System"`, `"Executor"`,
+    /// `"Verifier"`).
+    #[getter]
+    fn author_type(&self) -> String {
+        format!("{:?}", self.inner.author.type_)
+    }
+
+    /// Whether the author carries a signature.
+    #[getter]
+    fn signed(&self) -> bool {
+        self.inner.author.signature.is_some()
+    }
+
+    /// Evidence class (`"Deterministic"`, `"Verified"`, `"Reported"`,
+    /// `"Inferred"`, `"Assumed"`).
+    #[getter]
+    fn evidence(&self) -> String {
+        format!("{:?}", self.inner.evidence)
+    }
+
+    /// Schema id, lowercase hex.
+    #[getter]
+    fn schema(&self) -> String {
+        hex_encode(&self.inner.schema)
+    }
+
+    /// Typed edges to prior records, as `{"type": str, "target": hex}` dicts.
+    #[getter]
+    fn refs<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        self.inner
+            .refs
+            .iter()
+            .map(|r| {
+                let d = PyDict::new_bound(py);
+                d.set_item("type", format!("{:?}", r.type_))?;
+                d.set_item("target", hex_encode(&r.target))?;
+                Ok(d)
+            })
+            .collect()
+    }
+
+    /// The raw payload as a JSON string (parse with `json.loads`). This is the
+    /// record's canonical `data` bytes, decoded as UTF-8.
+    #[getter]
+    fn payload_json(&self) -> String {
+        String::from_utf8_lossy(&self.inner.data).into_owned()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Record(kind={:?}, time={}, id={}...)",
+            format!("{:?}", self.inner.kind),
+            self.inner.time,
+            &hex_encode(&self.inner.id)[..12]
+        )
+    }
+}
+
+/// Parse a receipt for inspection. Raises `ValueError` if the bytes are not a
+/// parseable receipt. Reading does not verify - use [`validate`] for the
+/// decision.
+#[pyfunction]
+fn read(data: &[u8]) -> PyResult<Receipt> {
+    CoreReceipt::from_bytes(data)
+        .map(|inner| Receipt { inner })
+        .map_err(|e| PyValueError::new_err(format!("not a parseable receipt: {e}")))
+}
+
 #[pymodule]
 fn bellbook(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(validate, m)?)?;
+    m.add_function(wrap_pyfunction!(read, m)?)?;
     m.add_class::<Report>()?;
+    m.add_class::<Receipt>()?;
+    m.add_class::<Record>()?;
     Ok(())
 }

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -1,0 +1,71 @@
+"""Stage 2: parse a receipt and inspect its records from Python."""
+
+import json
+import pathlib
+
+import pytest
+
+import bellbook
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+V03 = ROOT / "spec" / "conformance" / "v0.3" / "receipt-cases.json"
+
+
+def _first_receipt() -> bytes:
+    corpus = json.loads(V03.read_text())
+    return json.dumps(corpus["cases"][0]["receipt"]).encode()
+
+
+def test_read_exposes_records():
+    receipt = bellbook.read(_first_receipt())
+    assert receipt.spec_version == "0.3"
+    records = receipt.records
+    assert len(records) == len(receipt)
+    assert len(records) > 0
+
+    r = records[0]
+    # id and schema are 32-byte lowercase hex.
+    assert len(r.id) == 64 and r.id == r.id.lower()
+    assert len(r.schema) == 64
+    assert r.time == 1  # genesis is time 1
+    assert isinstance(r.kind, str) and r.kind
+    assert isinstance(r.author_id, str)
+    assert r.author_type in {"User", "Provider", "System", "Executor", "Verifier"}
+    # The payload round-trips through json.
+    assert isinstance(json.loads(r.payload_json), (dict, list))
+
+
+def test_records_pair_with_verdicts():
+    """Every subject record is followed by a Verdict, so a receipt over N
+    subjects has 2N records and exactly N verdicts."""
+    receipt = bellbook.read(_first_receipt())
+    kinds = [r.kind for r in receipt.records]
+    verdicts = [k for k in kinds if k == "Verdict"]
+    assert verdicts, "expected Verdict records"
+    assert len(kinds) == 2 * len(verdicts)
+
+
+def test_refs_are_typed_and_hex():
+    receipt = bellbook.read(_first_receipt())
+    for r in receipt.records:
+        for ref in r.refs:
+            assert set(ref.keys()) == {"type", "target"}
+            assert ref["type"] in {"Cause", "Use", "Require", "Replace"}
+            assert len(ref["target"]) == 64
+
+
+def test_evolution_kinds_present_in_v03_evolution_receipt():
+    """Find a receipt case that contains the evolution kinds and confirm they
+    are surfaced."""
+    corpus = json.loads(V03.read_text())
+    seen = set()
+    for case in corpus["cases"]:
+        receipt = bellbook.read(json.dumps(case["receipt"]).encode())
+        seen.update(r.kind for r in receipt.records)
+    for kind in ("Candidate", "Evaluation", "Selection"):
+        assert kind in seen, kind
+
+
+def test_read_rejects_garbage():
+    with pytest.raises(ValueError):
+        bellbook.read(b"not a receipt")


### PR DESCRIPTION
Stage 2 of the Python bindings (#13): read a receipt from Python. Still
distribution work, no new version and nothing published.

```python
import bellbook, json

receipt = bellbook.read(open("receipt.json", "rb").read())
print(receipt.spec_version, len(receipt))
for r in receipt.records:
    print(r.kind, r.time, r.author_id, r.author_type, r.evidence)
    for ref in r.refs:
        print("  ", ref["type"], "->", ref["target"])
    payload = json.loads(r.payload_json)
```

## What's here

- `read(bytes) -> Receipt`. Reading does **not** verify; `validate` remains
  the decision. `read` raises `ValueError` on bytes that are not a parseable
  receipt.
- `Receipt`: `spec_version`, `len()`, and `records`.
- `Record`: `id`, `kind`, `time`, `author_id`, `author_type`, `signed`,
  `evidence`, `schema`, `refs` (typed `{"type", "target"}` dicts), and
  `payload_json` (the canonical payload as a JSON string). The enum-valued
  fields carry the record's Rust variant names
  (`"Candidate"`, `"Provider"`, `"Reported"`, `"Use"`).

## Tests

`tests/test_read.py` parses the committed v0.3 receipts and checks record
count, subject/verdict pairing (2N records for N verdicts), typed hex refs,
that the evolution kinds (`Candidate`/`Evaluation`/`Selection`) are surfaced,
and that garbage raises. All 9 binding tests (stage 1 + 2) pass; the existing
`python-bindings` CI job builds the extension and runs them.

A crate-level `allow(clippy::useless_conversion)` silences a pyo3-macro
artifact on `PyResult`-returning pyfunctions.

## Not in this stage

The multi-platform abi3 **wheel matrix** (`maturin-action`, stage 3), the
writer API (stage 4), and the PyPI publish (stage 5, which will need the
PyPI credentials and your go). Tracked in #13.