### PR TITLE
bindings(python): stage 4 - writer API (#13)

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -21,6 +21,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfde4f3518d497a90cbc3fef706b6269c60536fffa743d27482d785452ae9bd6"
 dependencies = [
  "ed25519-dalek",
+ "fs4",
  "ryu-js",
  "serde",
  "serde_json",
@@ -33,7 +34,15 @@ version = "0.3.0"
 dependencies = [
  "bellbook",
  "pyo3",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -147,10 +156,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "generic-array"
@@ -199,6 +228,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
@@ -334,6 +369,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -490,6 +538,21 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zeroize"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -22,11 +22,22 @@ crate-type = ["cdylib"]
 [dependencies]
 # Wraps the published crate (not a path dep), so the sdist and wheels are
 # installable from PyPI, and the bindings track a released core rather than
-# the working tree. Validation is feature-independent, so the wheel does not
-# pull in `persist`. Renamed to `bellbook_core` so it does not collide with
+# the working tree. Renamed to `bellbook_core` so it does not collide with
 # this crate's own library name (`bellbook`, the importable Python module).
-bellbook_core = { package = "bellbook", version = "0.3", default-features = false }
+#
+# The writer API (stage 4) records to a persistent, single-writer log, so the
+# wheel now enables the crate's `persist` feature (cross-platform file locking
+# via `fs4`, which builds on Linux, macOS, and Windows alike). Validation and
+# reading remain feature-independent.
+bellbook_core = { package = "bellbook", version = "0.3", default-features = false, features = [
+    "persist",
+] }
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"] }
+# The writer takes verifier rules as a JSON string (the same object embedded in
+# a receipt). serde_json parses it into the crate's `VerifierRules`; serde
+# bounds the pre-commit encode/decode round-trip that checks payload invariants.
+serde = "1"
+serde_json = "1"
 
 # Own workspace: keep this crate out of the library crate's workspace.
 [workspace]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -13,7 +13,7 @@ to cross-check the specification.)
 
 ## Status
 
-Validation and reading. The writer API lands in a later stage (issue #13).
+Validation, reading, and writing (issue #13).
 
 ## Validate
 
@@ -64,6 +64,55 @@ fields (`kind`, `author_type`, `evidence`, and each ref's `type`) are the
 record's Rust variant names, e.g. `"Candidate"`, `"Provider"`, `"Reported"`,
 `"Use"`. `read` raises `ValueError` on bytes that are not a parseable
 receipt.
+
+## Write
+
+`Writer(log_dir, rules)` records evolution to a persistent, single-writer log.
+It holds the same exclusive lock and runs the same replay-on-commit the Rust
+`LogWriter` does. `rules` is a JSON string: the verifier rules the log is
+committed under, the same object a receipt embeds under `rules`.
+
+```python
+import bellbook
+
+w = bellbook.Writer("./mylog", rules_json)
+
+c0 = w.candidate(author="agent", git_tree="a1b2...")            # a Root candidate
+e0 = w.evaluate(author="agent", candidate=c0.id, criterion="builds", passed=True)
+s0 = w.select(author="agent", objective="ship it",
+              consider=[c0.id], choose=[c0.id], uses_eval=[e0.id])
+
+print(c0.id, c0.accepted, c0.reason)   # each commit returns a Commit
+
+# Export and verify in the same process:
+report = bellbook.validate(w.receipt())
+assert report.status == "clean"
+```
+
+Each of `candidate`, `evaluate`, and `select` commits one record and returns a
+`Commit` (`id`, `accepted`, `result`, `reason`). A record is durably committed
+whether accepted or rejected - a rejected record is evidence a proposal was
+refused - so `accepted` may be `False` without an exception. Statically-knowable
+payload violations (an unregistered author, a score scale above 12, an upgrade
+whose tree differs from its target) raise `ValueError` before anything is
+written.
+
+- `candidate(author, git_tree, *, git_commit=None, algo="sha1", note=None,
+  continues=None, parent=None, derives_from=None, upgrades=None, manifest=None)`
+  - basis is exactly one of `continues` (with `parent`), `derives_from`, or
+    `upgrades`; omit all three for a Root. `manifest` (a directory path) binds
+    the source by a canonical manifest hash instead of a reported tree.
+- `evaluate(author, candidate, criterion, *, passed=False, failed=False,
+  score=None, scale=None, procedure=None, uses=None)` - exactly one of
+  `passed`, `failed`, or a `score` (with `scale`, a decimal exponent 0-12).
+- `select(author, objective, consider, *, choose=None, uses_eval=None,
+  none=False, replaces=None, rationale=None)` - exactly one of `choose` (with
+  `uses_eval`) or `none=True`; `replaces` reaffirms a prior selection.
+
+The writer is deliberately single-writer (SPEC 5.1): it holds an exclusive lock
+for the log directory, so a second `Writer` on the same directory raises. Other
+useful members: `w.head` (current head, hex), `w.records` (the committed
+records, as `Record`s), `len(w)`, and `w.receipt()` (portable receipt bytes).
 
 ## Build from source
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -7,8 +7,11 @@
 //! - `bellbook.read(data: bytes) -> Receipt` parses a receipt for inspection
 //!   (records, kinds, authors, evidence, refs, payloads). Reading does not
 //!   verify; call `validate` for the decision.
-//!
-//! The writer API lands in a later stage.
+//! - `bellbook.Writer(log_dir, rules)` records evolution to a persistent,
+//!   single-writer log: `candidate`, `evaluate`, and `select` each commit one
+//!   record and return a [`Commit`]. The writer holds the same exclusive lock
+//!   and runs the same replay-on-commit the Rust `LogWriter` does. Export the
+//!   log with `writer.receipt()` and feed it straight back to `validate`.
 
 // `#[pyfunction]` generates a result conversion that clippy reads as a
 // useless `PyErr -> PyErr` conversion for any `PyResult`-returning function.
@@ -16,12 +19,18 @@
 #![allow(clippy::useless_conversion)]
 
 use bellbook_core::{
-    hex_encode, validate as core_validate, Receipt as CoreReceipt, Record as CoreRecord,
-    Report as CoreReport, ValidationStatus,
+    decode, encode, hex_decode, hex_encode, manifest_from_dir, manifest_hash, schema_id,
+    validate as core_validate, verify_and_build_state, Author, BindingMode, CandidateBasis,
+    CandidateData, EvaluationData, EvaluationOutcome, GitSource, Kind, LogWriter, Proposal,
+    Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType, Report as CoreReport,
+    ScoredValue, SelectionData, SelectionOutcome, SourceAlgo, SourceBinding, State, ValidationStatus,
+    VerdictResult, VerifierRules, SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_SELECTION,
 };
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyBytes, PyDict};
+use std::collections::BTreeMap;
+use std::path::Path;
 
 /// The result of validating a receipt. A read-only view over the crate's
 /// `Report`; every field is re-derived by validation, never trusted from the
@@ -299,6 +308,484 @@ fn read(data: &[u8]) -> PyResult<Receipt> {
         .map_err(|e| PyValueError::new_err(format!("not a parseable receipt: {e}")))
 }
 
+// ---------------------------------------------------------------------------
+// Writer (persistent, single-writer log)
+// ---------------------------------------------------------------------------
+
+/// The outcome of committing one record. The record is durably appended and
+/// immediately judged by replay. A *rejected* record is still committed - it
+/// is durable evidence that a proposal was refused - so `accepted` is `False`
+/// and `reason` carries the verifier's reason code; the writer does not raise.
+#[pyclass(frozen, name = "Commit", module = "bellbook")]
+struct Commit {
+    /// Content-address id of the committed record, lowercase hex.
+    #[pyo3(get)]
+    id: String,
+    /// `True` if the record was accepted by replay, `False` if rejected.
+    #[pyo3(get)]
+    accepted: bool,
+    /// `"accept"` or `"reject"`.
+    #[pyo3(get)]
+    result: String,
+    /// Verifier reason code when the record was rejected.
+    #[pyo3(get)]
+    reason: Option<String>,
+}
+
+#[pymethods]
+impl Commit {
+    fn __repr__(&self) -> String {
+        format!(
+            "Commit(id={}..., accepted={}, reason={:?})",
+            &self.id[..12.min(self.id.len())],
+            if self.accepted { "True" } else { "False" },
+            self.reason
+        )
+    }
+}
+
+fn parse_id(hex: &str) -> PyResult<RecordId> {
+    hex_decode(hex).ok_or_else(|| PyValueError::new_err(format!("invalid record id {hex:?}")))
+}
+
+/// Encode a payload, then decode it back so the payload's `TryFrom` invariants
+/// (score bounds, non-empty criterion/objective) are checked before the write,
+/// exactly as the CLI does. Without this a statically-knowable violation would
+/// serialize, commit, and only then reject as a durable record with an opaque
+/// reason; here it is a clean `ValueError` and nothing is written.
+fn checked_encode<T>(value: &T) -> PyResult<Vec<u8>>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    let bytes = encode(value).map_err(|e| PyValueError::new_err(format!("{e}")))?;
+    decode::<T>(&bytes).map_err(|e| PyValueError::new_err(format!("invalid payload: {e}")))?;
+    Ok(bytes)
+}
+
+/// Records evolution to a persistent, single-writer log. A thin wrapper over
+/// the crate's `LogWriter`: it holds the same exclusive `.lock`, re-verifies
+/// the existing log on open, and replays every commit. Rules are the verifier
+/// rules the log is committed under, given as a JSON string (the same object a
+/// receipt embeds under `rules`).
+///
+/// Concurrency (SPEC 5.1): the log is deliberately single-writer. Generate
+/// candidates concurrently, then record them serially through one `Writer`.
+#[pyclass(unsendable, name = "Writer", module = "bellbook")]
+struct Writer {
+    inner: LogWriter,
+    rules: VerifierRules,
+    state: State,
+}
+
+impl Writer {
+    /// Resolve an actor id to an `Author` via the rules' `author_roles`. The
+    /// declared role on a record is never trusted; the writer binds the role
+    /// from the rules, so an unregistered author is refused before any write.
+    fn resolve_author(&self, id: &str) -> PyResult<Author> {
+        let type_ = self.rules.author_roles.get(id).copied().ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "author {id:?} is not registered in the rules' author_roles"
+            ))
+        })?;
+        Ok(Author {
+            id: id.to_string(),
+            type_,
+            signature: None,
+        })
+    }
+
+    fn do_commit(
+        &mut self,
+        author: Author,
+        kind: Kind,
+        schema: bellbook_core::SchemaId,
+        data: Vec<u8>,
+        refs: Vec<Ref>,
+    ) -> PyResult<Commit> {
+        let proposal = Proposal {
+            space: self.rules.space,
+            // Single-thread writer: thread == space id, as the CLI does.
+            thread: self.rules.space,
+            author,
+            kind,
+            schema,
+            data,
+            refs,
+        };
+        let (id, verdict) = self
+            .inner
+            .commit(proposal, &self.rules, &mut self.state)
+            .map_err(|e| PyRuntimeError::new_err(format!("commit failed: {e}")))?;
+        let accepted = verdict.result == VerdictResult::Accept;
+        Ok(Commit {
+            id: hex_encode(&id),
+            accepted,
+            result: if accepted { "accept" } else { "reject" }.to_string(),
+            reason: verdict.reason.map(|r| format!("{r:?}")),
+        })
+    }
+}
+
+#[pymethods]
+impl Writer {
+    /// Open (or create) the log at `log_dir` under `rules` (a JSON string).
+    /// Rebuilds and re-verifies state from the committed records; raises if the
+    /// existing log does not verify, or if another writer holds the lock.
+    #[new]
+    #[pyo3(signature = (log_dir, rules))]
+    fn new(log_dir: &str, rules: &str) -> PyResult<Self> {
+        let rules: VerifierRules = serde_json::from_str(rules)
+            .map_err(|e| PyValueError::new_err(format!("invalid rules JSON: {e}")))?;
+        let inner = LogWriter::open(Path::new(log_dir), &rules)
+            .map_err(|e| PyRuntimeError::new_err(format!("cannot open log: {e}")))?;
+        let state = verify_and_build_state(inner.records(), &rules).map_err(|_| {
+            PyValueError::new_err("the existing log does not verify under these rules")
+        })?;
+        Ok(Writer {
+            inner,
+            rules,
+            state,
+        })
+    }
+
+    /// Record a Candidate (a proposed source state). Basis is chosen by exactly
+    /// one of `continues` (with `parent`), `derives_from`, or `upgrades`;
+    /// omitting all three records a Root. `algo` is `"sha1"` (default) or
+    /// `"sha256"`. Passing `manifest` (a directory path) binds the source by a
+    /// canonical manifest hash; otherwise the git tree is reported.
+    #[pyo3(signature = (author, git_tree, *, git_commit=None, algo="sha1", note=None,
+        continues=None, parent=None, derives_from=None, upgrades=None, manifest=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn candidate(
+        &mut self,
+        author: &str,
+        git_tree: &str,
+        git_commit: Option<String>,
+        algo: &str,
+        note: Option<String>,
+        continues: Option<&str>,
+        parent: Option<&str>,
+        derives_from: Option<Vec<String>>,
+        upgrades: Option<&str>,
+        manifest: Option<&str>,
+    ) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        let algo = match algo {
+            "sha1" => SourceAlgo::Sha1,
+            "sha256" => SourceAlgo::Sha256,
+            other => return Err(PyValueError::new_err(format!("invalid algo {other:?}"))),
+        };
+
+        // Basis selection is mutually exclusive.
+        let n_basis = [continues.is_some(), derives_from.is_some(), upgrades.is_some()]
+            .iter()
+            .filter(|b| **b)
+            .count();
+        if n_basis > 1 {
+            return Err(PyValueError::new_err(
+                "continues, derives_from, and upgrades are mutually exclusive",
+            ));
+        }
+        // `parent` names the continued-from candidate and is meaningful only
+        // for a continuation; refuse it elsewhere rather than drop stated intent.
+        if continues.is_none() && parent.is_some() {
+            return Err(PyValueError::new_err("parent is only valid with continues"));
+        }
+
+        let (basis, parent_id, refs) = if let Some(sel) = continues {
+            let parent = parent.ok_or_else(|| {
+                PyValueError::new_err("continues requires parent (the continued candidate id)")
+            })?;
+            (
+                CandidateBasis::Continuation,
+                Some(parse_id(parent)?),
+                vec![Ref {
+                    type_: RefType::Cause,
+                    target: parse_id(sel)?,
+                }],
+            )
+        } else if let Some(ids) = &derives_from {
+            if ids.is_empty() {
+                return Err(PyValueError::new_err("derives_from requires at least one id"));
+            }
+            let refs = ids
+                .iter()
+                .map(|s| {
+                    parse_id(s).map(|t| Ref {
+                        type_: RefType::Cause,
+                        target: t,
+                    })
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            (CandidateBasis::Derivation, None, refs)
+        } else if let Some(target_hex) = upgrades {
+            // Binding upgrade: a Derivation over the target with the SAME tree.
+            let target = parse_id(target_hex)?;
+            let target_data = self
+                .inner
+                .records()
+                .iter()
+                .find(|r| r.id == target && r.kind == Kind::Candidate)
+                .and_then(|r| decode::<CandidateData>(&r.data).ok())
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "upgrades target {target_hex:?} is not a Candidate in this log"
+                    ))
+                })?;
+            if !self.state.accepted_records.contains(&target) {
+                return Err(PyValueError::new_err(format!(
+                    "upgrades target {target_hex:?} is not an accepted Candidate"
+                )));
+            }
+            if self.state.retracted_records.contains(&target) {
+                return Err(PyValueError::new_err(format!(
+                    "upgrades target {target_hex:?} is retracted; upgrade a live candidate"
+                )));
+            }
+            if target_data.source.git.tree != git_tree {
+                return Err(PyValueError::new_err(format!(
+                    "refusing upgrade: git_tree {git_tree:?} differs from the target's tree {:?}",
+                    target_data.source.git.tree
+                )));
+            }
+            (
+                CandidateBasis::Derivation,
+                None,
+                vec![Ref {
+                    type_: RefType::Cause,
+                    target,
+                }],
+            )
+        } else {
+            (CandidateBasis::Root, None, Vec::new())
+        };
+
+        // A manifest binding when `manifest` is given; reported otherwise.
+        let (manifest_hash_val, binding) = match manifest {
+            Some(path) => {
+                let entries = manifest_from_dir(Path::new(path), &BTreeMap::new())
+                    .map_err(|e| PyValueError::new_err(format!("cannot walk tree {path}: {e}")))?;
+                let h = manifest_hash(&entries).ok_or_else(|| {
+                    PyValueError::new_err("manifest has duplicate paths".to_string())
+                })?;
+                (Some(h), BindingMode::Manifest)
+            }
+            None => (None, BindingMode::Reported),
+        };
+
+        let data = checked_encode(&CandidateData {
+            source: SourceBinding {
+                git: GitSource {
+                    algo,
+                    tree: git_tree.to_string(),
+                    commit: git_commit,
+                },
+                manifest_hash: manifest_hash_val,
+                binding,
+            },
+            basis,
+            parent: parent_id,
+            note,
+        })?;
+        self.do_commit(
+            author,
+            Kind::Candidate,
+            schema_id(SCHEMA_CANDIDATE),
+            data,
+            refs,
+        )
+    }
+
+    /// Record an Evaluation of a candidate. Exactly one of `passed`, `failed`,
+    /// or a `score` (with `scale`) states the outcome. The evaluation Uses its
+    /// candidate, plus any extra `uses` ids.
+    #[pyo3(signature = (author, candidate, criterion, *, passed=false, failed=false,
+        score=None, scale=None, procedure=None, uses=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn evaluate(
+        &mut self,
+        author: &str,
+        candidate: &str,
+        criterion: &str,
+        passed: bool,
+        failed: bool,
+        score: Option<i64>,
+        scale: Option<u8>,
+        procedure: Option<String>,
+        uses: Option<Vec<String>>,
+    ) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        let candidate = parse_id(candidate)?;
+
+        let outcome = match (passed, failed, score) {
+            (true, false, None) => EvaluationOutcome::Passed,
+            (false, true, None) => EvaluationOutcome::Failed,
+            (false, false, Some(value)) => {
+                let scale = scale.ok_or_else(|| {
+                    PyValueError::new_err("score requires scale (the denominator)")
+                })?;
+                EvaluationOutcome::Scored(ScoredValue { value, scale })
+            }
+            _ => {
+                return Err(PyValueError::new_err(
+                    "exactly one of passed, failed, or score is required",
+                ))
+            }
+        };
+
+        // The evaluation must Use its candidate, plus any extra uses refs.
+        let mut refs = vec![Ref {
+            type_: RefType::Use,
+            target: candidate,
+        }];
+        if let Some(extra) = &uses {
+            for s in extra {
+                refs.push(Ref {
+                    type_: RefType::Use,
+                    target: parse_id(s)?,
+                });
+            }
+        }
+
+        let data = checked_encode(&EvaluationData {
+            candidate,
+            criterion: criterion.to_string(),
+            procedure,
+            outcome,
+        })?;
+        self.do_commit(
+            author,
+            Kind::Evaluation,
+            schema_id(SCHEMA_EVALUATION),
+            data,
+            refs,
+        )
+    }
+
+    /// Record a Selection over candidates, or a reaffirmation. Exactly one of
+    /// `choose` (with `uses_eval`) or `none=True` states the outcome. `replaces`
+    /// adds a Replace ref to a prior Selection (a reaffirmation).
+    #[pyo3(signature = (author, objective, consider, *, choose=None, uses_eval=None,
+        none=false, replaces=None, rationale=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn select(
+        &mut self,
+        author: &str,
+        objective: &str,
+        consider: Vec<String>,
+        choose: Option<Vec<String>>,
+        uses_eval: Option<Vec<String>>,
+        none: bool,
+        replaces: Option<&str>,
+        rationale: Option<String>,
+    ) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        if consider.is_empty() {
+            return Err(PyValueError::new_err(
+                "consider requires at least one candidate id",
+            ));
+        }
+        let considered = consider
+            .iter()
+            .map(|s| parse_id(s))
+            .collect::<PyResult<Vec<_>>>()?;
+
+        if none == choose.is_some() {
+            return Err(PyValueError::new_err(
+                "exactly one of choose or none=True is required",
+            ));
+        }
+
+        let mut refs = Vec::new();
+        let outcome = if none {
+            SelectionOutcome::None
+        } else {
+            let winners = choose
+                .unwrap()
+                .iter()
+                .map(|s| parse_id(s))
+                .collect::<PyResult<Vec<_>>>()?;
+            for w in &winners {
+                refs.push(Ref {
+                    type_: RefType::Require,
+                    target: *w,
+                });
+            }
+            let evals = uses_eval.ok_or_else(|| {
+                PyValueError::new_err("choose requires uses_eval with at least one evaluation")
+            })?;
+            if evals.is_empty() {
+                return Err(PyValueError::new_err("uses_eval requires at least one evaluation"));
+            }
+            for s in &evals {
+                refs.push(Ref {
+                    type_: RefType::Use,
+                    target: parse_id(s)?,
+                });
+            }
+            SelectionOutcome::Selected {
+                candidates: winners,
+            }
+        };
+
+        if let Some(sel) = replaces {
+            refs.push(Ref {
+                type_: RefType::Replace,
+                target: parse_id(sel)?,
+            });
+        }
+
+        let data = checked_encode(&SelectionData {
+            objective: objective.to_string(),
+            considered,
+            outcome,
+            rationale,
+        })?;
+        self.do_commit(
+            author,
+            Kind::Selection,
+            schema_id(SCHEMA_SELECTION),
+            data,
+            refs,
+        )
+    }
+
+    /// The current head id, lowercase hex (all-zero for an empty log).
+    #[getter]
+    fn head(&self) -> String {
+        hex_encode(&self.inner.head())
+    }
+
+    /// The committed records in order (subjects and verdicts).
+    #[getter]
+    fn records(&self) -> Vec<Record> {
+        self.inner
+            .records()
+            .iter()
+            .cloned()
+            .map(|inner| Record { inner })
+            .collect()
+    }
+
+    /// Number of committed records (subjects and verdicts).
+    fn __len__(&self) -> usize {
+        self.inner.records().len()
+    }
+
+    /// Export the log as a portable receipt (canonical JSON bytes). Feed it to
+    /// `validate` or `read`, or hand it to any independent verifier.
+    fn receipt<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = CoreReceipt::new(self.inner.records(), &self.rules)
+            .to_bytes()
+            .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize receipt: {e}")))?;
+        Ok(PyBytes::new_bound(py, &bytes))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Writer(records={})", self.inner.records().len())
+    }
+}
+
 #[pymodule]
 fn bellbook(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -307,5 +794,7 @@ fn bellbook(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Report>()?;
     m.add_class::<Receipt>()?;
     m.add_class::<Record>()?;
+    m.add_class::<Writer>()?;
+    m.add_class::<Commit>()?;
     Ok(())
 }

--- a/bindings/python/tests/test_writer.py
+++ b/bindings/python/tests/test_writer.py
@@ -1,0 +1,267 @@
+"""Stage 4: record evolution to a log from Python, then verify it.
+
+These tests drive the whole loop in one process: open a Writer, commit a
+candidate / evaluation / selection, export the receipt, and feed it straight
+back to `validate` and `read`. What the writer records must be exactly what the
+verifier accepts.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+import bellbook
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+V03 = ROOT / "spec" / "conformance" / "v0.3" / "receipt-cases.json"
+
+
+def _rules() -> str:
+    """The verifier rules a v0.3 corpus receipt was committed under, as JSON.
+    Its `author_roles` binds `agent` to Provider, which these tests author as."""
+    corpus = json.loads(V03.read_text())
+    return json.dumps(corpus["cases"][0]["receipt"]["rules"])
+
+
+def _writer(tmp_path) -> "bellbook.Writer":
+    return bellbook.Writer(str(tmp_path / "log"), _rules())
+
+
+def test_write_then_validate_is_clean(tmp_path):
+    """A Root candidate, an evaluation, and a selection over it: the exported
+    receipt validates Clean, and the writer's own records survive replay."""
+    w = _writer(tmp_path)
+
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    assert c0.accepted, c0.reason
+    assert c0.result == "accept"
+    assert len(c0.id) == 64 and c0.id == c0.id.lower()
+
+    e0 = w.evaluate(author="agent", candidate=c0.id, criterion="builds", passed=True)
+    assert e0.accepted, e0.reason
+
+    s0 = w.select(
+        author="agent",
+        objective="ship it",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[e0.id],
+    )
+    assert s0.accepted, s0.reason
+
+    # Every commit paired a subject with a verdict: 3 subjects -> 6 records.
+    assert len(w) == 6
+    # The head is the last committed record (the selection's verdict), so it has
+    # advanced off the empty-log all-zero head.
+    assert w.head != "0" * 64
+
+    receipt = w.receipt()
+    report = bellbook.validate(receipt)
+    assert report.status == "clean", report.problem or report.reason
+    assert report.record_count == 6
+
+    # The same receipt reads back with the evolution kinds present.
+    parsed = bellbook.read(receipt)
+    kinds = {r.kind for r in parsed.records}
+    assert {"Candidate", "Evaluation", "Selection", "Verdict"} <= kinds
+
+
+def test_continuation_and_derivation_basis(tmp_path):
+    """A continuation names its parent and Causes the prior selection; a
+    derivation Causes its sources. Both must be accepted."""
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    e0 = w.evaluate(author="agent", candidate=c0.id, criterion="ok", passed=True)
+    s0 = w.select(
+        author="agent",
+        objective="pick",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[e0.id],
+    )
+
+    c1 = w.candidate(
+        author="agent", git_tree="b" * 40, continues=s0.id, parent=c0.id
+    )
+    assert c1.accepted, c1.reason
+
+    c2 = w.candidate(author="agent", git_tree="c" * 40, derives_from=[c0.id, c1.id])
+    assert c2.accepted, c2.reason
+
+    assert bellbook.validate(w.receipt()).status == "clean"
+
+
+def test_upgrade_requires_same_tree(tmp_path):
+    """A binding upgrade must carry the target candidate's tree; a different
+    tree is refused before anything is written."""
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    before = len(w)
+
+    with pytest.raises(ValueError, match="differs from the target"):
+        w.candidate(author="agent", git_tree="f" * 40, upgrades=c0.id)
+    assert len(w) == before  # nothing committed
+
+    up = w.candidate(author="agent", git_tree="a" * 40, upgrades=c0.id)
+    assert up.accepted, up.reason
+    assert bellbook.validate(w.receipt()).status == "clean"
+
+
+def test_basis_flags_are_mutually_exclusive(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        w.candidate(
+            author="agent",
+            git_tree="b" * 40,
+            derives_from=[c0.id],
+            upgrades=c0.id,
+        )
+
+
+def test_parent_only_with_continues(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    with pytest.raises(ValueError, match="parent is only valid with continues"):
+        w.candidate(author="agent", git_tree="b" * 40, parent=c0.id)
+
+
+def test_evaluate_outcome_is_exclusive(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    with pytest.raises(ValueError, match="exactly one of passed"):
+        w.evaluate(author="agent", candidate=c0.id, criterion="x", passed=True, failed=True)
+    with pytest.raises(ValueError, match="exactly one of passed"):
+        w.evaluate(author="agent", candidate=c0.id, criterion="x")
+
+
+def test_scored_evaluation_needs_scale(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    with pytest.raises(ValueError, match="scale"):
+        w.evaluate(author="agent", candidate=c0.id, criterion="perf", score=8)
+    ok = w.evaluate(author="agent", candidate=c0.id, criterion="perf", score=8, scale=10)
+    assert ok.accepted, ok.reason
+
+
+def test_score_out_of_range_is_caught_before_commit(tmp_path):
+    """`scale` is a decimal exponent bounded at 12. A scale above it is a
+    payload violation the round-trip catches as a ValueError; nothing is
+    written (no durable rejected record with an opaque reason)."""
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    before = len(w)
+    with pytest.raises(ValueError, match="invalid payload"):
+        w.evaluate(author="agent", candidate=c0.id, criterion="perf", score=8, scale=13)
+    assert len(w) == before
+
+
+def test_select_choose_or_none(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    e0 = w.evaluate(author="agent", candidate=c0.id, criterion="ok", passed=True)
+    # neither
+    with pytest.raises(ValueError, match="choose or none"):
+        w.select(author="agent", objective="o", consider=[c0.id])
+    # both
+    with pytest.raises(ValueError, match="choose or none"):
+        w.select(
+            author="agent",
+            objective="o",
+            consider=[c0.id],
+            choose=[c0.id],
+            uses_eval=[e0.id],
+            none=True,
+        )
+    # a none-selection is valid on its own
+    s = w.select(author="agent", objective="o", consider=[c0.id], none=True)
+    assert s.accepted, s.reason
+
+
+def test_reaffirmation_replaces_prior_selection(tmp_path):
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    e0 = w.evaluate(author="agent", candidate=c0.id, criterion="ok", passed=True)
+    s0 = w.select(
+        author="agent",
+        objective="pick",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[e0.id],
+    )
+    e1 = w.evaluate(author="agent", candidate=c0.id, criterion="recheck", passed=True)
+    s1 = w.select(
+        author="agent",
+        objective="pick",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[e1.id],
+        replaces=s0.id,
+    )
+    assert s1.accepted, s1.reason
+    assert bellbook.validate(w.receipt()).status == "clean"
+
+
+def test_rejected_record_is_durable_and_writer_continues(tmp_path):
+    """A rejected proposal is still committed (durable evidence of a refusal):
+    `accepted` is False, no exception, and the writer's state stays consistent
+    so the next valid commit still goes through."""
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    before = len(w)
+
+    # An evaluation whose candidate ref resolves to nothing is rejected by
+    # replay (RefUnresolved), not caught pre-commit.
+    rej = w.evaluate(author="agent", candidate="b" * 64, criterion="x", passed=True)
+    assert not rej.accepted
+    assert rej.result == "reject"
+    assert rej.reason  # a reason code is set
+    assert len(w) == before + 2  # subject + verdict still appended
+
+    # State survived the rejection: a subsequent valid commit is accepted.
+    e0 = w.evaluate(author="agent", candidate=c0.id, criterion="ok", passed=True)
+    assert e0.accepted, e0.reason
+
+    # A durable rejected record is refused history, not retraction: still valid.
+    assert bellbook.validate(w.receipt()).status in {"clean", "tainted"}
+
+
+def test_unregistered_author_is_refused(tmp_path):
+    w = _writer(tmp_path)
+    with pytest.raises(ValueError, match="not registered"):
+        w.candidate(author="nobody", git_tree="a" * 40)
+
+
+def test_reopen_sees_prior_records(tmp_path):
+    """Closing and reopening the log rebuilds verified state; new commits
+    continue the same chain."""
+    log = str(tmp_path / "log")
+    rules = _rules()
+
+    w1 = bellbook.Writer(log, rules)
+    c0 = w1.candidate(author="agent", git_tree="a" * 40)
+    head1 = w1.head
+    n1 = len(w1)
+    del w1  # release the exclusive lock
+
+    w2 = bellbook.Writer(log, rules)
+    assert len(w2) == n1
+    assert w2.head == head1
+    e0 = w2.evaluate(author="agent", candidate=c0.id, criterion="ok", passed=True)
+    assert e0.accepted, e0.reason
+    assert bellbook.validate(w2.receipt()).status == "clean"
+
+
+def test_second_writer_is_locked_out(tmp_path):
+    log = str(tmp_path / "log")
+    rules = _rules()
+    w1 = bellbook.Writer(log, rules)
+    w1.candidate(author="agent", git_tree="a" * 40)
+    with pytest.raises(RuntimeError):
+        bellbook.Writer(log, rules)  # exclusive lock still held by w1
+
+
+def test_bad_rules_json_raises(tmp_path):
+    with pytest.raises(ValueError, match="invalid rules JSON"):
+        bellbook.Writer(str(tmp_path / "log"), "{ not json")


### PR DESCRIPTION
## What

Stage 4 of the Python bindings (#13): a writer API. Adds `bellbook.Writer`, a thin PyO3 wrapper over the crate's persistent, single-writer `LogWriter`. Python can now record evolution to a log, not just validate and read one.

```python
w = bellbook.Writer("./mylog", rules_json)
c0 = w.candidate(author="agent", git_tree="a1b2...")
e0 = w.evaluate(author="agent", candidate=c0.id, criterion="builds", passed=True)
s0 = w.select(author="agent", objective="ship it",
              consider=[c0.id], choose=[c0.id], uses_eval=[e0.id])
assert bellbook.validate(w.receipt()).status == "clean"
```

## How it wraps the core

The wrapper is not a reimplementation; the crate stays the single source of truth. It mirrors the CLI's recording discipline:

- Opens a log under a JSON `rules` string (the same object a receipt embeds under `rules`), then rebuilds and re-verifies state from the committed records.
- Resolves the author role from the rules' `author_roles`, never trusting a declared type; an unregistered author is refused before any write.
- `candidate` / `evaluate` / `select` each commit one record and return a `Commit` (`id`, `accepted`, `result`, `reason`).
- Enforces the mutually exclusive candidate basis (`continues`+`parent` / `derives_from` / `upgrades`), and refuses an upgrade whose tree differs from its target's.
- Round-trips each payload through `encode`/`decode` so a statically knowable violation (e.g. a score scale above 12) raises `ValueError` instead of committing a durable rejected record with an opaque reason.
- A rejected proposal is still committed - durable evidence of a refusal - and returned with `accepted=False`, not raised.
- Also exposes `head`, `records`, `len()`, and `receipt()`, so a caller can write and validate/read in one process.

The wheel now enables the crate's `persist` feature (cross-platform file locking via `fs4`, which builds on Linux, macOS, and Windows). `validate` and `read` remain feature-independent.

## Verification

- `cargo check` and `cargo clippy --all-targets -- -D warnings` clean.
- New `tests/test_writer.py` (15 cases) drives the full loop - write, export receipt, validate/read - and covers basis selection, upgrade tree-equality, argument guards, payload-invariant pre-checks, reaffirmation, single-writer locking, reopen-and-continue, and state consistency across a durable rejection. Full suite: 24 passed.
- Verified the sdist installs from scratch in a clean venv (compiles the extension with the persist feature, fetches the published core `0.3.0`) and the writer end-to-end loop returns a Clean receipt.

## Scope

Stage 5 (the actual PyPI publish) is deliberately not included: it is the one irreversible outward step and needs credentials/trusted-publishing configured.