### PR TITLE
rfc: draft RFC-0002 read-side queries, with coherence fixes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1166,7 +1166,8 @@ implements.
   by the spec version, which portable artifacts (receipts, head
   attestations) carry explicitly. Hosts embedding raw logs pin the crate
   version, whose CHANGELOG names the spec version it implements.
-- Spec 0.3 (in development) is the second compatibility epoch: fifteen
+- Spec 0.3 is the second and current compatibility epoch, first released
+  in crate 0.3.0 and implemented by every release since: fifteen
   kinds, signing domain `bellbook.record-signature.v0.3`. A v0.3 validator
   rejects a v0.2 receipt as `Invalid` with a clear unsupported-version
   report; v0.2 artifacts remain valid under v0.2 rules, whose validator is

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -132,6 +132,21 @@ The long-term shape, if every gate is passed: one substrate where autonomous
 software is versioned, evaluated, run, observed, and continuously evolved,
 with the same state identity throughout its lifecycle.
 
+### Build-ahead note (recorded 2026-08-27)
+
+The maintainer may advance the *design* of a later stage ahead of its
+adoption gate - RFCs and first-party field tests - when first-party
+evidence justifies it; conviction is a legitimate reason to design.
+Implementing a gated stage still requires either the gate's pre-registered
+signal or an explicit, recorded decision in the accepting RFC that names
+the gate being set aside and why; wire-format changes never build ahead of
+their gates. This note exists so that practice and this document cannot
+quietly diverge: any build-ahead is visible here and in the RFC that
+carries it. First application: RFC-0002 (read-side queries) was drafted
+from first-party field evidence while RFC-0001 §15's evaluation window was
+still open; it completes the traversal set RFC-0001 §7 already defines,
+and the general query engine remains gated on §15's read-side signal.
+
 ## Design rules
 
 Every proposed Bellbook feature must pass:

--- a/docs/rfcs/0002-read-side-queries.md
+++ b/docs/rfcs/0002-read-side-queries.md
@@ -1,0 +1,182 @@
+# RFC-0002: Read-side queries over lineage and evidence
+
+**Status:** Draft (revision 1). This document proposes the design for the
+v0.6.0 milestone (tracking: #91, #90). It proposes **no spec change**: no
+new record kinds, no wire-format change, and no spec-version bump; the spec
+epoch stays 0.3. Implementation begins only once this RFC is Accepted.
+Where this design and SPEC.md differ about the present, SPEC.md is
+authoritative.
+
+**Scope anchor:** the read side of the current layer. RFC-0001 §7 already
+*defines* lineage as derived queries over canonical record relationships,
+and the CLI already exposes one of them (`bellbook lineage`). This RFC
+completes that named set and gives it surface parity (Rust, Python, CLI;
+over a log or a receipt) - the read-side counterpart of what v0.5.0 did for
+the write side.
+
+**Gate honesty (drift control):** RFC-0001 §14 declares "no general query
+engine" a binding non-goal, and §15 criterion 5 pre-registers *external
+read-side adoption* as the only trigger for the VISION query-engine stage.
+This RFC does **not** propose that stage, and does not touch that gate: the
+general engine (query languages, composition, payload predicates, indexes)
+remains gated on §15's signal. What it proposes is a **closed, named query
+set** with fixed semantics - the completion of RFC-0001 §7's own list. The
+design is advanced ahead of the §15 window on first-party field evidence,
+under VISION's build-ahead note; accepting this RFC is the explicit,
+recorded decision to implement the named set and nothing beyond it.
+
+---
+
+## 1. Summary
+
+Seven named, deterministic, read-only queries over canonical record
+relationships, answerable identically from Rust, Python, and the CLI, over
+a live log or a portable receipt. All of them derive from what replay
+already computes; none of them store anything, rank anything, or interpret
+payloads beyond the spec's own fields.
+
+## 2. Motivation
+
+A field test (2026-08-26: a real best-of-N over eightbells-canary Git
+trees, followed by the retraction story) surfaced the asymmetry. The write
+side has full surface parity since 0.5.0. On the read side, every real
+question required hand-walking `records()` and parsing payload JSON from
+Python; the CLI has `lineage` but receipts and Python have nothing. The
+questions asked in practice were concrete and few:
+
+- what is the line of descent, and what happened to it?
+- which sound, selected candidates stand under this objective?
+- what evidence does the survivor's line rest on?
+- how do the siblings of a generation compare?
+
+Three generations were enough to make each of these painful. The need is
+not speculative and not external: it is the project's own field tests. That
+is exactly the evidence class VISION's build-ahead note admits for *design*
+work, and exactly not the evidence class RFC-0001 §15 requires for the
+*engine* stage; hence the shape of this RFC.
+
+## 3. Design constraints
+
+- **C1: derived, never stored.** No new state, no indexes, no
+  materialization. Lineage remains derived from canonical relationships
+  (RFC-0001 §7); a query is a pure function of `(records, rules)`.
+- **C2: deterministic and cross-implementation testable.** The same
+  `(records, rules, query, args)` yields the same answer on every surface
+  and in both implementations (Rust core and the independent Python
+  validator). The conformance corpus gains query vectors.
+- **C3: no ranking, no scoring.** Bellbook records the consequences of
+  intelligence, not its architecture (VISION design rule 2). There is
+  deliberately no "best descendant" query: Bellbook returns the *sound,
+  selected* candidates and their evidence; the caller ranks. Naming a
+  winner is the harness's job and stays out of the core forever.
+- **C4: log and receipt parity.** Every query runs over an open log or a
+  portable receipt, after verification. Queries never run on an unverified
+  receipt: an Invalid receipt returns the validation error, not answers.
+- **C5: closed set.** The queries are enumerated here with fixed semantics.
+  Anything parameterized beyond the named arguments - payload predicates,
+  pattern matching, composition - is the gated engine and out of scope.
+
+## 4. The named query set (v1)
+
+All queries operate on the replayed state of an accepted record sequence.
+Ids are record ids; "sound" and "compromised" are the standing dimension of
+RFC-0001 §6.2 exactly, never recomputed differently.
+
+- **q1 `descent(candidate)`** - the line of descent from a candidate back
+  to its root: continuation edges (`Cause`d Selection plus `parent`) and
+  derivation `Cause` edges, each node annotated with kind, standing, and
+  taint. The existing `bellbook lineage` view, normalized.
+- **q2 `descendants(record)`** - the forward closure: every candidate
+  whose descent passes through the given record, annotated as q1.
+- **q3 `siblings(candidate)`** - the generation: candidates sharing the
+  same `Cause`d Selection (continuations) or the same `Cause` target set
+  (derivations), per RFC-0001 §7.
+- **q4 `frontier()`** - candidates appearing in no Selection's
+  `considered`, plus selected candidates with no continuation yet, per
+  RFC-0001 §7.
+- **q5 `standing(id)`** - `sound` | `compromised` | `unsound`, with the
+  restoring reaffirmation ids when a restoration applies. Today partially
+  visible via the report's standing section; q5 makes it addressable per
+  record.
+- **q6 `evidence(id)`** - for a Selection: the evaluations it `Use`d, with
+  their outcomes and current standing. For a Candidate: the same,
+  transitively along its descent - "what does this line rest on", the exact
+  question the field test hand-walked.
+- **q7 `selected(objective)`** - the accepted Selections whose `objective`
+  equals the given string exactly (no patterns - patterns are engine
+  territory), with their chosen candidates, each annotated with standing
+  and the q6 evidence set.
+
+Each query's full input/output shape, error behavior, and edge cases
+(rejected records, retracted targets, empty logs) are specified before
+implementation in this document's acceptance revision; the JSON shapes are
+shared verbatim across all three surfaces so answers are diffable.
+
+## 5. Surfaces
+
+- **Rust:** a `queries` module over `(&[Record], &VerifierRules)`; the CLI
+  and the binding are thin callers, per the v0.5.0 precedent.
+- **Python:** methods on `Receipt` and `Writer` returning plain
+  dicts/lists with the shared JSON shapes.
+- **CLI:** `bellbook query q-name [args] (--log DIR --rules FILE | --receipt FILE)`
+  emitting the shared JSON (human-readable rendering as `lineage` does
+  today). `bellbook lineage` remains as the q1 convenience.
+
+## 6. Conformance
+
+The corpus gains query vectors: `(case, query, args) -> expected answer`.
+The Rust runner asserts them; the independent Python validator implements
+the same named set and asserts the same vectors. Two implementations,
+byte-for-decision agreement, as with verdicts - determinism is a claim only
+until it is cross-checked.
+
+## 7. Non-goals (binding for v0.6)
+
+No query language or composition; no predicates over payload fields beyond
+the named arguments; no pattern or substring matching on objectives; no
+ranking or scoring of any kind; no indexes or persisted derived state; no
+cross-receipt joins; no remote or streaming queries. The general query
+engine remains gated on RFC-0001 §15 criterion 5 (external read-side
+adoption), and nothing in this RFC re-opens that decision.
+
+## 8. Validation and falsification criteria (pre-registered)
+
+Recorded before implementation. Evaluation window: 90 days from shipping
+v0.6.0.
+
+**Validation - the named set is the right shape if at least 2 hold:**
+1. Re-running the project's own field tests (the canary best-of-N and the
+   retraction story) requires **zero** hand-walking of `records()`: every
+   question maps to a named query. Measured by rewriting the field-test
+   scripts against the query set.
+2. External read-side usage of any named query (an integration, issue, or
+   discussion exercising them) - which would *simultaneously* progress
+   RFC-0001 §15 criterion 5.
+3. An external request for a query outside the named set - demand evidence
+   for the gated engine, to be recorded against §15, not quietly absorbed
+   into this set.
+
+**Falsification - the shape missed if both hold:**
+1. The rewritten field tests still need hand-walking (the set answers the
+   wrong questions), and
+2. no external signal engages the read side during the window.
+
+**Decision rule:** falsified means the named set is revised before any
+further read-side work, and the engine stage remains untouched either way -
+it opens only on RFC-0001 §15's own terms.
+
+## 9. Open questions (to resolve in review, before acceptance)
+
+1. **Frontier scope:** per thread, per space, or whole log? (The writer is
+   single-thread today; the answer should not bake that in.)
+2. **Evidence transitivity depth:** q6 on a candidate walks the full
+   descent by default; is a depth bound needed for very long lines, and if
+   so is it an argument or a limit?
+3. **Where the semantics live:** this RFC plus a short SPEC section
+   documenting the named set (recommended, since two implementations must
+   agree and the corpus pins the answers), or RFC plus docs only.
+4. **#90 (tie-break evidence)** resolves inside this design: the
+   recommended answer is the documentation pattern - record the
+   discriminating fact as an Evaluation under its own criterion, so q6/q7
+   surface it - with no payload change. To be confirmed or refuted in
+   review.


### PR DESCRIPTION
Opens the v0.6.0 chapter the way the process demands: design before code. This PR is for **review and acceptance of the RFC**, not implementation - no code changes, no spec change. Part of #91; #90's recommended resolution is recorded as open question 4.

## RFC-0002: read-side queries (Draft, revision 1)

A **closed, named set of seven** deterministic, read-only queries over canonical record relationships (descent, descendants, siblings, frontier, standing, evidence, selected-by-objective), with surface parity: Rust, Python, CLI, over a log or a verified receipt, all emitting the same JSON shapes, cross-checked by corpus query vectors in both implementations.

The design decisions worth reviewing hardest:

- **Gate honesty.** RFC-0001 §14 binds "no general query engine," and §15 criterion 5 pre-registers *external* read-side adoption as the engine's only trigger - a window still open. This RFC does not touch that gate: it completes the traversal set RFC-0001 **§7 already defines** (the same class of work as v0.5.0's write-side surfacing) and leaves the engine gated. The boundary is drawn in C5/§7: named queries with fixed semantics in; predicates, patterns, composition, indexes out.
- **No "best descendant" query, deliberately.** Ranking is the harness's job forever (VISION rule 2). q7 returns sound, selected candidates with their evidence; the caller ranks.
- **Queries run only on verified state** - an Invalid receipt returns the validation error, never answers.
- **Pre-registered validation/falsification** (§8), including the honest cross-link: external read-side usage of these queries would simultaneously progress RFC-0001 §15.5, and an external ask for a query outside the set is engine demand to record against that gate, not to absorb here.
- **Open questions** (§9) for your review: frontier scope, evidence depth, whether the semantics get a SPEC section, and #90's proposed resolution as a documentation pattern.

## Coherence fixes (from the same audit)

- **SPEC §14** still said spec 0.3 "(in development)" - stale since crate 0.3.0 shipped. Now: "second and current compatibility epoch, first released in crate 0.3.0 and implemented by every release since."
- **VISION gains the build-ahead note** agreed when development moved to conviction mode but never written down: design may advance ahead of an adoption gate on first-party evidence; implementing a gated stage requires the gate's signal or an explicit, recorded override in the accepting RFC; wire-format changes never build ahead. First application recorded: this RFC.

## What acceptance means

Review the RFC, resolve §9's open questions (comment here or edit directly), then: acceptance = flipping Status to Accepted and merging. Implementation of the v0.6.0 milestone starts only after that, scoped by the accepted text.

Docs only; `cargo` untouched; no em dashes; RFC-0001 section references verified against the source.