### PR TITLE
bindings(python): stage 3 - wheel matrix and sdist (#13)

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,67 @@
+name: Python wheels
+
+# Stage 3 of the Python bindings (issue #13): build the abi3 wheels and the
+# sdist on every platform, so the package is proven buildable everywhere and
+# is one step from publishable. Publishing (PyPI) is a later stage and a
+# separate, credentialed workflow.
+
+on:
+  pull_request:
+    paths:
+      - "bindings/python/**"
+      - ".github/workflows/python-wheels.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bindings/python/**"
+      - ".github/workflows/python-wheels.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wheels:
+    name: wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build the abi3 wheel
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
+        with:
+          command: build
+          args: --release --out dist
+          working-directory: bindings/python
+          manylinux: auto
+      - name: Smoke test the built wheel
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-index --find-links bindings/python/dist bellbook
+          python -c "import bellbook; assert bellbook.__version__ == '0.3.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wheel-${{ matrix.os }}
+          path: bindings/python/dist/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build the sdist
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: bindings/python
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sdist
+          path: bindings/python/dist/*.tar.gz
+          if-no-files-found: error

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -17,6 +17,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bellbook"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfde4f3518d497a90cbc3fef706b6269c60536fffa743d27482d785452ae9bd6"
 dependencies = [
  "ed25519-dalek",
  "ryu-js",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -20,10 +20,12 @@ name = "bellbook"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Validation is feature-independent, so the wheel does not pull in `persist`.
-# Renamed to `bellbook_core` so it does not collide with this crate's own
-# library name (`bellbook`, the importable Python module).
-bellbook_core = { package = "bellbook", path = "../..", default-features = false }
+# Wraps the published crate (not a path dep), so the sdist and wheels are
+# installable from PyPI, and the bindings track a released core rather than
+# the working tree. Validation is feature-independent, so the wheel does not
+# pull in `persist`. Renamed to `bellbook_core` so it does not collide with
+# this crate's own library name (`bellbook`, the importable Python module).
+bellbook_core = { package = "bellbook", version = "0.3", default-features = false }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"] }
 
 # Own workspace: keep this crate out of the library crate's workspace.


### PR DESCRIPTION
Stage 3 of the Python bindings (#13): make the package build everywhere and
produce publishable artifacts. Still publishes nothing - that's Stage 5.

## Publishable dependency

The bindings now depend on the **published** `bellbook 0.3.0` crate (a
version dep from crates.io, not a path dep). A path dep cannot resolve from a
PyPI sdist; a version dep can, and it also means the bindings track a
released core rather than the working tree.

Verified locally: `maturin sdist` builds a tarball that **installs from
scratch in a clean venv** - it fetches the published core, compiles the
extension, and `import bellbook; bellbook.validate(...)` works. The abi3
wheel and the existing parity tests still build and pass.

## Wheel matrix

New `.github/workflows/python-wheels.yml`:

- Builds the **abi3 wheel** on ubuntu / macos / windows via
  `maturin-action` (manylinux `auto` on Linux), and **smoke-tests each built
  wheel** (install into a clean environment, import, run `validate`).
- Builds the **sdist**.
- Uploads wheels and sdist as artifacts.
- Runs on `bindings/python/**` changes, on `main`, and on demand
  (`workflow_dispatch`). Actions are SHA-pinned (maturin-action v1.51.0,
  upload-artifact v4.6.2).

## Not in this stage

The writer API (stage 4) and the PyPI publish (stage 5, a separate
credentialed workflow that needs your PyPI setup and explicit go). Tracked in
#13.