### PR TITLE
cli: add `bellbook rules init` and `bellbook export` (#70, #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **CLI `bellbook rules init` and `bellbook export`** (#70, #71). `rules init`
+  writes a starter verifier-rules file from `--author <id>:<role>` bindings, so
+  a new user no longer hand-authors one (it is feature-independent, like
+  `validate`). `export` bundles a log directory into a portable receipt,
+  closing the record -> receipt -> validate loop from the CLI alone; previously
+  the export step required the Rust or Python API. Both were surfaced as
+  adoption friction while writing the best-of-N quickstart.
 - **Fuzzing harness over the receipt trust boundary** (#65). A fast, seeded
   harness (`tests/fuzz_trust_boundary.rs`) runs in the ordinary test suite on
   every push, asserting that `validate` never panics and that its reports,

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -44,6 +44,8 @@ USAGE:
                            (--choose <id> ... --uses-eval <id> ... | --none)
                            [--replaces <selection-id>] [--rationale <s>] [--json]
     bellbook lineage       --log <dir> --rules <file> <id> [--json]
+    bellbook rules init    --author <id>:<role> ... [--max-context <n>] [--out <file>]
+    bellbook export        --log <dir> --rules <file> [--out <file>]
 
 COMMANDS:
     validate    Verify a receipt offline: ids (RFC 8785 canonical form),
@@ -53,6 +55,10 @@ COMMANDS:
     eval        Record an Evaluation of a candidate.
     select      Record a Selection over candidates (or a reaffirmation).
     lineage     Show a candidate's descent, siblings, taint, and standing.
+    rules init  Generate a starter verifier-rules file. Roles are one of
+                user|provider|system|executor|verifier.
+    export      Bundle a log directory into a portable receipt (the input
+                `bellbook validate` verifies).
 
 EXIT CODES:
     0 clean/success   1 invalid   2 tainted   64 usage   65 command failed
@@ -70,12 +76,127 @@ fn main() -> ExitCode {
     };
     match command {
         "validate" => cmd_validate(&rest),
-        "candidate" | "eval" | "select" | "lineage" => cmd_evolution(command, &rest),
+        "rules" => cmd_rules(&rest),
+        "candidate" | "eval" | "select" | "lineage" | "export" => cmd_evolution(command, &rest),
         other => {
             eprintln!("unknown command {other:?}\n\n{USAGE}");
             ExitCode::from(64)
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// rules init (feature-independent)
+// ---------------------------------------------------------------------------
+
+fn parse_role(s: &str) -> Option<AuthorType> {
+    match s.to_ascii_lowercase().as_str() {
+        "user" => Some(AuthorType::User),
+        "provider" => Some(AuthorType::Provider),
+        "system" => Some(AuthorType::System),
+        "executor" => Some(AuthorType::Executor),
+        "verifier" => Some(AuthorType::Verifier),
+        _ => None,
+    }
+}
+
+/// `rules init` writes a starter verifier-rules file: the default space, a
+/// context bound, and one author-role binding per `--author <id>:<role>`. It is
+/// the trust policy the CLI's `--rules` flag and the receipt embed; generating
+/// one by hand is the main ceremony a new user hits, so this removes it.
+fn cmd_rules(rest: &[String]) -> ExitCode {
+    let (sub, rest) = match rest.split_first() {
+        Some((s, r)) => (s.as_str(), r),
+        None => {
+            eprintln!("rules needs a subcommand (init)\n\n{USAGE}");
+            return ExitCode::from(64);
+        }
+    };
+    if sub != "init" {
+        eprintln!("unknown rules subcommand {sub:?} (expected init)\n\n{USAGE}");
+        return ExitCode::from(64);
+    }
+
+    let mut authors: Vec<(String, AuthorType)> = Vec::new();
+    let mut max_context: u32 = 200;
+    let mut out: Option<String> = None;
+    let mut it = rest.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--author" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--author requires <id>:<role>");
+                    return ExitCode::from(64);
+                };
+                let Some((id, role)) = v.split_once(':') else {
+                    eprintln!("--author must be <id>:<role>, got {v:?}");
+                    return ExitCode::from(64);
+                };
+                if id.is_empty() {
+                    eprintln!("--author id must be non-empty");
+                    return ExitCode::from(64);
+                }
+                let Some(role) = parse_role(role) else {
+                    eprintln!("invalid role {role:?} (user|provider|system|executor|verifier)");
+                    return ExitCode::from(64);
+                };
+                authors.push((id.to_string(), role));
+            }
+            "--max-context" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--max-context requires a value");
+                    return ExitCode::from(64);
+                };
+                match v.parse::<u32>() {
+                    Ok(n) => max_context = n,
+                    Err(_) => {
+                        eprintln!("invalid --max-context value {v:?}");
+                        return ExitCode::from(64);
+                    }
+                }
+            }
+            "--out" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--out requires a path");
+                    return ExitCode::from(64);
+                };
+                out = Some(v.clone());
+            }
+            other => {
+                eprintln!("unexpected argument {other:?}\n\n{USAGE}");
+                return ExitCode::from(64);
+            }
+        }
+    }
+
+    if authors.is_empty() {
+        eprintln!("rules init needs at least one --author <id>:<role>");
+        return ExitCode::from(64);
+    }
+
+    let mut rules = VerifierRules::new(default_space(), max_context);
+    for (id, role) in authors {
+        rules = rules.with_author_role(id, role);
+    }
+    let json = match serde_json::to_string(&rules) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("cannot serialize rules: {e}");
+            return ExitCode::from(70);
+        }
+    };
+    match out {
+        Some(path) => {
+            if let Err(e) = std::fs::write(&path, json.as_bytes()) {
+                eprintln!("cannot write {path}: {e}");
+                return ExitCode::from(66);
+            }
+            // The data output is the file; a confirmation goes to stderr.
+            eprintln!("wrote starter rules to {path}");
+        }
+        None => println!("{json}"),
+    }
+    ExitCode::SUCCESS
 }
 
 // ---------------------------------------------------------------------------
@@ -176,6 +297,7 @@ fn cmd_evolution(command: &str, rest: &[String]) -> ExitCode {
         "eval" => persist_cmds::eval(rest),
         "select" => persist_cmds::select(rest),
         "lineage" => persist_cmds::lineage(rest),
+        "export" => persist_cmds::export(rest),
         _ => unreachable!(),
     };
     match result {
@@ -382,6 +504,33 @@ mod persist_cmds {
         } else {
             ExitCode::from(65)
         })
+    }
+
+    // --- export ------------------------------------------------------------
+
+    /// Bundle a log directory into a portable receipt. `open` rebuilds and
+    /// re-verifies state from the committed records, so a log that does not
+    /// verify under the given rules is refused before anything is written.
+    pub fn export(rest: &[String]) -> Result<ExitCode, String> {
+        let p = parse(rest, &["log", "rules", "out"], &[], &[])?;
+        let rules = load_rules(&p)?;
+        let (writer, _state) = open(&p, &rules)?;
+        let bytes = Receipt::new(writer.records(), &rules)
+            .to_bytes()
+            .map_err(|e| format!("cannot serialize receipt: {e}"))?;
+        match p.singles.get("out") {
+            Some(path) => {
+                std::fs::write(path, &bytes).map_err(|e| format!("cannot write {path}: {e}"))?;
+                eprintln!("wrote receipt to {path} ({} bytes)", bytes.len());
+            }
+            None => {
+                use std::io::Write;
+                std::io::stdout()
+                    .write_all(&bytes)
+                    .map_err(|e| format!("cannot write receipt to stdout: {e}"))?;
+            }
+        }
+        Ok(ExitCode::SUCCESS)
     }
 
     // --- candidate add -----------------------------------------------------

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -468,6 +468,124 @@ fn upgrade_missing_target_is_rejected() {
 }
 
 #[test]
+fn rules_init_output_drives_the_other_commands() {
+    // `rules init` must produce a rules file the recording commands accept -
+    // that is the whole point of removing the hand-authoring step.
+    let dir = tempfile::tempdir().unwrap();
+    let rules = dir.path().join("rules.json");
+    let out = bellbook()
+        .args(["rules", "init", "--author", "agent:provider", "--out"])
+        .arg(&rules)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // It parses as VerifierRules with the requested binding.
+    let parsed: VerifierRules = serde_json::from_str(&std::fs::read_to_string(&rules).unwrap())
+        .expect("rules init output must parse as VerifierRules");
+    assert_eq!(
+        parsed.author_roles.get("agent"),
+        Some(&AuthorType::Provider)
+    );
+
+    // And it works end to end: record a candidate against it.
+    let log = dir.path().join("log");
+    let out = bellbook()
+        .args([
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--json",
+        ])
+        .arg("--log")
+        .arg(&log)
+        .arg("--rules")
+        .arg(&rules)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn rules_init_rejects_an_unknown_role() {
+    let out = bellbook()
+        .args(["rules", "init", "--author", "agent:wizard"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(64));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("invalid role"));
+}
+
+#[test]
+fn export_round_trips_to_a_clean_receipt() {
+    let env = setup();
+    let root = add_root(&env, TREE_A);
+    let out = run(
+        &env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            "agent",
+            "--candidate",
+            &root,
+            "--criterion",
+            "unit-tests",
+            "--passed",
+            "--json",
+        ],
+    );
+    let eval = committed_id(&out);
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &root,
+            "--choose",
+            &root,
+            "--uses-eval",
+            &eval,
+            "--json",
+        ],
+    );
+    let _ = committed_id(&out);
+
+    // export the log, then validate the receipt with the same binary: the CLI
+    // now closes the record -> receipt -> validate loop without the API.
+    let receipt = env._dir.path().join("receipt.json");
+    let out = run(&env, &["export", "--out", receipt.to_str().unwrap()]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = bellbook().arg("validate").arg(&receipt).output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("CLEAN"));
+}
+
+#[test]
 fn validate_is_feature_independent() {
     // `validate` needs no log; a missing file is an unreadable-input error (66),
     // proving the command dispatches without touching the persist path.


### PR DESCRIPTION
## What

The two CLI adoption features surfaced while writing the best-of-N quickstart. With these, a **CLI-only** user goes from nothing to a verifiable receipt without dropping into a language binding - which is what turns v0.4.0 from a docs/test bucket into a real, user-facing release.

## Commands

- **`bellbook rules init`** (feature-independent, like `validate`) - writes a starter `VerifierRules` file from repeatable `--author <id>:<role>` bindings, with optional `--max-context` and `--out`. Removes the hand-authoring of the rules object (its `space` and kind-schema map are byte arrays) that was the main ceremony for a new user.

  ```sh
  bellbook rules init --author agent:provider --author evaluator:provider --out rules.json
  ```

- **`bellbook export`** (persist) - bundles a log directory into a portable receipt over `--log`/`--rules`, to `--out` or stdout. It reuses the verified-open path, so a log that does not verify under the given rules is refused before anything is written. Closes the **record → receipt → validate** loop from the CLI alone; previously `export` went through `Receipt::new(...)` in Rust or `Writer.receipt()` in Python.

  ```sh
  bellbook export --log ./mylog --rules rules.json --out receipt.json
  bellbook validate receipt.json
  ```

## Verification

- New end-to-end CLI tests: `rules init` output parses as `VerifierRules` and drives the other commands; an unknown role is a usage error (exit 64); `export` produces a receipt that `validate` reports Clean.
- Confirmed `rules init` builds and runs under `--no-default-features` (feature-independent), and `export` correctly reports the persist requirement there.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` and `--no-default-features` (both `-D warnings`), and the full `cargo test` suite pass locally.

## Scope

Closes #70, #71. This is a user-facing CLI addition - the last piece before a v0.4.0 release. A follow-up PR will bump the version, finalize the CHANGELOG, and update the quickstart to use these commands natively.