### PR TITLE
bindings(python): pin bellbook_core to 0.4

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde4f3518d497a90cbc3fef706b6269c60536fffa743d27482d785452ae9bd6"
+checksum = "761f1e995301425f867993f2c33182f174e44b734325ce30aac5e263787cef46"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # (that release adds only the CLI binary, fuzzing, and docs). Pinning the
 # major-compatible 0.3 line keeps the bindings buildable from crates.io without
 # a publish-ordering deadlock; the compiled extension is identical either way.
-bellbook_core = { package = "bellbook", version = "0.3", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.4", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }


### PR DESCRIPTION
Now that `bellbook` 0.4.0 core is published on crates.io, align the Python bindings dependency pin from `0.3` to `0.4` and refresh the bindings lockfile.

## Why now

During release prep the pin was deliberately kept at `0.3` so the release PR's CI stayed green while 0.4.0 core was not yet on crates.io (the library API is identical across 0.3.x and 0.4.0, so building the bindings against published 0.3.x was correct). With 0.4.0 now live, the pin can track the current line.

## Changes

- `bindings/python/Cargo.toml`: `bellbook_core` version `"0.3"` -> `"0.4"`.
- `bindings/python/Cargo.lock`: `bellbook` `0.3.0` -> `0.4.0` (checksum from the published crate).

## Verification

- `cargo check` in `bindings/python` passes against 0.4.0 core.
- Source-alignment only: no binding code changes, no API change, and the abi3 wheels already publish at 0.4.0. The next PyPI build will resolve 0.4.0 core instead of 0.3.x.