### PR TITLE
python: expose retraction in the Writer and document the repair pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Python `Writer.retract(author, target, reason)`** (#82). Commits a
+  `Retraction` record (payload `{target_id, reason}` with the exactly-one
+  `Cause` ref the verifier checks) and returns a `Commit` like the other
+  verbs. Ownership is enforced by replay: the retractor must be the
+  target's author or an admin retraction actor, an Executor may never
+  author one, and a Verdict or Retraction cannot be retracted. On
+  acceptance the receipt reports Tainted permanently; a reaffirming
+  selection restores standing, never Clean. With this, the broken-benchmark
+  story (retract -> taint -> reaffirm -> restore) runs end to end from
+  Python alone.
+- **The repair pattern documented for Python** (#85). A Derivation
+  candidate's `derives_from` members may be candidates or evaluations, so a
+  repair *motivated by* an evaluation names it there
+  (`derives_from=[sound_parent, failing_eval]`); `Cause` carries intent,
+  not taint, so retracting that evaluation later does not compromise the
+  repair. Verified against the verifier and pinned by a binding test; the
+  set-valued `Writer` parameters are now documented as lists.
+
 - **Retraction-story rules knobs on both surfaces** (#84). `bellbook rules
   init` gains repeatable `--admin <id>` (populates `admin_retraction_actors`:
   actors allowed to retract records they did not author) and

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -98,8 +98,8 @@ report = bellbook.validate(w.receipt())
 assert report.status == "clean"
 ```
 
-Each of `candidate`, `evaluate`, and `select` commits one record and returns a
-`Commit` (`id`, `accepted`, `result`, `reason`). A record is durably committed
+Each of `candidate`, `evaluate`, `select`, and `retract` commits one record
+and returns a `Commit` (`id`, `accepted`, `result`, `reason`). A record is durably committed
 whether accepted or rejected - a rejected record is evidence a proposal was
 refused - so `accepted` may be `False` without an exception. Statically-knowable
 payload violations (an unregistered author, a score scale above 12, an upgrade
@@ -108,15 +108,47 @@ written.
 
 - `candidate(author, git_tree, *, git_commit=None, algo="sha1", note=None,
   continues=None, parent=None, derives_from=None, upgrades=None, manifest=None)`
-  - basis is exactly one of `continues` (with `parent`), `derives_from`, or
-    `upgrades`; omit all three for a Root. `manifest` (a directory path) binds
-    the source by a canonical manifest hash instead of a reported tree.
+  - basis is exactly one of `continues` (with `parent`), `derives_from` (a
+    **list** of record ids), or `upgrades`; omit all three for a Root.
+    `manifest` (a directory path) binds the source by a canonical manifest
+    hash instead of a reported tree. A `derives_from` member may be a
+    candidate or an evaluation: a repair *motivated by* an evaluation names
+    it there alongside the candidate it derives from
+    (`derives_from=[sound_parent.id, failing_eval.id]`), and because `Cause`
+    carries intent, not taint, retracting that evaluation later does not
+    taint the repair.
 - `evaluate(author, candidate, criterion, *, passed=False, failed=False,
   score=None, scale=None, procedure=None, uses=None)` - exactly one of
   `passed`, `failed`, or a `score` (with `scale`, a decimal exponent 0-12).
 - `select(author, objective, consider, *, choose=None, uses_eval=None,
   none=False, replaces=None, rationale=None)` - exactly one of `choose` (with
   `uses_eval`) or `none=True`; `replaces` reaffirms a prior selection.
+  `consider`, `choose`, and `uses_eval` are **lists** of record ids.
+
+## Retract
+
+`retract(author, target, reason)` asserts a committed record's content is
+wrong. The target stays in the log; its id enters the retracted set, its
+epistemic dependents become tainted, and the receipt reports **Tainted** from
+then on - permanently. A later reaffirming selection (one that `replaces` the
+unsound one on surviving evidence) restores the line's *standing*, but never
+turns the receipt Clean again: the episode is part of history, and that is the
+point.
+
+```python
+r = w.retract(author="evaluator", target=e0.id,
+              reason="benchmark harness measured the wrong thing")
+assert r.accepted
+assert bellbook.validate(w.receipt()).status == "tainted"
+```
+
+Retraction is ownership-bound (SPEC section 2): it is accepted only when
+`author` is the target's author, or is listed in the rules'
+`admin_retraction_actors` (set via `default_rules(..., admins=[...])`). An
+Executor may never author a retraction, so Executor-authored records are
+retractable only through an admin actor. A Verdict or a Retraction cannot be
+retracted. As with the other verbs, a rejected retraction is still durably
+committed with `accepted == False` and the verifier's reason.
 
 The writer is deliberately single-writer (SPEC 5.1): it holds an exclusive lock
 for the log directory, so a second `Writer` on the same directory raises. Other

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -23,9 +23,9 @@ use bellbook_core::{
     schema_id, validate as core_validate, verify_and_build_state, Author, AuthorType, BindingMode,
     CandidateBasis, CandidateData, EvaluationData, EvaluationOutcome, GitSource, Kind, LogWriter,
     Proposal, Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType,
-    Report as CoreReport, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo, SourceBinding,
-    State, ValidationStatus, VerdictResult, VerifierRules, SCHEMA_CANDIDATE, SCHEMA_EVALUATION,
-    SCHEMA_SELECTION,
+    Report as CoreReport, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
+    SourceBinding, State, ValidationStatus, VerdictResult, VerifierRules, SCHEMA_CANDIDATE,
+    SCHEMA_EVALUATION, SCHEMA_RETRACTION, SCHEMA_SELECTION,
 };
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -827,6 +827,41 @@ impl Writer {
             author,
             Kind::Selection,
             schema_id(SCHEMA_SELECTION),
+            data,
+            refs,
+        )
+    }
+
+    /// Retract a committed record: assert its content is wrong. The target
+    /// stays in the log; on acceptance its id enters the retracted set and
+    /// its epistemic dependents become tainted, so the receipt reports
+    /// Tainted from then on - permanently. `reason` is a free-form statement
+    /// of why the content is wrong; it is recorded, not interpreted.
+    ///
+    /// Ownership is enforced by replay (SPEC section 2): the retraction is
+    /// accepted only when `author` is the target's author or is listed in the
+    /// rules' `admin_retraction_actors` (see `default_rules(admins=...)`).
+    /// An Executor may never author a Retraction. A Verdict or a Retraction
+    /// cannot be retracted. As with the other verbs, a rejected retraction
+    /// is still durably committed, with `accepted=False` and the reason.
+    #[pyo3(signature = (author, target, reason))]
+    fn retract(&mut self, author: &str, target: &str, reason: &str) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        let target = parse_id(target)?;
+
+        // The verifier requires exactly one Cause ref naming the target.
+        let refs = vec![Ref {
+            type_: RefType::Cause,
+            target,
+        }];
+        let data = checked_encode(&RetractionData {
+            target_id: target,
+            reason: reason.to_string(),
+        })?;
+        self.do_commit(
+            author,
+            Kind::Retraction,
+            schema_id(SCHEMA_RETRACTION),
             data,
             refs,
         )

--- a/bindings/python/tests/test_retract.py
+++ b/bindings/python/tests/test_retract.py
@@ -1,0 +1,147 @@
+"""`Writer.retract` - the retraction half of the model, from Python.
+
+Retraction asserts a committed record's content is wrong: the target stays in
+the log, its id enters the retracted set, dependents become tainted, and the
+receipt reports Tainted permanently. Ownership is enforced by replay: the
+retractor must be the target's author or an admin retraction actor, and an
+Executor may never author one.
+"""
+
+import pytest
+
+import bellbook
+
+
+def _writer(tmp_path, name="log", **kwargs):
+    rules = bellbook.default_rules(
+        {"agent": "provider", "evaluator": "provider", "human": "user"}, **kwargs
+    )
+    return bellbook.Writer(str(tmp_path / name), rules)
+
+
+def _line(w):
+    """One candidate, one passing evaluation, one selection resting on it."""
+    c = w.candidate(author="agent", git_tree="a" * 40)
+    e = w.evaluate(author="evaluator", candidate=c.id, criterion="fitness", passed=True)
+    s = w.select(
+        author="agent",
+        objective="best-of-n",
+        consider=[c.id],
+        choose=[c.id],
+        uses_eval=[e.id],
+    )
+    assert s.accepted, s.reason
+    return c, e, s
+
+
+def test_retract_turns_the_receipt_tainted_permanently(tmp_path):
+    w = _writer(tmp_path)
+    c, e, s = _line(w)
+    assert bellbook.validate(w.receipt()).status == "clean"
+
+    r = w.retract(author="evaluator", target=e.id, reason="benchmark was broken")
+    assert r.accepted, r.reason
+
+    report = bellbook.validate(w.receipt())
+    assert report.status == "tainted"
+    assert report.retracted == [e.id]
+    # The selection Used the retracted evaluation, so kernel taint reaches it.
+    assert report.tainted == [s.id]
+    # Standing: the unsound selection is named, nothing restored yet.
+    assert s.id in report.standing["unsound"]
+    assert report.standing["restorations"] == {}
+
+
+def test_cross_author_retraction_is_rejected(tmp_path):
+    # Ownership: an actor may not retract someone else's record unless it is
+    # an admin retraction actor. The rejected record is still committed.
+    w = _writer(tmp_path)
+    c, e, s = _line(w)
+    r = w.retract(author="agent", target=e.id, reason="not mine to retract")
+    assert not r.accepted
+    assert r.reason == "AuthorRoleInvalid"
+    # The receipt stays clean: a rejected retraction retracts nothing.
+    assert bellbook.validate(w.receipt()).status == "clean"
+
+
+def test_admin_actor_may_retract_across_authors(tmp_path):
+    # The same cross-author retraction is accepted once the retractor is
+    # listed in admin_retraction_actors (default_rules admins=).
+    w = _writer(tmp_path, admins=["human"])
+    c, e, s = _line(w)
+    r = w.retract(author="human", target=e.id, reason="admin override")
+    assert r.accepted, r.reason
+    assert bellbook.validate(w.receipt()).status == "tainted"
+
+
+def test_retracting_a_retraction_or_missing_target_is_rejected(tmp_path):
+    w = _writer(tmp_path)
+    c, e, s = _line(w)
+    r1 = w.retract(author="evaluator", target=e.id, reason="broken")
+    assert r1.accepted
+
+    # A retraction cannot be retracted (that would un-assert wrongness).
+    r2 = w.retract(author="evaluator", target=r1.id, reason="undo")
+    assert not r2.accepted
+
+    # A target that is not in the log resolves nowhere.
+    r3 = w.retract(author="evaluator", target="f" * 64, reason="ghost")
+    assert not r3.accepted
+
+    # A second retraction of the same target is valid (the record stays
+    # retracted; asserting wrongness twice is redundant, not contradictory).
+    r4 = w.retract(author="evaluator", target=e.id, reason="again")
+    assert r4.accepted
+
+
+def test_reaffirmation_restores_standing_but_not_clean(tmp_path):
+    # The full story: retract the evidence, watch the line go unsound, then
+    # reaffirm on fresh evidence. Standing is restored; Clean never returns.
+    w = _writer(tmp_path)
+    c, e, s = _line(w)
+    w.retract(author="evaluator", target=e.id, reason="benchmark was broken")
+
+    e2 = w.evaluate(
+        author="evaluator", candidate=c.id, criterion="manual-review", passed=True
+    )
+    s2 = w.select(
+        author="agent",
+        objective="best-of-n",
+        consider=[c.id],
+        choose=[c.id],
+        uses_eval=[e2.id],
+        replaces=s.id,
+    )
+    assert s2.accepted, s2.reason
+
+    report = bellbook.validate(w.receipt())
+    # Tainted forever: the retraction is part of history.
+    assert report.status == "tainted"
+    # But the standing section records the restoration.
+    assert report.standing["restorations"] == {s.id: [s2.id]}
+
+
+def test_repair_motivated_by_a_retracted_evaluation_stays_sound(tmp_path):
+    # The repair pattern (#85): a candidate may name the evaluation that
+    # motivated it in derives_from, alongside the candidate it derives from.
+    # Cause carries intent, not taint, so retracting that evaluation later
+    # does not compromise the repair.
+    w = _writer(tmp_path)
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    e0 = w.evaluate(
+        author="evaluator", candidate=c0.id, criterion="fitness", failed=True
+    )
+    repair = w.candidate(
+        author="agent", git_tree="b" * 40, derives_from=[c0.id, e0.id]
+    )
+    assert repair.accepted, repair.reason
+
+    r = w.retract(author="evaluator", target=e0.id, reason="the check was wrong")
+    assert r.accepted
+
+    report = bellbook.validate(w.receipt())
+    assert report.status == "tainted"
+    assert report.retracted == [e0.id]
+    # The repair is not tainted and its standing is not compromised.
+    assert repair.id not in report.tainted
+    assert repair.id not in report.standing["compromised"]


### PR DESCRIPTION
Second v0.5.0 PR. With this, the broken-benchmark story (build a line, retract the evaluation it rests on, watch standing collapse, reaffirm, watch it restore) runs end to end from Python alone - the largest gap the canary field test surfaced.

Closes #82
Closes #85

## Changes

**`Writer.retract(author, target, reason)`** commits a `Kind::Retraction` record and returns a `Commit` like the other verbs:

- Payload is `RetractionData { target_id, reason }` with the exactly-one `Cause` ref to the target - matched to `check_retraction`'s shape, not reimplemented (the binding stays thin; ownership, kind restrictions, and target resolution are the verifier's, and a rejected retraction is durably committed with `accepted == False` and the reason, as the other verbs do).
- Docstring and Python README document the semantics honestly: Tainted is permanent; a reaffirming selection restores *standing*, never Clean; an Executor may never author a retraction; admin actors (from #84's `default_rules(admins=...)`) may retract across authors.

**The repair pattern (#85) is verified and documented rather than added.** The verifier's Derivation basis accepts `Cause` targets that are candidates **or evaluations**, and `derives_from` passes ids through unfiltered - so `derives_from=[sound_parent.id, failing_eval.id]` already expresses "motivated by" from Python. Confirmed live against the verifier (a `Cause` to a Selection is correctly rejected with `LineageInvalid`). Documented in the Python README; the set-valued parameters (`derives_from`, `consider`, `choose`, `uses_eval`) are now stated as lists - the exact thing the field test tripped on.

## Tests (6 new, pytest suite now 37)

- retract turns the receipt Tainted permanently, with the expected retracted/tainted/standing sets
- cross-author retraction rejected (`AuthorRoleInvalid`); the same retraction accepted from an admin actor - the end-to-end proof #92 deferred
- retracting a Retraction rejected; a missing target rejected; a second retraction of the same target accepted (redundant, not contradictory)
- reaffirmation restores `standing["restorations"]` while the receipt stays Tainted
- the repair motivated by a retracted evaluation stays sound (not tainted, not compromised)

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets` clean on both crates (fmt caught an unsorted import during the audit; fixed).
- Full Rust suite: 227 tests green. Binding rebuilt with maturin; 37 pytest green.
- No spec change; epoch stays 0.3. `RetractionData`/`SCHEMA_RETRACTION` are in the published 0.4.0 core, so the binding builds against the published crate unchanged.