### PR TITLE
queries: the named set q1-q7 in the core (RFC-0002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The named query set q1-q7 in the core** (`bellbook::queries`,
+  RFC-0002; #91). Seven deterministic, read-only queries over canonical
+  record relationships - `descent`, `descendants`, `siblings`, `frontier`,
+  `standing`, `evidence`, `selected` - derived from what replay already
+  computes: never stored, never ranked, answered only over verified state
+  (an unverifiable log returns `LogInvalid`, not answers). Rejected
+  records are not addressable (they made no claim); every reported node
+  carries its standing, taint, and retraction annotations so nothing is
+  silently filtered. A closed set with fixed semantics: `selected`
+  matches its objective exactly, and the general query engine remains
+  gated on RFC-0001 section 15. Library-only in this change; the CLI,
+  Python, and corpus surfaces follow in the same milestone.
+
 ## [0.5.0] - 2026-08-27
 
 Retraction and standing on every surface. No new record kinds and no spec

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod manifest;
 /// The untrusted [`Proposer`] interface - emits proposals, holds no append
 /// authority.
 pub mod propose;
+pub mod queries;
 /// Portable receipts: export a log as a self-contained bundle and
 /// validate it offline.
 pub mod receipt;
@@ -131,6 +132,11 @@ pub use receipt::{
     validate, validate_with_limits, Receipt, Report, ValidationLimits, ValidationStatus,
 };
 
+pub use queries::{
+    DescendantsReport, DescentReport, DescentStep, EvidenceEntry, EvidenceReport, FrontierEntry,
+    FrontierReport, Node, Queries, QueryError, SelectedEntry, SelectedReport, SelectionEvidence,
+    SiblingsReport, StandingReport,
+};
 pub use verify::rules::VerifierRules;
 pub use verify::standing::{derive_standing, StandingSection};
 pub use verify::verifier::{verify_log, verify_record, LogVerdict};

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,0 +1,630 @@
+//! Read-side queries (RFC-0002): the named set q1-q7.
+//!
+//! Deterministic, read-only queries over canonical record relationships,
+//! derived from what replay already computes - never stored, never ranked.
+//! Every query is a pure function of `(records, rules)`; the CLI and the
+//! Python binding are thin callers over this module, and the same JSON
+//! shapes are emitted on every surface so answers are diffable.
+//!
+//! Queries run only on verified state: [`Queries::new`] replays the log and
+//! refuses a rejecting one ([`QueryError::LogInvalid`]), so answers are
+//! never derived from history that does not verify. Only accepted records
+//! participate in lineage and evidence; rejected records made no claim.
+//!
+//! Boundaries (RFC-0002 sections 3 and 7): a closed set with fixed
+//! semantics. No predicates over payload fields, no pattern matching, no
+//! composition, no indexes; `selected` matches its objective exactly. The
+//! general query engine remains gated on RFC-0001 section 15.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use serde::{Deserialize, Serialize};
+
+use crate::base::hash::hex_encode;
+use crate::record::kind::{Kind, ReasonCode, RefType, VerdictResult};
+use crate::record::payloads::{
+    CandidateBasis, CandidateData, EvaluationData, EvaluationOutcome, SelectionData,
+    SelectionOutcome,
+};
+use crate::record::record::{decode, Record};
+use crate::record::refs::RecordId;
+use crate::state::build::build_state_unchecked;
+use crate::state::state::State;
+use crate::verify::rules::VerifierRules;
+use crate::verify::verifier::{verify_log, LogVerdict};
+
+/// Why a query could not be answered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryError {
+    /// The log or receipt does not verify under the given rules; queries
+    /// never run on unverified history.
+    LogInvalid(Option<ReasonCode>),
+    /// No record with this id exists in the verified sequence.
+    NotFound(RecordId),
+    /// The record exists but was rejected at commit; a rejected record made
+    /// no claim, so lineage and evidence queries do not address it.
+    NotAccepted(RecordId),
+    /// The record is accepted but not of the kind the query addresses.
+    KindMismatch {
+        /// The addressed record.
+        id: RecordId,
+        /// What the query needed, e.g. "Candidate".
+        expected: &'static str,
+    },
+}
+
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryError::LogInvalid(reason) => {
+                write!(f, "log does not verify: {reason:?}")
+            }
+            QueryError::NotFound(id) => write!(f, "record {} not found", hex_encode(id)),
+            QueryError::NotAccepted(id) => {
+                write!(f, "record {} was rejected at commit", hex_encode(id))
+            }
+            QueryError::KindMismatch { id, expected } => {
+                write!(f, "record {} is not a {expected}", hex_encode(id))
+            }
+        }
+    }
+}
+
+impl std::error::Error for QueryError {}
+
+/// A record reference as every query reports it: id plus the annotations a
+/// reader needs to judge it without a second lookup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Node {
+    /// Record id, lowercase hex.
+    pub id: String,
+    /// Rust variant name of the kind, e.g. `"Candidate"`.
+    pub kind: String,
+    /// `"sound"` | `"compromised"` (candidates), `"sound"` | `"unsound"`
+    /// (selections), `"n/a"` otherwise.
+    pub standing: String,
+    /// Kernel taint (epistemic dependence on a retracted record).
+    pub tainted: bool,
+    /// Target of an accepted Retraction.
+    pub retracted: bool,
+}
+
+/// One step of a line of descent: the ancestor and the edge that reached it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescentStep {
+    /// The ancestor record (a Candidate, or a continuation's anchor
+    /// Selection).
+    pub node: Node,
+    /// `"parent"` (continuation parent), `"continuation-anchor"` (the
+    /// `Cause`d Selection), or `"derivation"` (a derivation `Cause` to a
+    /// candidate).
+    pub via: String,
+}
+
+/// q1: the line of descent from a candidate back to its roots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescentReport {
+    /// The queried candidate.
+    pub target: Node,
+    /// Ancestors in breadth-first order from the target, each edge's
+    /// neighbors visited in ascending id order; every reachable ancestor
+    /// appears exactly once.
+    pub line: Vec<DescentStep>,
+}
+
+/// q2: the forward closure of a record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescendantsReport {
+    /// The queried record.
+    pub target: Node,
+    /// Every candidate whose descent passes through the target, in log
+    /// order.
+    pub descendants: Vec<Node>,
+}
+
+/// q3: the generation of a candidate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SiblingsReport {
+    /// The queried candidate.
+    pub target: Node,
+    /// Continuations sharing the target's anchor Selection, or derivations
+    /// sharing the target's exact `Cause` target set; excludes the target;
+    /// log order. Empty for a Root.
+    pub siblings: Vec<Node>,
+}
+
+/// One frontier entry and why it is on the frontier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrontierEntry {
+    /// The frontier candidate.
+    pub node: Node,
+    /// `"unconsidered"` (in no accepted Selection's `considered`) or
+    /// `"selected-no-continuation"` (chosen, with no continuation yet).
+    pub reason: String,
+}
+
+/// q4: the frontier of the whole log (or receipt).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrontierReport {
+    /// Frontier candidates in log order. Nothing is silently filtered:
+    /// retracted or compromised candidates appear with their annotations,
+    /// and the reader decides what "live" means.
+    pub frontier: Vec<FrontierEntry>,
+}
+
+/// q5: the standing of one record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StandingReport {
+    /// The queried record, with its standing annotations.
+    pub node: Node,
+    /// For an unsound Selection with sound replacement chains: the
+    /// restoring Selection ids, ascending. Empty otherwise.
+    pub restorations: Vec<String>,
+}
+
+/// One piece of evaluation evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceEntry {
+    /// The evaluation record.
+    pub node: Node,
+    /// The evaluation's criterion.
+    pub criterion: String,
+    /// `"passed"`, `"failed"`, or `"scored <value>e-<scale>"`.
+    pub outcome: String,
+}
+
+/// The evidence one Selection rests on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectionEvidence {
+    /// The selection.
+    pub selection: Node,
+    /// The evaluations it `Use`d, in ref order.
+    pub evidence: Vec<EvidenceEntry>,
+}
+
+/// q6: what a record rests on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceReport {
+    /// The queried record.
+    pub target: Node,
+    /// For a Selection: exactly one entry, its own evidence. For a
+    /// Candidate: the evidence of every anchor Selection along its descent,
+    /// in descent (breadth-first) order - the full walk, unbounded by
+    /// design (RFC-0002 section 9.2).
+    pub rests_on: Vec<SelectionEvidence>,
+}
+
+/// One selection under q7, with its chosen candidates and evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedEntry {
+    /// The selection.
+    pub selection: Node,
+    /// Its chosen candidates, each annotated.
+    pub chosen: Vec<Node>,
+    /// The evaluations the selection `Use`d.
+    pub evidence: Vec<EvidenceEntry>,
+}
+
+/// q7: the accepted `Selected` selections under an exact objective.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedReport {
+    /// The exact objective string queried.
+    pub objective: String,
+    /// Matching selections in log order. Bellbook does not rank: the reader
+    /// sees the sound and unsound alike, annotated, and decides.
+    pub selections: Vec<SelectedEntry>,
+}
+
+/// The verified context every query runs against.
+pub struct Queries<'a> {
+    records: &'a [Record],
+    verdict: LogVerdict,
+    state: State,
+    by_id: BTreeMap<RecordId, usize>,
+}
+
+impl<'a> Queries<'a> {
+    /// Verify the records under `rules` and build the query context.
+    /// Returns [`QueryError::LogInvalid`] if replay rejects: queries never
+    /// answer over unverified history.
+    pub fn new(records: &'a [Record], rules: &VerifierRules) -> Result<Self, QueryError> {
+        let verdict = verify_log(records, rules, None);
+        if verdict.result != VerdictResult::Accept {
+            return Err(QueryError::LogInvalid(verdict.reason));
+        }
+        // An accepting log has canonical payloads, so the unchecked build
+        // cannot fail; surface the impossible case as invalid, never panic.
+        let state = build_state_unchecked(records).map_err(|_| QueryError::LogInvalid(None))?;
+        let by_id = records.iter().enumerate().map(|(i, r)| (r.id, i)).collect();
+        Ok(Queries {
+            records,
+            verdict,
+            state,
+            by_id,
+        })
+    }
+
+    // --- shared helpers ----------------------------------------------------
+
+    fn get(&self, id: RecordId) -> Result<&'a Record, QueryError> {
+        let idx = *self.by_id.get(&id).ok_or(QueryError::NotFound(id))?;
+        Ok(&self.records[idx])
+    }
+
+    fn get_accepted(&self, id: RecordId) -> Result<&'a Record, QueryError> {
+        let rec = self.get(id)?;
+        if !self.state.accepted_records.contains(&id) {
+            return Err(QueryError::NotAccepted(id));
+        }
+        Ok(rec)
+    }
+
+    fn node(&self, rec: &Record) -> Node {
+        let standing = match rec.kind {
+            Kind::Candidate => {
+                if self.verdict.standing.compromised.contains(&rec.id) {
+                    "compromised"
+                } else {
+                    "sound"
+                }
+            }
+            Kind::Selection => {
+                if self.verdict.standing.unsound.contains(&rec.id) {
+                    "unsound"
+                } else {
+                    "sound"
+                }
+            }
+            _ => "n/a",
+        };
+        Node {
+            id: hex_encode(&rec.id),
+            kind: format!("{:?}", rec.kind),
+            standing: standing.to_string(),
+            tainted: self.verdict.tainted_records.contains(&rec.id),
+            retracted: self.verdict.retracted_records.contains(&rec.id),
+        }
+    }
+
+    fn candidate_data(&self, rec: &Record) -> Result<CandidateData, QueryError> {
+        if rec.kind != Kind::Candidate {
+            return Err(QueryError::KindMismatch {
+                id: rec.id,
+                expected: "Candidate",
+            });
+        }
+        decode::<CandidateData>(&rec.data).map_err(|_| QueryError::NotFound(rec.id))
+    }
+
+    /// The backward edges of one accepted candidate:
+    /// `(ancestor id, via)` pairs in ascending id order per edge class.
+    /// Continuations contribute the anchor Selection and the `parent`
+    /// candidate; derivations contribute their candidate-kind `Cause`
+    /// targets (evaluation-kind causes are motivation, surfaced by q6, not
+    /// structure). Roots contribute nothing.
+    fn back_edges(&self, rec: &Record, data: &CandidateData) -> Vec<(RecordId, &'static str)> {
+        let mut edges = Vec::new();
+        match data.basis {
+            CandidateBasis::Root => {}
+            CandidateBasis::Continuation => {
+                let mut anchors: Vec<RecordId> = rec
+                    .refs
+                    .iter()
+                    .filter(|r| r.type_ == RefType::Cause)
+                    .map(|r| r.target)
+                    .collect();
+                anchors.sort();
+                for a in anchors {
+                    edges.push((a, "continuation-anchor"));
+                }
+                if let Some(p) = data.parent {
+                    edges.push((p, "parent"));
+                }
+            }
+            CandidateBasis::Derivation => {
+                let mut causes: Vec<RecordId> = rec
+                    .refs
+                    .iter()
+                    .filter(|r| r.type_ == RefType::Cause)
+                    .map(|r| r.target)
+                    .collect();
+                causes.sort();
+                for c in causes {
+                    if self.get(c).map(|t| t.kind) == Ok(Kind::Candidate) {
+                        edges.push((c, "derivation"));
+                    }
+                }
+            }
+        }
+        edges
+    }
+
+    /// The evidence one accepted Selection `Use`d, in ref order.
+    fn selection_evidence(&self, rec: &Record) -> Vec<EvidenceEntry> {
+        let mut out = Vec::new();
+        for rf in rec.refs.iter().filter(|r| r.type_ == RefType::Use) {
+            let Ok(target) = self.get(rf.target) else {
+                continue;
+            };
+            if target.kind != Kind::Evaluation {
+                continue;
+            }
+            let Ok(ed) = decode::<EvaluationData>(&target.data) else {
+                continue;
+            };
+            let outcome = match ed.outcome {
+                EvaluationOutcome::Passed => "passed".to_string(),
+                EvaluationOutcome::Failed => "failed".to_string(),
+                EvaluationOutcome::Scored(s) => format!("scored {}e-{}", s.value, s.scale),
+            };
+            out.push(EvidenceEntry {
+                node: self.node(target),
+                criterion: ed.criterion,
+                outcome,
+            });
+        }
+        out
+    }
+
+    // --- the named set -----------------------------------------------------
+
+    /// q1: the line of descent from `candidate` back to its roots.
+    pub fn descent(&self, candidate: RecordId) -> Result<DescentReport, QueryError> {
+        let rec = self.get_accepted(candidate)?;
+        let data = self.candidate_data(rec)?;
+
+        let mut line = Vec::new();
+        let mut seen: BTreeSet<RecordId> = BTreeSet::new();
+        seen.insert(candidate);
+        let mut queue: VecDeque<(RecordId, &'static str)> =
+            self.back_edges(rec, &data).into_iter().collect();
+        while let Some((id, via)) = queue.pop_front() {
+            if !seen.insert(id) {
+                continue;
+            }
+            let anc = self.get(id)?;
+            line.push(DescentStep {
+                node: self.node(anc),
+                via: via.to_string(),
+            });
+            if anc.kind == Kind::Candidate {
+                let ad = self.candidate_data(anc)?;
+                queue.extend(self.back_edges(anc, &ad));
+            }
+        }
+        Ok(DescentReport {
+            target: self.node(rec),
+            line,
+        })
+    }
+
+    /// q2: every candidate whose descent passes through `id`, in log order.
+    pub fn descendants(&self, id: RecordId) -> Result<DescendantsReport, QueryError> {
+        let target_rec = self.get_accepted(id)?;
+        let mut descendants = Vec::new();
+        for rec in self.records {
+            if rec.kind != Kind::Candidate
+                || rec.id == id
+                || !self.state.accepted_records.contains(&rec.id)
+            {
+                continue;
+            }
+            let descent = self.descent(rec.id)?;
+            let target_hex = hex_encode(&id);
+            if descent.line.iter().any(|s| s.node.id == target_hex) {
+                descendants.push(self.node(rec));
+            }
+        }
+        Ok(DescendantsReport {
+            target: self.node(target_rec),
+            descendants,
+        })
+    }
+
+    /// q3: the generation of `candidate` (excluding itself), in log order.
+    pub fn siblings(&self, candidate: RecordId) -> Result<SiblingsReport, QueryError> {
+        let rec = self.get_accepted(candidate)?;
+        let data = self.candidate_data(rec)?;
+        let cause_set = |r: &Record| -> BTreeSet<RecordId> {
+            r.refs
+                .iter()
+                .filter(|rf| rf.type_ == RefType::Cause)
+                .map(|rf| rf.target)
+                .collect()
+        };
+        let own_causes = cause_set(rec);
+
+        let mut siblings = Vec::new();
+        for other in self.records {
+            if other.kind != Kind::Candidate
+                || other.id == candidate
+                || !self.state.accepted_records.contains(&other.id)
+            {
+                continue;
+            }
+            let Ok(od) = self.candidate_data(other) else {
+                continue;
+            };
+            let same_generation = match (&data.basis, &od.basis) {
+                (CandidateBasis::Continuation, CandidateBasis::Continuation) => {
+                    cause_set(other) == own_causes
+                }
+                (CandidateBasis::Derivation, CandidateBasis::Derivation) => {
+                    cause_set(other) == own_causes
+                }
+                _ => false,
+            };
+            if same_generation {
+                siblings.push(self.node(other));
+            }
+        }
+        Ok(SiblingsReport {
+            target: self.node(rec),
+            siblings,
+        })
+    }
+
+    /// q4: the frontier of the whole log, in log order.
+    pub fn frontier(&self) -> FrontierReport {
+        // Every candidate id any accepted Selection considered, and every
+        // id it chose.
+        let mut considered: BTreeSet<RecordId> = BTreeSet::new();
+        let mut chosen: BTreeSet<RecordId> = BTreeSet::new();
+        for rec in self.records {
+            if rec.kind != Kind::Selection || !self.state.accepted_records.contains(&rec.id) {
+                continue;
+            }
+            let Ok(sd) = decode::<SelectionData>(&rec.data) else {
+                continue;
+            };
+            considered.extend(sd.considered.iter().copied());
+            if let SelectionOutcome::Selected { candidates } = &sd.outcome {
+                chosen.extend(candidates.iter().copied());
+            }
+        }
+        // Chosen candidates that some accepted continuation already extends.
+        let mut continued: BTreeSet<RecordId> = BTreeSet::new();
+        for rec in self.records {
+            if rec.kind != Kind::Candidate || !self.state.accepted_records.contains(&rec.id) {
+                continue;
+            }
+            if let Ok(cd) = decode::<CandidateData>(&rec.data) {
+                if cd.basis == CandidateBasis::Continuation {
+                    if let Some(p) = cd.parent {
+                        continued.insert(p);
+                    }
+                }
+            }
+        }
+
+        let mut frontier = Vec::new();
+        for rec in self.records {
+            if rec.kind != Kind::Candidate || !self.state.accepted_records.contains(&rec.id) {
+                continue;
+            }
+            let reason = if !considered.contains(&rec.id) {
+                Some("unconsidered")
+            } else if chosen.contains(&rec.id) && !continued.contains(&rec.id) {
+                Some("selected-no-continuation")
+            } else {
+                None
+            };
+            if let Some(reason) = reason {
+                frontier.push(FrontierEntry {
+                    node: self.node(rec),
+                    reason: reason.to_string(),
+                });
+            }
+        }
+        FrontierReport { frontier }
+    }
+
+    /// q5: the standing of one accepted record.
+    pub fn standing(&self, id: RecordId) -> Result<StandingReport, QueryError> {
+        let rec = self.get_accepted(id)?;
+        let restorations = self
+            .verdict
+            .standing
+            .restorations
+            .get(&id)
+            .map(|set| set.iter().map(hex_encode).collect())
+            .unwrap_or_default();
+        Ok(StandingReport {
+            node: self.node(rec),
+            restorations,
+        })
+    }
+
+    /// q6: what `id` rests on. For a Selection, its own evidence; for a
+    /// Candidate, the evidence of every anchor Selection along its descent.
+    pub fn evidence(&self, id: RecordId) -> Result<EvidenceReport, QueryError> {
+        let rec = self.get_accepted(id)?;
+        let rests_on = match rec.kind {
+            Kind::Selection => vec![SelectionEvidence {
+                selection: self.node(rec),
+                evidence: self.selection_evidence(rec),
+            }],
+            Kind::Candidate => {
+                let descent = self.descent(id)?;
+                let mut out = Vec::new();
+                for step in &descent.line {
+                    if step.node.kind == "Selection" {
+                        let sel = self.get(parse_hex(&step.node.id))?;
+                        out.push(SelectionEvidence {
+                            selection: step.node.clone(),
+                            evidence: self.selection_evidence(sel),
+                        });
+                    }
+                }
+                out
+            }
+            _ => {
+                return Err(QueryError::KindMismatch {
+                    id,
+                    expected: "Candidate or Selection",
+                })
+            }
+        };
+        Ok(EvidenceReport {
+            target: self.node(rec),
+            rests_on,
+        })
+    }
+
+    /// q7: the accepted `Selected` selections whose objective equals
+    /// `objective` exactly, in log order.
+    pub fn selected(&self, objective: &str) -> SelectedReport {
+        let mut selections = Vec::new();
+        for rec in self.records {
+            if rec.kind != Kind::Selection || !self.state.accepted_records.contains(&rec.id) {
+                continue;
+            }
+            let Ok(sd) = decode::<SelectionData>(&rec.data) else {
+                continue;
+            };
+            if sd.objective != objective {
+                continue;
+            }
+            let SelectionOutcome::Selected { candidates } = &sd.outcome else {
+                continue;
+            };
+            let chosen = candidates
+                .iter()
+                .filter_map(|c| self.get(*c).ok())
+                .map(|c| self.node(c))
+                .collect();
+            selections.push(SelectedEntry {
+                selection: self.node(rec),
+                chosen,
+                evidence: self.selection_evidence(rec),
+            });
+        }
+        SelectedReport {
+            objective: objective.to_string(),
+            selections,
+        }
+    }
+}
+
+/// Decode a lowercase-hex id this module itself produced; ids in reports
+/// round-trip by construction, so a failure is a bug, not bad input.
+fn parse_hex(hex: &str) -> RecordId {
+    let mut id = [0u8; 32];
+    for (i, byte) in id.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).unwrap_or(0);
+    }
+    id
+}

--- a/tests/queries.rs
+++ b/tests/queries.rs
@@ -1,0 +1,598 @@
+//! The named query set q1-q7 (RFC-0002) over a real log: the
+//! broken-benchmark shape (root, continuation, derivations at depth, a
+//! motivated-by repair, a retraction, and a restoring reaffirmation), which
+//! exercises every annotation a query can emit. Assertions pin exact ids
+//! and orders, not just counts.
+
+#![cfg(feature = "persist")]
+
+use bellbook::*;
+
+fn cause_ref(target: RecordId) -> Ref {
+    Ref {
+        type_: RefType::Cause,
+        target,
+    }
+}
+fn use_ref(target: RecordId) -> Ref {
+    Ref {
+        type_: RefType::Use,
+        target,
+    }
+}
+fn require_ref(target: RecordId) -> Ref {
+    Ref {
+        type_: RefType::Require,
+        target,
+    }
+}
+fn replace_ref(target: RecordId) -> Ref {
+    Ref {
+        type_: RefType::Replace,
+        target,
+    }
+}
+
+fn source(tree: &str) -> SourceBinding {
+    SourceBinding {
+        git: GitSource {
+            algo: SourceAlgo::Sha1,
+            tree: tree.into(),
+            commit: None,
+        },
+        manifest_hash: None,
+        binding: BindingMode::Reported,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn commit<T: serde::Serialize>(
+    writer: &mut LogWriter,
+    rules: &VerifierRules,
+    state: &mut State,
+    author_id: &str,
+    kind: Kind,
+    schema: &str,
+    payload: &T,
+    refs: Vec<Ref>,
+    space: SpaceId,
+    expect_accept: bool,
+) -> RecordId {
+    let (id, verdict) = writer
+        .commit(
+            Proposal {
+                space,
+                thread: space,
+                author: Author {
+                    id: author_id.into(),
+                    type_: AuthorType::Provider,
+                    signature: None,
+                },
+                kind,
+                schema: schema_id(schema),
+                data: encode(payload).unwrap(),
+                refs,
+            },
+            rules,
+            state,
+        )
+        .unwrap();
+    assert_eq!(
+        verdict.result == VerdictResult::Accept,
+        expect_accept,
+        "unexpected verdict for {kind:?}: {:?}",
+        verdict.reason
+    );
+    id
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    records: Vec<Record>,
+    rules: VerifierRules,
+    c0: RecordId,
+    bench0: RecordId,
+    s0: RecordId,
+    c1: RecordId,
+    c2: RecordId,
+    c2b: RecordId,
+    c3: RecordId,
+    c4: RecordId,
+    c5: RecordId,
+    review0: RecordId,
+    s1: RecordId,
+    rejected: RecordId,
+}
+
+/// The broken-benchmark story plus a derivation sibling (c2b) and one
+/// rejected record (a cross-author retraction attempt).
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let space = default_space();
+    let rules = VerifierRules::new(space, 200)
+        .with_author_role("agent", AuthorType::Provider)
+        .with_author_role("benchmark", AuthorType::Provider)
+        .with_author_role("reviewer", AuthorType::Provider);
+    let mut w = LogWriter::open(dir.path(), &rules).unwrap();
+    let mut st = State::default();
+
+    let cand = |src: &str, basis: CandidateBasis, parent: Option<RecordId>| CandidateData {
+        source: source(src),
+        basis,
+        parent,
+        note: None,
+    };
+
+    let c0 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+            CandidateBasis::Root,
+            None,
+        ),
+        vec![],
+        space,
+        true,
+    );
+    let bench0 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "benchmark",
+        Kind::Evaluation,
+        SCHEMA_EVALUATION,
+        &EvaluationData {
+            candidate: c0,
+            criterion: "bench-suite".into(),
+            procedure: None,
+            outcome: EvaluationOutcome::Passed,
+        },
+        vec![use_ref(c0)],
+        space,
+        true,
+    );
+    let s0 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Selection,
+        SCHEMA_SELECTION,
+        &SelectionData {
+            objective: "adopt-baseline".into(),
+            considered: vec![c0],
+            outcome: SelectionOutcome::Selected {
+                candidates: vec![c0],
+            },
+            rationale: None,
+        },
+        vec![require_ref(c0), use_ref(bench0)],
+        space,
+        true,
+    );
+    let c1 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "1111111111111111111111111111111111111111",
+            CandidateBasis::Continuation,
+            Some(c0),
+        ),
+        vec![cause_ref(s0)],
+        space,
+        true,
+    );
+    let c2 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "2222222222222222222222222222222222222222",
+            CandidateBasis::Derivation,
+            None,
+        ),
+        vec![cause_ref(c1)],
+        space,
+        true,
+    );
+    // A sibling of c2: same derivation cause set {c1}.
+    let c2b = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            CandidateBasis::Derivation,
+            None,
+        ),
+        vec![cause_ref(c1)],
+        space,
+        true,
+    );
+    let c3 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "3333333333333333333333333333333333333333",
+            CandidateBasis::Derivation,
+            None,
+        ),
+        vec![cause_ref(c2)],
+        space,
+        true,
+    );
+    // The motivated-by repair: derives from sound c0, Cause to the benchmark.
+    let c4 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "4444444444444444444444444444444444444444",
+            CandidateBasis::Derivation,
+            None,
+        ),
+        vec![cause_ref(c0), cause_ref(bench0)],
+        space,
+        true,
+    );
+    // The benchmark retracts its own evaluation.
+    commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "benchmark",
+        Kind::Retraction,
+        SCHEMA_RETRACTION,
+        &RetractionData {
+            target_id: bench0,
+            reason: "harness measured the wrong thing".into(),
+        },
+        vec![cause_ref(bench0)],
+        space,
+        true,
+    );
+    // Work continues under compromise.
+    let c5 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Candidate,
+        SCHEMA_CANDIDATE,
+        &cand(
+            "5555555555555555555555555555555555555555",
+            CandidateBasis::Derivation,
+            None,
+        ),
+        vec![cause_ref(c3)],
+        space,
+        true,
+    );
+    // Recovery: surviving evidence plus a reaffirming Selection.
+    let review0 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "reviewer",
+        Kind::Evaluation,
+        SCHEMA_EVALUATION,
+        &EvaluationData {
+            candidate: c0,
+            criterion: "manual-review".into(),
+            procedure: None,
+            outcome: EvaluationOutcome::Passed,
+        },
+        vec![use_ref(c0)],
+        space,
+        true,
+    );
+    let s1 = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Selection,
+        SCHEMA_SELECTION,
+        &SelectionData {
+            objective: "adopt-baseline".into(),
+            considered: vec![c0],
+            outcome: SelectionOutcome::Selected {
+                candidates: vec![c0],
+            },
+            rationale: None,
+        },
+        vec![require_ref(c0), use_ref(review0), replace_ref(s0)],
+        space,
+        true,
+    );
+    // A rejected record: the agent may not retract the reviewer's record.
+    let rejected = commit(
+        &mut w,
+        &rules,
+        &mut st,
+        "agent",
+        Kind::Retraction,
+        SCHEMA_RETRACTION,
+        &RetractionData {
+            target_id: review0,
+            reason: "not mine to retract".into(),
+        },
+        vec![cause_ref(review0)],
+        space,
+        false,
+    );
+
+    Fixture {
+        records: w.records().to_vec(),
+        _dir: dir,
+        rules,
+        c0,
+        bench0,
+        s0,
+        c1,
+        c2,
+        c2b,
+        c3,
+        c4,
+        c5,
+        review0,
+        s1,
+        rejected,
+    }
+}
+
+fn hex(id: &RecordId) -> String {
+    hex_encode(id)
+}
+
+#[test]
+fn queries_refuse_an_unverified_log() {
+    let f = fixture();
+    // The same records under rules that never registered the authors: the
+    // replay rejects, and so must the query context.
+    let wrong = VerifierRules::new(default_space(), 200);
+    match Queries::new(&f.records, &wrong) {
+        Err(QueryError::LogInvalid(_)) => {}
+        Err(other) => panic!("expected LogInvalid, got {other:?}"),
+        Ok(_) => panic!("expected LogInvalid, got a query context"),
+    }
+}
+
+#[test]
+fn descent_walks_continuations_and_derivations_with_annotations() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let d = q.descent(f.c5).unwrap();
+    let line: Vec<(String, String)> = d
+        .line
+        .iter()
+        .map(|s| (s.node.id.clone(), s.via.clone()))
+        .collect();
+    assert_eq!(
+        line,
+        vec![
+            (hex(&f.c3), "derivation".into()),
+            (hex(&f.c2), "derivation".into()),
+            (hex(&f.c1), "derivation".into()),
+            (hex(&f.s0), "continuation-anchor".into()),
+            (hex(&f.c0), "parent".into()),
+        ]
+    );
+    // Annotations at the final state: the line is restored (nothing
+    // compromised), s0 stays unsound and tainted, permanently.
+    let s0_step = d.line.iter().find(|s| s.node.id == hex(&f.s0)).unwrap();
+    assert_eq!(s0_step.node.standing, "unsound");
+    assert!(s0_step.node.tainted);
+    let c2_step = d.line.iter().find(|s| s.node.id == hex(&f.c2)).unwrap();
+    assert_eq!(c2_step.node.standing, "sound");
+}
+
+#[test]
+fn descent_of_a_motivated_repair_excludes_the_evaluation() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+    // c4 derives from c0 and names the benchmark evaluation as motivation;
+    // structure follows candidates only.
+    let d = q.descent(f.c4).unwrap();
+    let ids: Vec<String> = d.line.iter().map(|s| s.node.id.clone()).collect();
+    assert_eq!(ids, vec![hex(&f.c0)]);
+}
+
+#[test]
+fn descendants_are_the_forward_closure_in_log_order() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let of_s0 = q.descendants(f.s0).unwrap();
+    let ids: Vec<String> = of_s0.descendants.iter().map(|n| n.id.clone()).collect();
+    assert_eq!(
+        ids,
+        vec![hex(&f.c1), hex(&f.c2), hex(&f.c2b), hex(&f.c3), hex(&f.c5)]
+    );
+
+    let of_c0 = q.descendants(f.c0).unwrap();
+    let ids: Vec<String> = of_c0.descendants.iter().map(|n| n.id.clone()).collect();
+    assert_eq!(
+        ids,
+        vec![
+            hex(&f.c1),
+            hex(&f.c2),
+            hex(&f.c2b),
+            hex(&f.c3),
+            hex(&f.c4),
+            hex(&f.c5)
+        ]
+    );
+}
+
+#[test]
+fn siblings_share_the_exact_cause_target_set() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let s = q.siblings(f.c2).unwrap();
+    let ids: Vec<String> = s.siblings.iter().map(|n| n.id.clone()).collect();
+    assert_eq!(ids, vec![hex(&f.c2b)]);
+
+    // c4's cause set {c0, bench0} is unique; c1 is the only continuation.
+    assert!(q.siblings(f.c4).unwrap().siblings.is_empty());
+    assert!(q.siblings(f.c1).unwrap().siblings.is_empty());
+    // A root has no generation.
+    assert!(q.siblings(f.c0).unwrap().siblings.is_empty());
+}
+
+#[test]
+fn frontier_reports_unconsidered_work_without_filtering() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let fr = q.frontier();
+    let ids: Vec<(String, String)> = fr
+        .frontier
+        .iter()
+        .map(|e| (e.node.id.clone(), e.reason.clone()))
+        .collect();
+    // c0 was considered, chosen, and continued: not frontier. Everything
+    // else was never considered by any selection.
+    let expect: Vec<(String, String)> = [&f.c1, &f.c2, &f.c2b, &f.c3, &f.c4, &f.c5]
+        .iter()
+        .map(|id| (hex(id), "unconsidered".to_string()))
+        .collect();
+    assert_eq!(ids, expect);
+}
+
+#[test]
+fn standing_is_kind_aware_and_names_restorations() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let s0 = q.standing(f.s0).unwrap();
+    assert_eq!(s0.node.standing, "unsound");
+    assert!(s0.node.tainted);
+    assert_eq!(s0.restorations, vec![hex(&f.s1)]);
+
+    let c2 = q.standing(f.c2).unwrap();
+    assert_eq!(c2.node.standing, "sound");
+    assert!(!c2.node.tainted);
+    assert!(c2.restorations.is_empty());
+
+    let bench = q.standing(f.bench0).unwrap();
+    assert_eq!(bench.node.standing, "n/a");
+    assert!(bench.node.retracted);
+}
+
+#[test]
+fn evidence_shows_what_a_line_rests_on() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    // A selection rests on its own Use-refs.
+    let e = q.evidence(f.s1).unwrap();
+    assert_eq!(e.rests_on.len(), 1);
+    assert_eq!(e.rests_on[0].selection.id, hex(&f.s1));
+    assert_eq!(e.rests_on[0].evidence.len(), 1);
+    let entry = &e.rests_on[0].evidence[0];
+    assert_eq!(entry.node.id, hex(&f.review0));
+    assert_eq!(entry.criterion, "manual-review");
+    assert_eq!(entry.outcome, "passed");
+
+    // A candidate rests on the evidence of the anchors along its descent -
+    // and the report shows that c3's line rests on a retracted evaluation.
+    let e = q.evidence(f.c3).unwrap();
+    assert_eq!(e.rests_on.len(), 1);
+    assert_eq!(e.rests_on[0].selection.id, hex(&f.s0));
+    let entry = &e.rests_on[0].evidence[0];
+    assert_eq!(entry.node.id, hex(&f.bench0));
+    assert!(entry.node.retracted);
+}
+
+#[test]
+fn selected_matches_the_objective_exactly_and_never_ranks() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    let sel = q.selected("adopt-baseline");
+    assert_eq!(
+        sel.selections.len(),
+        2,
+        "s0 and s1, unsound and sound alike"
+    );
+    assert_eq!(sel.selections[0].selection.id, hex(&f.s0));
+    assert_eq!(sel.selections[0].selection.standing, "unsound");
+    assert_eq!(sel.selections[1].selection.id, hex(&f.s1));
+    assert_eq!(sel.selections[1].selection.standing, "sound");
+    for entry in &sel.selections {
+        assert_eq!(entry.chosen.len(), 1);
+        assert_eq!(entry.chosen[0].id, hex(&f.c0));
+    }
+    assert_eq!(sel.selections[0].evidence[0].node.id, hex(&f.bench0));
+    assert_eq!(sel.selections[1].evidence[0].node.id, hex(&f.review0));
+
+    // Exact match only: near-misses return nothing, never patterns.
+    assert!(q.selected("adopt-baseline ").selections.is_empty());
+    assert!(q.selected("adopt").selections.is_empty());
+}
+
+#[test]
+fn query_errors_are_specific() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+
+    match q.standing([0xfe; 32]) {
+        Err(QueryError::NotFound(_)) => {}
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    match q.descent(f.bench0) {
+        Err(QueryError::KindMismatch { .. }) => {}
+        other => panic!("expected KindMismatch, got {other:?}"),
+    }
+    // A rejected record made no claim: queries do not address it.
+    match q.standing(f.rejected) {
+        Err(QueryError::NotAccepted(_)) => {}
+        other => panic!("expected NotAccepted, got {other:?}"),
+    }
+    match q.evidence(f.bench0) {
+        Err(QueryError::KindMismatch { .. }) => {}
+        other => panic!("expected KindMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn reports_serialize_to_stable_json() {
+    let f = fixture();
+    let q = Queries::new(&f.records, &f.rules).unwrap();
+    // Every report is Serialize with deny_unknown_fields: the JSON shapes
+    // are the cross-surface contract, so a round-trip must be lossless.
+    let d = q.descent(f.c5).unwrap();
+    let json = serde_json::to_string(&d).unwrap();
+    let back: DescentReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(d, back);
+
+    let sel = q.selected("adopt-baseline");
+    let json = serde_json::to_string(&sel).unwrap();
+    let back: SelectedReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(sel, back);
+}


### PR DESCRIPTION
First v0.6.0 implementation PR, scoped by the accepted RFC-0002: the `bellbook::queries` module - the closed, named set of seven read-side queries in the core. Part of #91.

## What it is

`Queries::new(records, rules)` verifies the log (an unverifiable log returns `QueryError::LogInvalid`, never answers) and then answers:

- **q1 `descent`** - the line back to the roots: derivation `Cause` edges, continuation anchor Selections, and parents, BFS with per-edge-class deterministic order; evaluation-kind causes (motivation) are deliberately excluded from structure - they are evidence, and q6's job.
- **q2 `descendants`** - the forward closure, log order.
- **q3 `siblings`** - the generation: identical `Cause` target set (derivations) or shared anchor (continuations).
- **q4 `frontier`** - unconsidered candidates plus selected-without-continuation, per RFC-0001 §7, with per-entry reasons; nothing silently filtered - retracted or compromised entries appear with their annotations and the reader decides.
- **q5 `standing`** - kind-aware standing plus restorations for an unsound Selection.
- **q6 `evidence`** - what a Selection Used; for a Candidate, transitively along its descent (unbounded by design, RFC §9.2).
- **q7 `selected`** - exact-objective match only, `Selected` outcomes, sound and unsound alike; deliberately no "best" query - Bellbook does not rank.

Every reported node carries `standing`/`tainted`/`retracted` annotations; all reports are `Serialize + Deserialize` with `deny_unknown_fields` - these JSON shapes are the cross-surface contract the CLI, Python, and corpus vectors will share. Rejected records are not addressable (`NotAccepted`): they made no claim.

## Boundaries held

Closed set with fixed semantics: no predicates, no patterns, no composition, no indexes. The general query engine stays gated on RFC-0001 §15 criterion 5, exactly as the accepted RFC states.

## Tests (11, all pinning exact ids/orders, not counts)

The fixture replays the broken-benchmark shape plus a derivation sibling and a rejected record. Highlights: descent of the motivated-by repair excludes the evaluation from structure; q6 on a compromised-then-restored line shows it **resting on a retracted evaluation** - the exact question the canary field test hand-walked; `selected` near-misses (`"adopt"`, trailing space) return nothing; an unverified log is refused; reports round-trip losslessly.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`: clean.
- Full suite: 241 tests green (230 + 11 new). No behavior change to anything existing; the module is purely additive and feature-independent (tests use `persist` for log construction only).
- CHANGELOG `[Unreleased]` entry added.

Next in the chain: corpus query vectors + the independent Python validator's implementation (PR2), CLI + Python surfaces + the RFC §8 gate proof (PR3), docs + SPEC section (PR4).