### PR TITLE
release: v0.5.0

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.4.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.5.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-27
+
+Retraction and standing on every surface. No new record kinds and no spec
+change - the epoch stays 0.3 - and the library API is unchanged. What
+changes is reach: the semantics that define Bellbook (retraction,
+transitive taint, standing, restoration) were previously exercisable only
+from the Rust core; the CLI and the Python package can now tell the whole
+story, and the story is enforced in CI on both surfaces. Existing 0.3/0.4
+receipts and rules validate identically.
+
 ### Added
 
 - **CLI `bellbook retract`** (#83). Retract a committed record from a log:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ evolution kinds to a log and exports a receipt. See
 
 ## Status
 
-**The published release is 0.4.0, implementing spec v0.3 (evolution
+**The published release is 0.5.0, implementing spec v0.3 (evolution
 semantics: Candidate, Evaluation, and Selection records with replay-derived
 lineage standing).** SPEC.md is the authority for what v0.3 means (design
 notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)). The previous epoch,

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -8,10 +8,11 @@
 //!   (records, kinds, authors, evidence, refs, payloads). Reading does not
 //!   verify; call `validate` for the decision.
 //! - `bellbook.Writer(log_dir, rules)` records evolution to a persistent,
-//!   single-writer log: `candidate`, `evaluate`, and `select` each commit one
-//!   record and return a [`Commit`]. The writer holds the same exclusive lock
-//!   and runs the same replay-on-commit the Rust `LogWriter` does. Export the
-//!   log with `writer.receipt()` and feed it straight back to `validate`.
+//!   single-writer log: `candidate`, `evaluate`, `select`, and `retract`
+//!   each commit one record and return a [`Commit`]. The writer holds the
+//!   same exclusive lock and runs the same replay-on-commit the Rust
+//!   `LogWriter` does. Export the log with `writer.receipt()` and feed it
+//!   straight back to `validate`.
 
 // `#[pyfunction]` generates a result conversion that clippy reads as a
 // useless `PyErr -> PyErr` conversion for any `PyResult`-returning function.

--- a/docs/quickstart-best-of-n.md
+++ b/docs/quickstart-best-of-n.md
@@ -57,8 +57,8 @@ for git_tree, score in [("a1b2...", 40), ("c3d4...", 90), ("e5f6...", 65)]:
 
 # your harness picks the winner; Bellbook records the choice and its evidence
 winner = cands[1]
-w.select(author="agent", objective="best-of-n",
-         consider=cands, choose=[winner], uses_eval=evals)
+s = w.select(author="agent", objective="best-of-n",
+             consider=cands, choose=[winner], uses_eval=evals)
 
 # export a receipt and verify it, all in one process
 report = bellbook.validate(w.receipt())
@@ -92,8 +92,8 @@ e1=$(bellbook eval add --log $LOG --rules $RULES --author evaluator \
        --candidate $c1 --criterion fitness --score 90 --scale 0 --json | jq -r .id)
 
 # choose the winner; name the evaluations the choice rests on
-bellbook select --log $LOG --rules $RULES --author agent --objective best-of-n \
-  --consider $c0 $c1 --choose $c1 --uses-eval $e0 $e1
+s0=$(bellbook select --log $LOG --rules $RULES --author agent --objective best-of-n \
+       --consider $c0 $c1 --choose $c1 --uses-eval $e0 $e1 --json | jq -r .id)
 
 # inspect a candidate's descent, siblings, taint, and standing
 bellbook lineage --log $LOG --rules $RULES $c1
@@ -106,6 +106,70 @@ record -> receipt -> validate loop stays in the CLI, no binding required:
 bellbook export --log $LOG --rules $RULES --out receipt.json
 bellbook validate receipt.json          # -> CLEAN
 ```
+
+## Phase 2: the benchmark was broken
+
+A Clean receipt is where most tools stop. Bellbook's value begins after
+that: suppose you discover the fitness harness was measuring the wrong
+thing. The evaluation your winning selection rests on is wrong, and the
+record has to absorb that honestly. Its author retracts it:
+
+```python
+r = w.retract(author="evaluator", target=evals[1],
+              reason="fitness harness measured the wrong thing")
+assert r.accepted
+
+report = bellbook.validate(w.receipt())
+print(report.status)                 # "tainted"
+print(report.retracted)              # the retracted evaluation
+print(report.standing["unsound"])    # the selection that rested on it
+```
+
+Or from the CLI:
+
+```sh
+bellbook retract --log $LOG --rules $RULES --author evaluator \
+  --target $e1 --reason "fitness harness measured the wrong thing"
+
+bellbook export --log $LOG --rules $RULES --out receipt.json
+bellbook validate receipt.json          # -> TAINTED, exit 2
+```
+
+Retraction is ownership-bound: `evaluator` may retract its own evaluation.
+Retracting someone else's record requires an admin retraction actor
+(`rules init --admin <id>`, or `default_rules(..., admins=[...])`).
+
+Recovery is one selection. Re-evaluate on something you still trust, then
+reaffirm the choice, naming the selection it replaces:
+
+```python
+e_new = w.evaluate(author="evaluator", candidate=winner,
+                   criterion="manual-review", passed=True)
+s_new = w.select(author="agent", objective="best-of-n",
+                 consider=cands, choose=[winner], uses_eval=[e_new.id],
+                 replaces=s.id)
+
+report = bellbook.validate(w.receipt())
+print(report.status)                     # still "tainted" - permanently
+print(report.standing["restorations"])   # {unsound id: [reaffirming id]}
+```
+
+```sh
+e2=$(bellbook eval add --log $LOG --rules $RULES --author evaluator \
+       --candidate $c1 --criterion manual-review --passed --json | jq -r .id)
+bellbook select --log $LOG --rules $RULES --author agent --objective best-of-n \
+  --consider $c0 $c1 --choose $c1 --uses-eval $e2 --replaces $s0
+
+bellbook export --log $LOG --rules $RULES --out receipt.json
+bellbook validate receipt.json   # still TAINTED; the report shows the restoration
+```
+
+**Restoration restores standing, not Clean.** The receipt stays Tainted
+(exit code 2) permanently, because the retraction is part of history. What
+changes is the standing section: the line is recorded as restored, with the
+whole episode - the break, the taint, and the repair - on the record. That
+is not a limitation; it is the point. A record that could quietly return to
+Clean after a retraction would be a record you could not trust.
 
 ## What Clean means (and does not)
 


### PR DESCRIPTION
Final v0.5.0 PR: quickstart Phase 2 and the release mechanics. After this merges, the publish workflows ship 0.5.0 to crates.io and PyPI.

Closes #86
Closes #88

## Quickstart Phase 2: the benchmark was broken (#86)

`docs/quickstart-best-of-n.md` no longer ends at a Clean receipt. Phase 2 walks the retraction story in both columns: retract the winning evaluation, observe the Tainted receipt and the unsound selection, reaffirm on fresh evidence naming the replaced selection, observe the restoration. The ownership rule and the admin-actor escape hatch are stated where they bite.

The sentence the audit required is there, plainly: **restoration restores standing, not Clean** - the receipt stays Tainted (exit code 2) permanently because the retraction is part of history, and a record that could quietly return to Clean would be a record you could not trust.

Both columns were executed verbatim against this tree before commit: CLI phases returned CLEAN/exit 0, TAINTED/exit 2, TAINTED/exit 2 with the restoration in the report; the Python column asserted the same transitions and `standing["restorations"] == {s0: [s1]}`.

## Release mechanics (#88)

- `Cargo.toml`, `bindings/python/Cargo.toml`, `bindings/python/pyproject.toml`: 0.5.0 (both lockfiles refreshed).
- `python-wheels.yml` smoke assert: `__version__ == '0.5.0'`.
- README status line: published release 0.5.0, spec v0.3. SPEC.md's "0.4.0 and later" wording already covers 0.5.0.
- CHANGELOG: `[Unreleased]` finalized as `[0.5.0] - 2026-08-27` with a release summary (no spec change, no API change, reach: retraction/standing on every surface, gate enforced in CI); fresh `[Unreleased]` on top.
- The bindings keep `bellbook_core = "0.4"` until the 0.5.0 core is on crates.io (library API unchanged), exactly as done for 0.4.0; the post-publish pin bump is a follow-up as before.
- Binding module doc updated to name the four verbs.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets`: clean on both crates.
- Full Rust suite 230 green; pytest 38 green with the rebuilt 0.5.0 binding.
- Quickstart executed verbatim, both columns, all phases (above).
- No em dashes; version strings consistent across every `.md` (checked by grep).