### PR TITLE
adoption: ADOPTERS.md and a weekly traffic-snapshot workflow

### DIFF
--- a/.github/scripts/traffic_snapshot.py
+++ b/.github/scripts/traffic_snapshot.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Snapshot GitHub repository traffic into committed CSV history.
+
+The GitHub traffic API only retains the last 14 days of clones and views, and
+referrers are a point-in-time top list. This script fetches all three and
+merges them into CSVs under ``metrics/`` so the record survives beyond the
+14-day window:
+
+- ``metrics/clones.csv``   date,count,uniques   (one row per day, merged)
+- ``metrics/views.csv``    date,count,uniques   (one row per day, merged)
+- ``metrics/referrers.csv``  snapshot_date,referrer,count,uniques  (appended)
+
+Clone and view days overlap between runs; the newest fetch is authoritative, so
+a day already present is overwritten with the latest values rather than
+duplicated. Referrers are appended with the run date, since they are a snapshot
+rather than a time series.
+
+Environment:
+- ``GH_TOKEN``    a token that can read the traffic API (fine-grained PAT with
+                  ``Administration: read``, or a classic PAT with ``repo``).
+                  The built-in ``GITHUB_TOKEN`` cannot read traffic.
+- ``REPO``        ``owner/name`` (GitHub Actions sets this as github.repository).
+
+Standard library only; no third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "https://api.github.com"
+METRICS = Path("metrics")
+
+
+def fetch(path: str, token: str) -> dict | list:
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "bellbook-traffic-snapshot",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def merge_daily(filename: str, rows: list[dict], key: str) -> None:
+    """Merge a clones/views time series into a date-keyed CSV."""
+    path = METRICS / filename
+    by_date: dict[str, tuple[str, str]] = {}
+    if path.exists():
+        with path.open(newline="") as fh:
+            for row in csv.DictReader(fh):
+                by_date[row["date"]] = (row["count"], row["uniques"])
+    for item in rows:
+        date = item["timestamp"][:10]  # ISO 8601 -> YYYY-MM-DD
+        by_date[date] = (str(item["count"]), str(item["uniques"]))
+    METRICS.mkdir(exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["date", "count", "uniques"])
+        for date in sorted(by_date):
+            count, uniques = by_date[date]
+            writer.writerow([date, count, uniques])
+    print(f"{filename}: {len(by_date)} day(s) total (fetched {len(rows)})")
+
+
+def append_referrers(referrers: list[dict], today: str) -> None:
+    path = METRICS / "referrers.csv"
+    METRICS.mkdir(exist_ok=True)
+    new = path.exists() is False
+    with path.open("a", newline="") as fh:
+        writer = csv.writer(fh)
+        if new:
+            writer.writerow(["snapshot_date", "referrer", "count", "uniques"])
+        for r in referrers:
+            writer.writerow([today, r["referrer"], r["count"], r["uniques"]])
+    print(f"referrers.csv: appended {len(referrers)} row(s) for {today}")
+
+
+def main() -> int:
+    token = os.environ.get("GH_TOKEN")
+    repo = os.environ.get("REPO")
+    if not token or not repo:
+        print("GH_TOKEN and REPO must be set", file=sys.stderr)
+        return 1
+    try:
+        clones = fetch(f"/repos/{repo}/traffic/clones", token)
+        views = fetch(f"/repos/{repo}/traffic/views", token)
+        referrers = fetch(f"/repos/{repo}/traffic/popular/referrers", token)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:300]
+        print(f"traffic API error {exc.code}: {detail}", file=sys.stderr)
+        if exc.code in (401, 403):
+            print(
+                "The token cannot read traffic. Use a PAT with "
+                "Administration: read (fine-grained) or repo (classic); "
+                "the built-in GITHUB_TOKEN does not work here.",
+                file=sys.stderr,
+            )
+        return 1
+
+    merge_daily("clones.csv", clones.get("clones", []), "clones")
+    merge_daily("views.csv", views.get("views", []), "views")
+
+    # Derive the run date from the latest datapoint when available, so the
+    # output is deterministic and does not depend on wall-clock at commit time.
+    dated = [d["timestamp"][:10] for d in views.get("views", [])]
+    today = max(dated) if dated else "unknown"
+    append_referrers(referrers if isinstance(referrers, list) else [], today)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/traffic-snapshot.yml
+++ b/.github/workflows/traffic-snapshot.yml
@@ -1,0 +1,58 @@
+name: Traffic snapshot
+
+# GitHub's traffic API only retains the last 14 days of clones and views, and
+# referrers are a point-in-time top list. This job snapshots all three weekly
+# and commits the history into metrics/ so the record survives that window.
+# Clone/view counts and referrers are aggregate, non-personal data.
+#
+# Requires a token that can read repository traffic. The built-in GITHUB_TOKEN
+# CANNOT read the traffic API, so create a repository secret named
+# TRAFFIC_TOKEN, one of:
+#   - a fine-grained PAT scoped to this repo with "Administration: read", or
+#   - a classic PAT with the "repo" scope.
+# Without the secret the job logs a warning and exits cleanly rather than
+# failing, so a fork without the secret stays green.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: traffic-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Guard on the traffic token
+        env:
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        run: |
+          if [ -z "$TRAFFIC_TOKEN" ]; then
+            echo "::warning::TRAFFIC_TOKEN secret is not set; skipping snapshot. See the workflow header for setup."
+            echo "skip=1" >> "$GITHUB_ENV"
+          fi
+      - name: Fetch and merge traffic
+        if: env.skip != '1'
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: python3 .github/scripts/traffic_snapshot.py
+      - name: Commit the snapshot
+        if: env.skip != '1'
+        run: |
+          git config user.name "Cristian Ducu"
+          git config user.email "32098558+cristianducu@users.noreply.github.com"
+          git add metrics/
+          if git diff --cached --quiet; then
+            echo "No traffic changes to commit."
+          else
+            git commit -m "metrics: weekly traffic snapshot"
+            git push
+          fi

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,34 @@
+# Adopters
+
+Bellbook records and verifies activity entirely offline. It never phones home,
+counts installs, or reports usage anywhere - by design, because a tool meant to
+prove integrity should not itself be a side channel. The cost of that stance is
+that we cannot see who uses it.
+
+This file is how adoption becomes visible. If you use Bellbook, add yourself. It
+helps other evaluators see real usage, and it tells us which directions
+(profiles, selective disclosure, engine adapters) have demand behind them rather
+than being built on speculation.
+
+## Who is using Bellbook
+
+<!--
+Add one row per adopter, newest at the bottom. Only the first column is
+required; leave the others blank if you prefer. Use "personal" or a short
+description instead of an organization name if you would rather not name one.
+Share only what you are comfortable making public.
+-->
+
+| Organization or project | Since | How you use Bellbook | Contact (optional) |
+| --- | --- | --- | --- |
+| _example: Acme Agents (remove this row)_ | _2026-08_ | _receipts for best-of-N model selection in CI_ | _@handle_ |
+
+## How to add yourself
+
+Open a pull request that adds one row to the table above. If you would rather
+not open a pull request, comment on the "Who is using Bellbook?" discussion and
+we will add you. Removing your entry later is always a one-line pull request
+away.
+
+Not ready to be listed but using it anyway? A GitHub star, an issue, or a note
+in Discussions still helps us gauge real demand.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,19 @@
+# Traffic metrics
+
+Weekly snapshots of GitHub repository traffic, written by the
+[`traffic-snapshot`](../.github/workflows/traffic-snapshot.yml) workflow. GitHub
+only retains 14 days of traffic, so this directory is the long-term record.
+
+- `clones.csv` - `date,count,uniques`, one row per day (merged, not duplicated).
+- `views.csv` - `date,count,uniques`, one row per day.
+- `referrers.csv` - `snapshot_date,referrer,count,uniques`, appended each run
+  (referrers are a point-in-time top list, not a time series).
+
+These are aggregate, non-personal counts. `uniques` is a better adoption proxy
+than raw `count`, and a clone/view trend that does not track your CI schedule is
+the signal worth watching. See [ADOPTERS.md](../ADOPTERS.md) for the qualitative
+counterpart.
+
+The CSV files appear here after the first successful run of the workflow, which
+needs a `TRAFFIC_TOKEN` secret (the built-in `GITHUB_TOKEN` cannot read the
+traffic API).


### PR DESCRIPTION
Bellbook does not phone home, so adoption cannot be measured passively (downloads are dominated by CI and mirrors, and there are no reverse dependencies yet). This adds two low-touch mechanisms to make real usage legible.

## ADOPTERS.md

A self-report table in the CNCF style (the pattern Kubernetes, Envoy, and containerd use), plus a short "how to add yourself" section. For a no-telemetry trust tool this is the honest way to surface who uses it and which directions (profiles, selective disclosure, engine adapters) have demand behind them.

## Weekly traffic snapshot

GitHub's traffic API only retains 14 days of clones and views, so the history is lost unless snapshotted.

- `.github/workflows/traffic-snapshot.yml` runs weekly (Mondays 06:17 UTC) and on demand.
- `.github/scripts/traffic_snapshot.py` fetches clones, views, and referrers and merges them into `metrics/` (`clones.csv`, `views.csv`, `referrers.csv`). Overlapping days update in place rather than duplicating; referrers are appended per run.
- No third-party actions are used (only pinned `actions/checkout`), and the script is standard-library only, to keep the supply-chain surface minimal.

### One setup step required

The built-in `GITHUB_TOKEN` cannot read the traffic API. Add a repository secret named `TRAFFIC_TOKEN`, one of:

- a fine-grained PAT scoped to this repo with `Administration: read`, or
- a classic PAT with the `repo` scope.

Without the secret the job logs a warning and exits cleanly (so forks stay green); it commits a snapshot only when there is a change.

## Verification

- `python3 -c "ast.parse(...)"` and a YAML load both pass.
- Dry-ran the merge logic: overlapping days are updated (not duplicated), new days append, and referrers append with the run date.

No library or spec changes; docs, CI, and repo-surface only.