### PR TITLE
build(deps): bump pyo3 to 0.29 in the Python bindings (#57)

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,15 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,15 +225,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -283,37 +259,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -321,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -333,13 +304,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.119",
 ]
@@ -383,12 +353,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu-js"
@@ -505,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "typenum"
@@ -520,12 +484,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "version_check"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -8,7 +8,10 @@
 name = "bellbook-python"
 version = "0.3.0"
 edition = "2021"
-rust-version = "1.75"
+# pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
+# not affect the library crate (a separate workspace), whose MSRV job is
+# unchanged. Wheel users are unaffected; this only bounds building from source.
+rust-version = "1.83"
 license = "MIT OR Apache-2.0"
 description = "Python bindings for the Bellbook receipt validator."
 repository = "https://github.com/bellbook-ai/bellbook"
@@ -32,7 +35,7 @@ crate-type = ["cdylib"]
 bellbook_core = { package = "bellbook", version = "0.3", default-features = false, features = [
     "persist",
 ] }
-pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 # The writer takes verifier rules as a JSON string (the same object embedded in
 # a receipt). serde_json parses it into the crate's `VerifierRules`; serde
 # bounds the pre-commit encode/decode round-trip that checks payload invariants.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -127,10 +127,10 @@ impl Report {
     #[getter]
     fn standing<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let s = &self.inner.standing;
-        let out = PyDict::new_bound(py);
+        let out = PyDict::new(py);
         out.set_item("compromised", ids(&s.compromised))?;
         out.set_item("unsound", ids(&s.unsound))?;
-        let restorations = PyDict::new_bound(py);
+        let restorations = PyDict::new(py);
         for (target, replacers) in &s.restorations {
             restorations.set_item(hex_encode(target), ids(replacers))?;
         }
@@ -273,7 +273,7 @@ impl Record {
             .refs
             .iter()
             .map(|r| {
-                let d = PyDict::new_bound(py);
+                let d = PyDict::new(py);
                 d.set_item("type", format!("{:?}", r.type_))?;
                 d.set_item("target", hex_encode(&r.target))?;
                 Ok(d)
@@ -778,7 +778,7 @@ impl Writer {
         let bytes = CoreReceipt::new(self.inner.records(), &self.rules)
             .to_bytes()
             .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize receipt: {e}")))?;
-        Ok(PyBytes::new_bound(py, &bytes))
+        Ok(PyBytes::new(py, &bytes))
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
## What

Upgrades pyo3 `0.22` → `0.29` for the Python bindings. Supersedes the dependabot bump in #57 (which can't be auto-merged - it needs the code migration below). Merging this closes #57.

## The migration is mechanical

pyo3 dropped the transitional `*_new_bound` constructors, so the four call sites move to the plain `Bound`-returning forms the code already used everywhere else:

- `PyDict::new_bound(py)` → `PyDict::new(py)` (3 sites)
- `PyBytes::new_bound(py, &bytes)` → `PyBytes::new(py, &bytes)` (1 site)

No behavior change, no API surface change for Python callers.

## One real side effect: MSRV

pyo3 0.29 requires **Rust 1.83**, so the **bindings crate's** `rust-version` rises `1.75` → `1.83`. This is isolated:

- The **library crate** is a separate workspace; its MSRV job builds only the root crate and is **unchanged**.
- **Wheel users are unaffected** - the floor only bounds compiling the bindings from source (and CI/maturin use current stable).

## Verification

- `cargo check` and `cargo clippy --all-targets -- -D warnings` clean on pyo3 0.29.2.
- `maturin develop --release` rebuilds the extension; the full suite (validate + read + writer) passes: **24 passed**.

## Release impact: none

pyo3 is a build-time dependency of the bindings only. Nothing is republished - the wheels already on PyPI (`0.3.0`, built against pyo3 0.22) are untouched, and this upgrade simply rides the next version bump whenever the package is next published.