### PR TITLE
cli: add bellbook retract and enforce the v0.5.0 gate on both surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **CLI `bellbook retract`** (#83). Retract a committed record from a log:
+  `bellbook retract --log DIR --rules FILE --author ID --target RECORD_ID
+  --reason TEXT [--json]`, with the same conventions as the other mutating
+  commands (prints the committed id, exit 65 on a rejected commit). With
+  #82's Python verb, the retraction story now runs from both adoption
+  surfaces, and the v0.5.0 gate is enforced in CI (#87): the
+  broken-benchmark story - Clean, retract, standing collapse, reaffirm,
+  restoration with the receipt Tainted permanently - is replayed end to end
+  by a CLI test and a Python test, plus an ownership battery (cross-author
+  rejected, admin accepted, Verdict/Retraction/missing targets rejected).
+
 - **Python `Writer.retract(author, target, reason)`** (#82). Commits a
   `Retraction` record (payload `{target_id, reason}` with the exactly-one
   `Cause` ref the verifier checks) and returns a `Commit` like the other

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ bellbook eval add      --log <dir> --rules <file> --author <id> \
          --candidate <id> --criterion <s> (--passed | --failed | --score <v> --scale <n>)
 bellbook select        --log <dir> --rules <file> --author <id> --objective <s> \
          --consider <id>... (--choose <id>... --uses-eval <id>... | --none) [--replaces <sel>]
+bellbook retract       --log <dir> --rules <file> --author <id> \
+         --target <record-id> --reason <text>   # receipt reports Tainted from then on
 bellbook lineage       --log <dir> --rules <file> <id> [--json]
 bellbook export        --log <dir> --rules <file> [--out <file>]   # log -> receipt
 ```
@@ -304,7 +306,7 @@ source binding, the selection and reaffirmation rule battery, and the
 replay-derived standing section, derived state with incremental/full-build
 equivalence, checkpoints, the crash-safe writer with idempotent
 compare-and-append, and portable receipts with the offline `bellbook
-validate` CLI, the `candidate`/`eval`/`select`/`lineage` recording
+validate` CLI, the `candidate`/`eval`/`select`/`retract`/`lineage` recording
 commands, and `rules init` / `export` to generate a starter rule set and
 bundle a log into a receipt - fully tested (every rejection reason code has a
 triggering test), clippy-clean, no `unsafe`, no panics in library code.

--- a/bindings/python/tests/test_story_gate.py
+++ b/bindings/python/tests/test_story_gate.py
@@ -1,0 +1,84 @@
+"""The v0.5.0 gate, Python half: the broken-benchmark story end to end.
+
+Behavioral equivalence with examples/broken_benchmark.rs - the same status
+transitions and standing sets, not byte-identical logs. Build a line resting
+on a benchmark evaluation, retract it, watch the whole descendant line go
+compromised while a repair deriving from the sound baseline stays sound,
+reaffirm on fresh evidence, and watch standing restore while the receipt
+stays Tainted permanently.
+"""
+
+import os
+
+import bellbook
+
+
+def test_broken_benchmark_story_runs_from_python_alone(tmp_path):
+    rules = bellbook.default_rules({"agent": "provider", "evaluator": "provider"})
+    w = bellbook.Writer(os.path.join(str(tmp_path), "log"), rules)
+
+    # Phase 1: the line is built, all sound.
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    bench = w.evaluate(
+        author="evaluator", candidate=c0.id, criterion="benchmark", passed=True
+    )
+    s0 = w.select(
+        author="agent",
+        objective="ship",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[bench.id],
+    )
+    c1 = w.candidate(
+        author="agent", git_tree="b" * 40, continues=s0.id, parent=c0.id
+    )
+    c2 = w.candidate(author="agent", git_tree="c" * 40, derives_from=[c1.id])
+    c3 = w.candidate(author="agent", git_tree="d" * 40, derives_from=[c2.id])
+    # The repair: derives from the sound baseline, motivated by the benchmark.
+    c4 = w.candidate(
+        author="agent", git_tree="e" * 40, derives_from=[c0.id, bench.id]
+    )
+    for commit in (c0, bench, s0, c1, c2, c3, c4):
+        assert commit.accepted, commit.reason
+
+    report = bellbook.validate(w.receipt())
+    assert report.status == "clean"
+    assert report.standing == {"compromised": [], "unsound": [], "restorations": {}}
+
+    # Phase 2: the benchmark harness was broken; its author retracts it.
+    r = w.retract(
+        author="evaluator", target=bench.id, reason="harness measured the wrong thing"
+    )
+    assert r.accepted, r.reason
+
+    report = bellbook.validate(w.receipt())
+    assert report.status == "tainted"
+    assert report.retracted == [bench.id]
+    assert report.tainted == [s0.id]
+    # The whole line resting on the unsound selection is compromised, at any
+    # depth; the repair deriving from the sound baseline is not.
+    assert set(report.standing["compromised"]) == {c1.id, c2.id, c3.id}
+    assert report.standing["unsound"] == [s0.id]
+    assert c4.id not in report.standing["compromised"]
+
+    # Phase 3: reaffirm on fresh evidence.
+    review = w.evaluate(
+        author="evaluator", candidate=c0.id, criterion="manual-review", passed=True
+    )
+    s1 = w.select(
+        author="agent",
+        objective="ship",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[review.id],
+        replaces=s0.id,
+    )
+    assert s1.accepted, s1.reason
+
+    report = bellbook.validate(w.receipt())
+    # Tainted permanently: the retraction is history, not an erasure.
+    assert report.status == "tainted"
+    assert report.retracted == [bench.id]
+    # But standing is restored: nothing compromised, the restoration recorded.
+    assert report.standing["compromised"] == []
+    assert report.standing["restorations"] == {s0.id: [s1.id]}

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -43,6 +43,8 @@ USAGE:
                            --objective <s> --consider <id> ...
                            (--choose <id> ... --uses-eval <id> ... | --none)
                            [--replaces <selection-id>] [--rationale <s>] [--json]
+    bellbook retract       --log <dir> --rules <file> --author <id>
+                           --target <record-id> --reason <text> [--json]
     bellbook lineage       --log <dir> --rules <file> <id> [--json]
     bellbook rules init    --author <id>:<role> ... [--admin <id>] ... [--reaffirmer <id>] ...
                            [--max-context <n>] [--out <file>]
@@ -55,6 +57,9 @@ COMMANDS:
     candidate   Record a Candidate (a proposed source state).
     eval        Record an Evaluation of a candidate.
     select      Record a Selection over candidates (or a reaffirmation).
+    retract     Assert a committed record's content is wrong. The target
+                stays in the log; the receipt reports Tainted from then on.
+                Accepted only from the target's author or an admin actor.
     lineage     Show a candidate's descent, siblings, taint, and standing.
     rules init  Generate a starter verifier-rules file. Roles are one of
                 user|provider|system|executor|verifier. --admin allows an
@@ -80,7 +85,9 @@ fn main() -> ExitCode {
     match command {
         "validate" => cmd_validate(&rest),
         "rules" => cmd_rules(&rest),
-        "candidate" | "eval" | "select" | "lineage" | "export" => cmd_evolution(command, &rest),
+        "candidate" | "eval" | "select" | "retract" | "lineage" | "export" => {
+            cmd_evolution(command, &rest)
+        }
         other => {
             eprintln!("unknown command {other:?}\n\n{USAGE}");
             ExitCode::from(64)
@@ -343,6 +350,7 @@ fn cmd_evolution(command: &str, rest: &[String]) -> ExitCode {
         "candidate" => persist_cmds::candidate(rest),
         "eval" => persist_cmds::eval(rest),
         "select" => persist_cmds::select(rest),
+        "retract" => persist_cmds::retract(rest),
         "lineage" => persist_cmds::lineage(rest),
         "export" => persist_cmds::export(rest),
         _ => unreachable!(),
@@ -810,6 +818,53 @@ mod persist_cmds {
             author,
             kind: Kind::Evaluation,
             schema: schema_id(SCHEMA_EVALUATION),
+            data,
+            refs,
+        };
+        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+    }
+
+    // --- retract -----------------------------------------------------------
+
+    /// Retract a committed record: assert its content is wrong. The target
+    /// stays in the log; on acceptance its id enters the retracted set, its
+    /// epistemic dependents become tainted, and the receipt reports Tainted
+    /// from then on - permanently. Ownership is the verifier's (SPEC 2): the
+    /// retraction is accepted only when `--author` is the target's author or
+    /// an admin retraction actor (`rules init --admin`); an Executor may
+    /// never author one; a Verdict or Retraction cannot be retracted. A
+    /// rejected retraction is still durably committed, exit 65, with the
+    /// verifier's reason.
+    pub fn retract(rest: &[String]) -> Result<ExitCode, String> {
+        let p = parse(
+            rest,
+            &["log", "rules", "author", "target", "reason"],
+            &[],
+            &["json"],
+        )?;
+        let rules = load_rules(&p)?;
+        let (writer, state) = open(&p, &rules)?;
+        let author = author(&rules, &p)?;
+
+        let target = parse_id(require(&p, "target")?)?;
+        let reason = require(&p, "reason")?.to_string();
+
+        // The verifier requires exactly one Cause ref naming the target.
+        let refs = vec![Ref {
+            type_: RefType::Cause,
+            target,
+        }];
+        let data = checked_encode(&RetractionData {
+            target_id: target,
+            reason,
+        })?;
+
+        let proposal = Proposal {
+            space: rules.space,
+            thread: rules.space,
+            author,
+            kind: Kind::Retraction,
+            schema: schema_id(SCHEMA_RETRACTION),
             data,
             refs,
         };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -756,3 +756,267 @@ fn validate_is_feature_independent() {
         .unwrap();
     assert_eq!(out.status.code(), Some(66));
 }
+
+// --- retract: the v0.5.0 gate (the broken-benchmark story, CLI alone) ------
+
+/// Rules for the retraction story: two providers plus a human admin who may
+/// retract across authors (`admin_retraction_actors`).
+fn story_env() -> Env {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("log");
+    let rules_path = dir.path().join("rules.json");
+    let rules = VerifierRules::new(SPACE, 200)
+        .with_author_role("agent", AuthorType::Provider)
+        .with_author_role("evaluator", AuthorType::Provider)
+        .with_author_role("human", AuthorType::User)
+        .with_admin_retraction_actor("human");
+    std::fs::write(&rules_path, serde_json::to_string_pretty(&rules).unwrap()).unwrap();
+    Env {
+        _dir: dir,
+        log,
+        rules: rules_path,
+    }
+}
+
+fn eval_passed(env: &Env, author: &str, candidate: &str, criterion: &str) -> String {
+    let out = run(
+        env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            author,
+            "--candidate",
+            candidate,
+            "--criterion",
+            criterion,
+            "--passed",
+            "--json",
+        ],
+    );
+    committed_id(&out)
+}
+
+fn validate_receipt(env: &Env, name: &str) -> Output {
+    let receipt = env._dir.path().join(name);
+    let out = run(env, &["export", "--out", receipt.to_str().unwrap()]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    bellbook().arg("validate").arg(&receipt).output().unwrap()
+}
+
+#[test]
+fn retract_reaffirm_story_runs_from_the_cli_alone() {
+    // The v0.5.0 gate, CLI half: build a line, retract the evaluation it
+    // rests on, watch standing collapse, reaffirm, watch it restore - with
+    // the receipt Tainted permanently from the retraction on.
+    let env = story_env();
+
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &bench,
+            "--json",
+        ],
+    );
+    let s0 = committed_id(&out);
+    // A continuation resting on the selection: the descendant the compromise
+    // must reach.
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_B,
+            "--continues",
+            &s0,
+            "--parent",
+            &c0,
+            "--json",
+        ],
+    );
+    let c1 = committed_id(&out);
+
+    // Phase 1: clean.
+    let out = validate_receipt(&env, "phase1.json");
+    assert_eq!(out.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("CLEAN"));
+
+    // Phase 2: the benchmark was broken; its author retracts it.
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "evaluator",
+            "--target",
+            &bench,
+            "--reason",
+            "benchmark harness measured the wrong thing",
+            "--json",
+        ],
+    );
+    let _retraction = committed_id(&out);
+
+    let out = validate_receipt(&env, "phase2.json");
+    assert_eq!(out.status.code(), Some(2), "tainted receipts exit 2");
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(text.contains("TAINTED"));
+    assert!(text.contains(&bench), "retracted id is reported");
+    assert!(text.contains(&s0), "the selection that Used it is unsound");
+    assert!(
+        text.contains("standing-compromised") && text.contains(&c1),
+        "the continuation descendant is compromised:\n{text}"
+    );
+
+    // Phase 3: reaffirm on fresh evidence; standing restores, Clean does not.
+    let review = eval_passed(&env, "evaluator", &c0, "manual-review");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &review,
+            "--replaces",
+            &s0,
+            "--json",
+        ],
+    );
+    let s1 = committed_id(&out);
+
+    let out = validate_receipt(&env, "phase3.json");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "restored standing stays Tainted"
+    );
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(text.contains("TAINTED"));
+    assert!(
+        text.contains("restorations") && text.contains(&s1),
+        "the restoration is on the record:\n{text}"
+    );
+    assert!(
+        !text.contains("standing-compromised"),
+        "restored line is no longer compromised:\n{text}"
+    );
+}
+
+#[test]
+fn retract_ownership_battery() {
+    // Cross-author rejected; admin accepted; a Retraction and a missing
+    // target rejected; a second retraction of the same target accepted.
+    let env = story_env();
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+
+    // Cross-author: the agent may not retract the evaluator's record.
+    let out = run(
+        &env,
+        &[
+            "retract", "--author", "agent", "--target", &bench, "--reason", "not mine",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("AuthorRoleInvalid"));
+
+    // Admin override: the human is in admin_retraction_actors.
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "human",
+            "--target",
+            &bench,
+            "--reason",
+            "admin override",
+            "--json",
+        ],
+    );
+    let retraction = committed_id(&out);
+
+    // A retraction cannot be retracted.
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "human",
+            "--target",
+            &retraction,
+            "--reason",
+            "undo",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+
+    // A target that resolves nowhere.
+    let ghost = "f".repeat(64);
+    let out = run(
+        &env,
+        &[
+            "retract", "--author", "human", "--target", &ghost, "--reason", "ghost",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+
+    // Redundant re-retraction of the same target is valid, not contradictory.
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "evaluator",
+            "--target",
+            &bench,
+            "--reason",
+            "again",
+            "--json",
+        ],
+    );
+    let _ = committed_id(&out);
+}
+
+#[test]
+fn retract_requires_target_and_reason() {
+    let env = story_env();
+    let c0 = add_root(&env, TREE_A);
+
+    let out = run(&env, &["retract", "--author", "agent", "--target", &c0]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--reason"));
+
+    let out = run(
+        &env,
+        &["retract", "--author", "agent", "--reason", "no target"],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--target"));
+}


### PR DESCRIPTION
Third v0.5.0 PR. The CLI gains the retract verb, and the milestone's release gate becomes an enforced CI check on both surfaces.

Closes #83
Closes #87

## Changes

**`bellbook retract`** (persist_cmds, same conventions as the other mutating commands):

```
bellbook retract --log DIR --rules FILE --author ID --target RECORD_ID --reason TEXT [--json]
```

- Commits `Kind::Retraction` with the `{target_id, reason}` payload and the exactly-one `Cause` ref the verifier checks; prints the committed id, `--json` for machine capture, exit 65 on a rejected commit, using the shared strict flag parser (typos, double flags, and swallowed values are refused).
- Ownership stays the verifier's (SPEC section 2); the CLI is thin and reports the verifier's reason on rejection. USAGE, COMMANDS help, root README usage block, and the feature list updated.

**The gate is now a check, not a claim** (#87):

- `tests/cli.rs`: `retract_reaffirm_story_runs_from_the_cli_alone` replays the whole story with the compiled binary - Clean (exit 0), retract, Tainted (exit 2) with the retracted id, unsound selection, and compromised continuation named in the report, reaffirm, restoration on the record with `standing-compromised` gone while the receipt stays Tainted. Plus `retract_ownership_battery` (cross-author rejected with `AuthorRoleInvalid`, admin actor accepted via `admin_retraction_actors`, retracting a Retraction rejected, missing target rejected, redundant re-retraction accepted) and a usage test.
- `bindings/python/tests/test_story_gate.py`: the same story from Python with the deeper shape of `examples/broken_benchmark.rs` - a three-generation line goes compromised at depth, the motivated-by repair (`derives_from=[c0, bench]`) stays sound, and reaffirmation clears `compromised` and records `restorations == {s0: [s1]}` while the receipt stays Tainted. Behavioral equivalence with the Rust example (same transitions and standing sets), as the milestone defines.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`: clean (fmt caught one long assert; fixed).
- Full Rust suite: 230 tests green (CLI suite now 29). Binding rebuilt with maturin; 38 pytest green.
- All three new CLI tests and the Python story gate passed on their first run against the implementation - the standing sets matched the Rust example exactly.
- No spec change; epoch stays 0.3. No new CI jobs; the gate runs in the ordinary suites.