### PR TITLE
rules: surface admin and reaffirmer actors in rules init and default_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Retraction-story rules knobs on both surfaces** (#84). `bellbook rules
+  init` gains repeatable `--admin <id>` (populates `admin_retraction_actors`:
+  actors allowed to retract records they did not author) and
+  `--reaffirmer <id>` (populates `reaffirmation_actors`: when non-empty,
+  restricts reaffirming selections to the listed actors); Python
+  `default_rules` gains matching `admins=` and `reaffirmers=` keyword
+  arguments, and `VerifierRules` gains the corresponding builder methods.
+  Both surfaces refuse an admin or reaffirmer id that has no author binding,
+  since such an actor could never author an accepted record. Without these,
+  Executor-authored records were retractable only through a knob no adoption
+  surface could set. The rules shape is unchanged - the fields existed since
+  their spec epochs; only the generation surface grew.
+
 ## [0.4.0] - 2026-08-20
 
 Adoption and hardening release. It adds no new record kinds and no spec change -

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ record and prints its id; `--json` prints `{ id, result, reason? }` that
 round-trips, so pipelines can chain ids without scraping text.
 
 ```
-bellbook rules init    --author <id>:<role>... [--max-context <n>] [--out <file>]
+bellbook rules init    --author <id>:<role>... [--admin <id>]... [--reaffirmer <id>]...
+                       [--max-context <n>] [--out <file>]
 bellbook candidate add --log <dir> --rules <file> --author <id> \
          --git-tree <oid> [--continues <sel> --parent <cand>
                            | --derives-from <id>... | --upgrades <cand>]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -72,10 +72,13 @@ It holds the same exclusive lock and runs the same replay-on-commit the Rust
 `LogWriter` does. `rules` is a JSON string: the verifier rules the log is
 committed under, the same object a receipt embeds under `rules`.
 
-`default_rules(authors, max_context=200)` builds that string for you - the
-Python counterpart to `bellbook rules init` - so you never hand-author a rules
-object. `authors` maps an actor id to a role (`user`, `provider`, `system`,
-`executor`, or `verifier`, case-insensitive):
+`default_rules(authors, max_context=200, admins=None, reaffirmers=None)` builds
+that string for you - the Python counterpart to `bellbook rules init` - so you
+never hand-author a rules object. `authors` maps an actor id to a role (`user`,
+`provider`, `system`, `executor`, or `verifier`, case-insensitive). `admins`
+lists actors allowed to retract records they did not author; `reaffirmers`,
+when given, restricts reaffirming selections to the listed actors. Both must
+also appear in `authors`:
 
 ```python
 import bellbook

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -328,13 +328,26 @@ fn parse_role(s: &str) -> PyResult<AuthorType> {
 /// actor id to one of `user`, `provider`, `system`, `executor`, or `verifier`
 /// (case-insensitive). The result is a JSON string ready to pass to `Writer`.
 ///
+/// `admins` lists actors allowed to retract records they did not author (a
+/// Retraction is otherwise valid only from the target's own author, and an
+/// Executor may never author one). `reaffirmers`, when non-empty, restricts
+/// reaffirming selections to the listed actors. Both must also appear in
+/// `authors`: an actor with no role binding could never author an accepted
+/// record, so listing it here would be a silent no-op.
+///
 /// ```python
-/// rules = bellbook.default_rules({"agent": "provider", "evaluator": "provider"})
+/// rules = bellbook.default_rules({"agent": "provider", "evaluator": "provider"},
+///                                admins=["agent"])
 /// w = bellbook.Writer("./log", rules)
 /// ```
 #[pyfunction]
-#[pyo3(signature = (authors, max_context=200))]
-fn default_rules(authors: BTreeMap<String, String>, max_context: u32) -> PyResult<String> {
+#[pyo3(signature = (authors, max_context=200, admins=None, reaffirmers=None))]
+fn default_rules(
+    authors: BTreeMap<String, String>,
+    max_context: u32,
+    admins: Option<Vec<String>>,
+    reaffirmers: Option<Vec<String>>,
+) -> PyResult<String> {
     if authors.is_empty() {
         return Err(PyValueError::new_err(
             "default_rules needs at least one author binding",
@@ -346,6 +359,24 @@ fn default_rules(authors: BTreeMap<String, String>, max_context: u32) -> PyResul
             return Err(PyValueError::new_err("author id must be non-empty"));
         }
         rules = rules.with_author_role(id.clone(), parse_role(role)?);
+    }
+    for (name, ids) in [("admins", &admins), ("reaffirmers", &reaffirmers)] {
+        for id in ids.iter().flatten() {
+            if !authors.contains_key(id) {
+                return Err(PyValueError::new_err(format!(
+                    "{name} entry {id:?} has no author binding; add it to authors"
+                )));
+            }
+        }
+    }
+    // Insert into the public sets directly rather than through the core's
+    // builder methods, so the binding keeps building against the published
+    // core crate (the builders arrive with the next core release).
+    for id in admins.iter().flatten() {
+        rules.admin_retraction_actors.insert(id.clone().into());
+    }
+    for id in reaffirmers.iter().flatten() {
+        rules.reaffirmation_actors.insert(id.clone().into());
     }
     serde_json::to_string(&rules)
         .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize rules: {e}")))

--- a/bindings/python/tests/test_default_rules.py
+++ b/bindings/python/tests/test_default_rules.py
@@ -49,3 +49,29 @@ def test_default_rules_rejects_bad_role():
 def test_default_rules_rejects_empty():
     with pytest.raises(ValueError, match="at least one"):
         bellbook.default_rules({})
+
+
+def test_default_rules_binds_admins_and_reaffirmers():
+    rules = json.loads(
+        bellbook.default_rules(
+            {"agent": "provider", "human": "user"},
+            admins=["human"],
+            reaffirmers=["human"],
+        )
+    )
+    assert rules["admin_retraction_actors"] == ["human"]
+    assert rules["reaffirmation_actors"] == ["human"]
+
+    # The knobs are opt-in: omitted, both sets stay empty.
+    bare = json.loads(bellbook.default_rules({"agent": "provider"}))
+    assert bare["admin_retraction_actors"] == []
+    assert bare["reaffirmation_actors"] == []
+
+
+def test_default_rules_rejects_admin_without_author_binding():
+    # An admin with no role binding could never author an accepted record,
+    # so listing it would be a silent no-op; it must be refused instead.
+    with pytest.raises(ValueError, match="no author binding"):
+        bellbook.default_rules({"agent": "provider"}, admins=["ghost"])
+    with pytest.raises(ValueError, match="no author binding"):
+        bellbook.default_rules({"agent": "provider"}, reaffirmers=["ghost"])

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -44,7 +44,8 @@ USAGE:
                            (--choose <id> ... --uses-eval <id> ... | --none)
                            [--replaces <selection-id>] [--rationale <s>] [--json]
     bellbook lineage       --log <dir> --rules <file> <id> [--json]
-    bellbook rules init    --author <id>:<role> ... [--max-context <n>] [--out <file>]
+    bellbook rules init    --author <id>:<role> ... [--admin <id>] ... [--reaffirmer <id>] ...
+                           [--max-context <n>] [--out <file>]
     bellbook export        --log <dir> --rules <file> [--out <file>]
 
 COMMANDS:
@@ -56,7 +57,9 @@ COMMANDS:
     select      Record a Selection over candidates (or a reaffirmation).
     lineage     Show a candidate's descent, siblings, taint, and standing.
     rules init  Generate a starter verifier-rules file. Roles are one of
-                user|provider|system|executor|verifier.
+                user|provider|system|executor|verifier. --admin allows an
+                actor to retract records it did not author; --reaffirmer
+                restricts reaffirming selections to the listed actors.
     export      Bundle a log directory into a portable receipt (the input
                 `bellbook validate` verifies).
 
@@ -101,9 +104,12 @@ fn parse_role(s: &str) -> Option<AuthorType> {
 }
 
 /// `rules init` writes a starter verifier-rules file: the default space, a
-/// context bound, and one author-role binding per `--author <id>:<role>`. It is
-/// the trust policy the CLI's `--rules` flag and the receipt embed; generating
-/// one by hand is the main ceremony a new user hits, so this removes it.
+/// context bound, one author-role binding per `--author <id>:<role>`, and
+/// optionally the two retraction-story knobs - `--admin <id>` (may retract
+/// records it did not author) and `--reaffirmer <id>` (restricts reaffirming
+/// selections to the listed actors). It is the trust policy the CLI's
+/// `--rules` flag and the receipt embed; generating one by hand is the main
+/// ceremony a new user hits, so this removes it.
 fn cmd_rules(rest: &[String]) -> ExitCode {
     let (sub, rest) = match rest.split_first() {
         Some((s, r)) => (s.as_str(), r),
@@ -118,11 +124,35 @@ fn cmd_rules(rest: &[String]) -> ExitCode {
     }
 
     let mut authors: Vec<(String, AuthorType)> = Vec::new();
+    let mut admins: Vec<String> = Vec::new();
+    let mut reaffirmers: Vec<String> = Vec::new();
     let mut max_context: u32 = 200;
     let mut out: Option<String> = None;
     let mut it = rest.iter();
     while let Some(arg) = it.next() {
         match arg.as_str() {
+            "--admin" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--admin requires an actor id");
+                    return ExitCode::from(64);
+                };
+                if v.is_empty() {
+                    eprintln!("--admin id must be non-empty");
+                    return ExitCode::from(64);
+                }
+                admins.push(v.clone());
+            }
+            "--reaffirmer" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--reaffirmer requires an actor id");
+                    return ExitCode::from(64);
+                };
+                if v.is_empty() {
+                    eprintln!("--reaffirmer id must be non-empty");
+                    return ExitCode::from(64);
+                }
+                reaffirmers.push(v.clone());
+            }
             "--author" => {
                 let Some(v) = it.next() else {
                     eprintln!("--author requires <id>:<role>");
@@ -174,9 +204,26 @@ fn cmd_rules(rest: &[String]) -> ExitCode {
         return ExitCode::from(64);
     }
 
+    // An admin or reaffirmer with no role binding could never author an
+    // accepted record, so the flag would be a silent no-op; refuse instead.
+    for (flag, ids) in [("--admin", &admins), ("--reaffirmer", &reaffirmers)] {
+        for id in ids {
+            if !authors.iter().any(|(a, _)| a == id) {
+                eprintln!("{flag} {id:?} has no --author {id}:<role> binding; add one");
+                return ExitCode::from(64);
+            }
+        }
+    }
+
     let mut rules = VerifierRules::new(default_space(), max_context);
     for (id, role) in authors {
         rules = rules.with_author_role(id, role);
+    }
+    for id in admins {
+        rules = rules.with_admin_retraction_actor(id);
+    }
+    for id in reaffirmers {
+        rules = rules.with_reaffirmation_actor(id);
     }
     let json = match serde_json::to_string(&rules) {
         Ok(s) => s,

--- a/src/verify/rules.rs
+++ b/src/verify/rules.rs
@@ -221,6 +221,24 @@ impl VerifierRules {
         self.author_roles.insert(actor.into(), role);
         self
     }
+
+    /// Allow an actor to retract records it did not author (see
+    /// `admin_retraction_actors`). The actor still needs an `author_roles`
+    /// binding for its Retraction records to be accepted at all. Returns
+    /// self for chaining during rules construction.
+    pub fn with_admin_retraction_actor(mut self, actor: impl Into<ActorId>) -> Self {
+        self.admin_retraction_actors.insert(actor.into());
+        self
+    }
+
+    /// Restrict reaffirming Selections to an identity allowlist (see
+    /// `reaffirmation_actors`); the first call switches the set from
+    /// "anyone with a valid role" to "listed actors only". Returns self for
+    /// chaining during rules construction.
+    pub fn with_reaffirmation_actor(mut self, actor: impl Into<ActorId>) -> Self {
+        self.reaffirmation_actors.insert(actor.into());
+        self
+    }
 }
 
 /// Build the frozen kind-schema map.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -634,6 +634,69 @@ fn rules_init_needs_an_author() {
 }
 
 #[test]
+fn rules_init_binds_admins_and_reaffirmers() {
+    let out = bellbook()
+        .args([
+            "rules",
+            "init",
+            "--author",
+            "agent:provider",
+            "--author",
+            "human:user",
+            "--admin",
+            "human",
+            "--reaffirmer",
+            "human",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed: VerifierRules = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(parsed.admin_retraction_actors.contains("human"));
+    assert!(parsed.reaffirmation_actors.contains("human"));
+    // The knobs are opt-in: nothing leaks into the sets besides what was asked.
+    assert_eq!(parsed.admin_retraction_actors.len(), 1);
+    assert_eq!(parsed.reaffirmation_actors.len(), 1);
+}
+
+#[test]
+fn rules_init_rejects_an_admin_without_an_author_binding() {
+    // An admin with no role binding could never author an accepted record,
+    // so the flag would be a silent no-op; it must be refused instead.
+    let out = bellbook()
+        .args([
+            "rules",
+            "init",
+            "--author",
+            "agent:provider",
+            "--admin",
+            "ghost",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(64));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("no --author"));
+
+    let out = bellbook()
+        .args([
+            "rules",
+            "init",
+            "--author",
+            "agent:provider",
+            "--reaffirmer",
+            "ghost",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(64));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("no --author"));
+}
+
+#[test]
 fn rules_init_rejects_bad_max_context() {
     let out = bellbook()
         .args([


### PR DESCRIPTION
First v0.5.0 PR - the foundation the retract verbs (#82, #83) and their adversarial tests (#87) need.

Closes #84

## Problem

Retraction is ownership-bound (SPEC section 2): the retractor must be the target's author or listed in `rules.admin_retraction_actors`, and an Executor may never author a Retraction at all - so Executor-authored records are retractable only through admin actors. Neither `bellbook rules init` nor Python `default_rules` could set that knob, making a whole class of retractions unreachable from any adoption surface. The restore path's `reaffirmation_actors` had the same gap.

## Changes

- `VerifierRules` gains `with_admin_retraction_actor` and `with_reaffirmation_actor` builder methods (style of `with_author_role`).
- `bellbook rules init` gains repeatable `--admin ID` and `--reaffirmer ID`; USAGE and help text updated.
- Python `default_rules(authors, max_context=200, admins=None, reaffirmers=None)`; docstring and Python README updated.
- Both surfaces refuse an admin or reaffirmer id that has no author binding - such an actor could never author an accepted record, so the flag would be a silent no-op; refusing is the honest behavior.
- CHANGELOG `[Unreleased]` entry.

Bounded to exactly these two knobs per the issue - this is not a general rules-editing surface.

## Notes

- The rules JSON shape is unchanged; both fields have existed since their spec epochs. Only the generation surface grew. No spec change; epoch stays 0.3.
- The binding inserts into the public sets directly instead of calling the new core builders, so it keeps building against the published `bellbook 0.4.0` crate (the builders ship with the 0.5.0 core). Caught during the pre-PR audit: the builder-method route fails to compile against the published core.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`: clean (core and binding).
- Full Rust suite green, including 2 new CLI tests (`rules_init_binds_admins_and_reaffirmers`, `rules_init_rejects_an_admin_without_an_author_binding`); CLI suite now 26 tests.
- Binding rebuilt with maturin against this tree; full pytest suite green (31 tests, including 2 new for the kwargs and their validation).
- The end-to-end proof that an admin actor's cross-author retraction is accepted necessarily waits for the retract verbs; it is specified in #87's battery and lands with PR 3.