### PR TITLE
test(fuzz): fuzzing harness over the receipt trust boundary (#65)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,47 @@
+name: Fuzz
+
+# Coverage-guided fuzzing of the receipt trust boundary (issue #65). This is the
+# deep layer; the always-on, per-push layer is tests/fuzz_trust_boundary.rs,
+# which runs in the normal test job. Fuzzing is long-running and
+# non-deterministic, so it runs on a schedule and on demand and NEVER gates a
+# pull request.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays, 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: "Seconds to run each fuzz target"
+        default: "300"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [validate, receipt_parse, canonical_json]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+      - name: Fuzz ${{ matrix.target }}
+        working-directory: fuzz
+        run: |
+          cargo +nightly fuzz run ${{ matrix.target }} -- \
+            -max_total_time=${{ github.event.inputs.max_total_time || '300' }} \
+            -rss_limit_mb=4096
+      - name: Upload crash reproducers
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Fuzzing harness over the receipt trust boundary** (#65). A fast, seeded
+  harness (`tests/fuzz_trust_boundary.rs`) runs in the ordinary test suite on
+  every push, asserting that `validate` never panics and that its reports,
+  along with `Receipt::from_bytes` and RFC 8785 canonicalization, stay
+  self-consistent for arbitrary input. A coverage-guided libFuzzer target set
+  (`fuzz/`) runs weekly and on demand for deeper exploration. `SECURITY.md`
+  documents both layers and the pending external-review gate. Development-only;
+  the published crate API is unchanged.
+
 ## [0.3.0] - 2026-08-20
 
 Second public release. Implements Bellbook spec version 0.3, the evolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/bellbook-ai/bellbook"
 keywords = ["audit", "append-only", "tamper-evident", "agent", "provenance"]
 categories = ["data-structures", "development-tools"]
 readme = "README.md"
-# The Python bindings under bindings/ are their own crate and not part of the
-# published Rust crate.
-exclude = ["bindings"]
+# The Python bindings under bindings/ and the fuzz targets under fuzz/ are their
+# own crates, not part of the published Rust crate.
+exclude = ["bindings", "fuzz"]
 
 # Standalone workspace root - intentionally not a member of any enclosing workspace.
 [workspace]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,3 +41,24 @@ author identity is cryptographically bound only for actors with pinned
 signing keys; logs and receipts assume in-memory scale, with validation
 resource-bounded by default (`ValidationLimits`, CLI `--max-size`).
 Reports within those documented bounds are welcome as regular issues.
+
+## Hardening
+
+**Fuzzing.** The receipt trust boundary - the surface that takes untrusted
+bytes: `validate`, `Receipt::from_bytes`, and `canonical_json` - is fuzzed at
+two levels (issue #65):
+
+- A fast, deterministic, seeded harness runs in the ordinary test suite on
+  every push (`tests/fuzz_trust_boundary.rs`). It asserts the invariants that
+  must hold for *any* input: `validate` never panics, a Clean report lists
+  nothing retracted or tainted, an Invalid report always states a reason, and
+  RFC 8785 canonicalization is total and idempotent.
+- A coverage-guided libFuzzer target set (`fuzz/`, run weekly and on demand via
+  `.github/workflows/fuzz.yml`) explores the same entry points more deeply. A
+  crash or a violated invariant there is a security finding, reported as above.
+
+**External security review.** An independent review of the kernel and
+verification path is planned; its acceptance gate is **zero unresolved
+blocker-severity findings**, and its findings will be published. This gap is
+tracked openly in issue #65 rather than implied done - Bellbook does not claim
+assurance it has not earned.

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+/target
+/corpus
+/artifacts
+/coverage
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,47 @@
+# Coverage-guided fuzz targets for Bellbook (issue #65). Its own crate and its
+# own workspace, excluded from the library crate so `cargo build`, `cargo test`,
+# and `cargo package` at the repo root never pull in libFuzzer or nightly.
+#
+# Run locally with a nightly toolchain:
+#   cargo install cargo-fuzz
+#   cargo +nightly fuzz run validate
+# See README.md.
+[package]
+name = "bellbook-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+# Validation, reading, and canonicalization are feature-independent, so the
+# fuzz build does not need `persist`.
+bellbook = { path = "..", default-features = false }
+
+[[bin]]
+name = "validate"
+path = "fuzz_targets/validate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "receipt_parse"
+path = "fuzz_targets/receipt_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "canonical_json"
+path = "fuzz_targets/canonical_json.rs"
+test = false
+doc = false
+bench = false
+
+# Own workspace: keep the fuzz crate out of the library crate's workspace.
+[workspace]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,44 @@
+# Fuzzing Bellbook
+
+Coverage-guided fuzz targets (libFuzzer, via [`cargo-fuzz`]) over the receipt
+**trust boundary** - the surface that takes untrusted bytes: `validate`,
+`Receipt::from_bytes`, and `canonical_json` (issue #65).
+
+This is the deep layer. A fast, deterministic, always-on layer runs in the
+ordinary test suite on every push (`tests/fuzz_trust_boundary.rs`); it hammers
+the same entry points with a seeded generator and asserts the same invariants.
+Use these libFuzzer targets for long, coverage-guided campaigns that reach
+states a fixed seed corpus does not.
+
+## Targets
+
+- **`validate`** - arbitrary bytes through `validate`; must never panic and must
+  return a self-consistent report.
+- **`receipt_parse`** - a receipt that parses must survive a canonical
+  round-trip (serialize, re-parse) unchanged.
+- **`canonical_json`** - RFC 8785 canonicalization must be total and idempotent
+  over any parseable JSON value.
+
+## Running
+
+Requires a nightly toolchain (libFuzzer needs `-Z` flags):
+
+```sh
+cargo install cargo-fuzz
+cargo +nightly fuzz run validate            # runs until a crash or Ctrl-C
+cargo +nightly fuzz run validate -- -max_total_time=120   # time-bounded
+cargo +nightly fuzz run receipt_parse
+cargo +nightly fuzz run canonical_json
+```
+
+A crash writes a reproducer under `fuzz/artifacts/<target>/`; replay it with:
+
+```sh
+cargo +nightly fuzz run validate fuzz/artifacts/validate/crash-<hash>
+```
+
+CI runs these on a weekly schedule and on manual dispatch (`.github/workflows/fuzz.yml`),
+never as a pull-request gate - fuzzing is long-running and non-deterministic.
+A finding here is a security issue; see `../SECURITY.md`.
+
+[`cargo-fuzz`]: https://github.com/rust-fuzz/cargo-fuzz

--- a/fuzz/fuzz_targets/canonical_json.rs
+++ b/fuzz/fuzz_targets/canonical_json.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+//! RFC 8785 canonicalization underlies every record id, so it must be total
+//! and idempotent over any parseable JSON value: canonicalizing the canonical
+//! form must reproduce it byte-for-byte.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(data) {
+        let once = bellbook::canonical_json(&value).expect("canonicalizing a parsed value");
+        let reparsed: serde_json::Value =
+            serde_json::from_slice(&once).expect("canonical output is valid JSON");
+        let twice = bellbook::canonical_json(&reparsed).expect("re-canonicalizing");
+        assert_eq!(once, twice, "canonical form is not idempotent");
+    }
+});

--- a/fuzz/fuzz_targets/receipt_parse.rs
+++ b/fuzz/fuzz_targets/receipt_parse.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+//! Parsing a receipt must be total (never panic), and any receipt that parses
+//! must survive a canonical round-trip unchanged: serialize to canonical bytes,
+//! parse again, and get an equal receipt. A mismatch would mean the canonical
+//! form is not a fixed point, which the ids depend on.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(receipt) = bellbook::Receipt::from_bytes(data) {
+        let bytes = receipt.to_bytes().expect("re-serializing a parsed receipt");
+        let again = bellbook::Receipt::from_bytes(&bytes).expect("re-parsing canonical bytes");
+        assert_eq!(receipt, again, "receipt not stable across a canonical round-trip");
+    }
+});

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+//! The security boundary: `validate` takes arbitrary, possibly hostile bytes
+//! and must reach a Clean / Tainted / Invalid decision without panicking,
+//! aborting, or contradicting itself. libFuzzer explores the byte space with
+//! coverage guidance, reaching parser and replay paths a fixed corpus misses.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let report = bellbook::validate(data);
+    // A cheap always-true invariant, so a self-contradictory report is a
+    // finding rather than a silent non-crash.
+    assert!(report.checked_records <= report.record_count);
+});

--- a/tests/fuzz_trust_boundary.rs
+++ b/tests/fuzz_trust_boundary.rs
@@ -1,0 +1,207 @@
+//! Fuzzing harness over the receipt trust boundary (issue #65).
+//!
+//! `validate` is the security boundary: it takes arbitrary, possibly hostile
+//! bytes and must reach a Clean / Tainted / Invalid decision without ever
+//! panicking, aborting, or returning a self-contradictory report. This is the
+//! stable, always-on layer of the fuzzing harness: a deterministic, seeded
+//! generator that hammers `validate`, `Receipt::from_bytes`, and
+//! `canonical_json` with pure-random buffers and with mutations of known-valid
+//! receipts, asserting the invariants that must hold for *any* input.
+//!
+//! It is deliberately dependency-free and bounded so it runs in the ordinary
+//! `cargo test` matrix on every push. The deeper, coverage-guided layer
+//! (libFuzzer via `cargo fuzz`, over the same entry points) lives under
+//! `fuzz/` and runs on its own schedule; see `fuzz/README.md`.
+
+use bellbook::{canonical_json, validate, validate_with_limits, Receipt, ValidationLimits};
+
+/// A small, fast, deterministic PRNG (SplitMix64). A fixed seed keeps the run
+/// reproducible: a failure reproduces byte-for-byte in CI and locally.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// A value in `0..n`. `n` must be non-zero.
+    fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % n as u64) as usize
+    }
+
+    fn byte(&mut self) -> u8 {
+        self.next_u64() as u8
+    }
+}
+
+/// Valid receipts to mutate, drawn from the committed conformance corpus, plus
+/// a few hand-written near-miss shapes to reach the structural decoder.
+fn seeds() -> Vec<Vec<u8>> {
+    let mut seeds: Vec<Vec<u8>> = Vec::new();
+    for rel in [
+        "spec/conformance/v0.3/receipt-cases.json",
+        "spec/conformance/v0.2/receipt-cases.json",
+    ] {
+        let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), rel);
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        let Ok(corpus) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            continue;
+        };
+        if let Some(cases) = corpus["cases"].as_array() {
+            for case in cases.iter().take(6) {
+                if let Ok(receipt) = serde_json::to_vec(&case["receipt"]) {
+                    seeds.push(receipt);
+                }
+            }
+        }
+    }
+    // Structural near-misses: exercise the parser's field handling directly.
+    for s in [
+        br#"{"spec_version":"0.3","rules":{},"records":[]}"#.as_slice(),
+        br#"{"spec_version":"0.2","rules":{},"records":[]}"#.as_slice(),
+        br#"{"records":[],"rules":{},"spec_version":"0.3"}"#.as_slice(),
+        b"{}".as_slice(),
+        b"[]".as_slice(),
+    ] {
+        seeds.push(s.to_vec());
+    }
+    assert!(!seeds.is_empty(), "no fuzz seeds available");
+    seeds
+}
+
+/// A pure-random buffer of small, varied length.
+fn random_buf(rng: &mut Rng) -> Vec<u8> {
+    let len = rng.below(300);
+    (0..len).map(|_| rng.byte()).collect()
+}
+
+/// Apply a handful of byte-level mutations to a seed.
+fn mutate(seed: &[u8], rng: &mut Rng) -> Vec<u8> {
+    let mut buf = seed.to_vec();
+    let ops = 1 + rng.below(8);
+    for _ in 0..ops {
+        if buf.is_empty() {
+            buf.push(rng.byte());
+            continue;
+        }
+        match rng.below(6) {
+            0 => {
+                let i = rng.below(buf.len());
+                buf[i] ^= 1u8 << rng.below(8);
+            }
+            1 => {
+                let i = rng.below(buf.len());
+                buf[i] = rng.byte();
+            }
+            2 => {
+                let i = rng.below(buf.len() + 1);
+                buf.insert(i, rng.byte());
+            }
+            3 => {
+                let i = rng.below(buf.len());
+                buf.remove(i);
+            }
+            4 => {
+                let i = rng.below(buf.len());
+                buf.truncate(i);
+            }
+            _ => {
+                // Splice a copy of one region over another: reaches
+                // length-prefixed and repeated-structure code paths.
+                let len = buf.len();
+                let src = rng.below(len);
+                let n = 1 + rng.below(len - src);
+                let chunk = buf[src..src + n].to_vec();
+                let at = rng.below(len);
+                for (k, b) in chunk.into_iter().enumerate() {
+                    if at + k < buf.len() {
+                        buf[at + k] = b;
+                    }
+                }
+            }
+        }
+    }
+    buf
+}
+
+/// Feed one input across the trust boundary and assert the always-true
+/// invariants. The overriding property is that none of these calls panic.
+fn check(data: &[u8]) {
+    // Reading never panics; it returns Ok or Err.
+    let _ = Receipt::from_bytes(data);
+
+    let report = validate(data);
+    // The same input under an explicit (unlimited) limit set must agree on the
+    // top-level decision; the resource bound is a refusal, not a verdict flip.
+    let unlimited = validate_with_limits(data, &ValidationLimits::unlimited());
+    let _ = &unlimited;
+
+    // Invariant 1: never more records checked than exist.
+    assert!(
+        report.checked_records <= report.record_count,
+        "checked_records {} exceeds record_count {}",
+        report.checked_records,
+        report.record_count
+    );
+
+    // Invariant 2: the three-way decision is internally consistent.
+    match report.status {
+        bellbook::ValidationStatus::Clean => {
+            // Clean means replayed and nothing retracted or tainted.
+            assert!(report.reason.is_none(), "Clean report carries a reason");
+            assert!(report.problem.is_none(), "Clean report carries a problem");
+            assert!(
+                report.retracted_records.is_empty() && report.tainted_records.is_empty(),
+                "Clean report lists retracted/tainted records"
+            );
+        }
+        bellbook::ValidationStatus::Invalid => {
+            // Invalid must say why: a structural problem or a verifier reason.
+            assert!(
+                report.problem.is_some() || report.reason.is_some(),
+                "Invalid report gives neither a problem nor a reason"
+            );
+        }
+        bellbook::ValidationStatus::Tainted => {}
+    }
+}
+
+#[test]
+fn validate_never_panics_and_reports_are_consistent() {
+    let seeds = seeds();
+    let mut rng = Rng(0x0B_E11B_00C5_EED1);
+    for _ in 0..12_000 {
+        check(&random_buf(&mut rng));
+        let seed = &seeds[rng.below(seeds.len())];
+        check(&mutate(seed, &mut rng));
+    }
+}
+
+#[test]
+fn canonical_json_is_total_and_idempotent() {
+    // Over any parseable JSON value, canonicalization must not panic and must
+    // be a fixed point: canonicalizing the canonical form reproduces it.
+    let mut rng = Rng(0xCA_0217_0A15_F00D);
+    let mut corpus: Vec<Vec<u8>> = seeds();
+    corpus.push(br#"{"b":1,"a":[3,2,1],"z":{"y":true,"x":null}}"#.to_vec());
+    corpus.push(br#"[{"k":"\u00e9"},1.5,-0,"","longer string value"]"#.to_vec());
+
+    for _ in 0..8_000 {
+        let seed = &corpus[rng.below(corpus.len())];
+        let data = mutate(seed, &mut rng);
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(&data) else {
+            continue;
+        };
+        let once = canonical_json(&value).expect("canonicalizing a parsed value");
+        let reparsed: serde_json::Value =
+            serde_json::from_slice(&once).expect("canonical output is valid JSON");
+        let twice = canonical_json(&reparsed).expect("re-canonicalizing");
+        assert_eq!(once, twice, "canonical form is not idempotent");
+    }
+}


### PR DESCRIPTION
## What

The fuzzing half of #65. Fuzzes the surface that takes untrusted bytes - `validate`, `Receipt::from_bytes`, and `canonical_json` - at two levels.

## Two layers

**Always-on, per-push** (`tests/fuzz_trust_boundary.rs`): a fast, deterministic, dependency-free seeded harness that runs in the ordinary `cargo test` matrix on every push (all three OSes). It feeds pure-random buffers and byte-level mutations of known-valid corpus receipts across the boundary and asserts the invariants that must hold for *any* input:

- `validate` never panics;
- `checked_records <= record_count`;
- a Clean report lists nothing retracted or tainted;
- an Invalid report always states a problem or a reason;
- RFC 8785 canonicalization is total and idempotent.

A fixed PRNG seed keeps any failure reproducible byte-for-byte. Bounded (~40k inputs, ~5s) so it fits the normal suite.

**Deep, coverage-guided** (`fuzz/`): a libFuzzer target set (`validate`, `receipt_parse`, `canonical_json`) via `cargo-fuzz`, its own crate and workspace, excluded from the library crate so root builds and `cargo package` are unaffected. `.github/workflows/fuzz.yml` runs it weekly and on demand - **never as a PR gate**, since fuzzing is long-running and non-deterministic.

## Docs

`SECURITY.md` gains a Hardening section documenting both layers, and records the **external security review** gate (zero unresolved blocker-severity findings) as *pending* - tracked openly in #65 rather than implied done.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test` suite all pass locally; the seeded harness runs clean over ~40k inputs.
- The libFuzzer targets mirror the exact API calls the verified stable harness uses. They need a nightly toolchain (libFuzzer `-Z` flags), which isn't available in this dev environment, so they're exercised by the scheduled workflow rather than locally.

## Scope

Part of #65; does **not** close it. The fuzzing harness lands here; the external security review remains open as the other half of that issue. The published crate API is unchanged (development/CI only).