### PR TITLE
bindings(python): pin bellbook_core to 0.5

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e995301425f867993f2c33182f174e44b734325ce30aac5e263787cef46"
+checksum = "530e84e85092344403f5265b10296ce62cdc6335ed0ea0edfb1ffc20db514b9d"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -32,11 +32,11 @@ crate-type = ["cdylib"]
 # wheel now enables the crate's `persist` feature (cross-platform file locking
 # via `fs4`, which builds on Linux, macOS, and Windows alike). Validation and
 # reading remain feature-independent.
-# Tracks the published core library API, which is unchanged in crate 0.4.0
-# (that release adds only the CLI binary, fuzzing, and docs). Pinning the
-# major-compatible 0.3 line keeps the bindings buildable from crates.io without
-# a publish-ordering deadlock; the compiled extension is identical either way.
-bellbook_core = { package = "bellbook", version = "0.4", default-features = false, features = [
+# Tracks the published core crate. During a release cycle the pin stays on the
+# previous published line until the new core is on crates.io (the library API
+# is unchanged across the bump), avoiding a publish-ordering deadlock; it is
+# aligned to the current line right after publish, as this release does.
+bellbook_core = { package = "bellbook", version = "0.5", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }


### PR DESCRIPTION
Post-publish follow-up, same as after 0.4.0 (#76): now that `bellbook` 0.5.0 core is on crates.io, align the bindings dependency pin from `0.4` to `0.5` and refresh the lockfile.

## Changes

- `bindings/python/Cargo.toml`: `bellbook_core` version `"0.4"` -> `"0.5"`; the dependency comment now describes the release-cycle pinning pattern (stay on the previous published line until the new core publishes, align right after) instead of naming stale versions.
- `bindings/python/Cargo.lock`: `bellbook` `0.4.0` -> `0.5.0` (checksum from the published crate).

## Verification

- `cargo check` passes against the published 0.5.0 core.
- Binding rebuilt with maturin; full pytest suite green (38 tests, including the retraction story gate).
- Source-alignment only: no binding code changes, no API change; the abi3 wheels already publish at 0.5.0.