### PR TITLE
cli: bellbook query, and the RFC-0002 gate proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   gains `bellbook_queries.py`, a from-scratch implementation of the named
   set that re-derives every vector from the stored receipt and matches
   the reference's surface JSON byte for byte.
+- **CLI `bellbook query`** (#91). Run any named query from the command
+  line: `bellbook query NAME [ID|OBJECTIVE] (--log DIR --rules FILE |
+  --receipt FILE) [--json]`, over an open log or a portable receipt
+  alike, with byte-identical `--json` output on both inputs (asserted in
+  CI). An invalid log or receipt is an error, never data. The CLI suite
+  also carries the RFC-0002 section 8 gate proof: the canary best-of-N
+  field test rewritten against the named set, every question answered by
+  `bellbook query` alone with zero hand-walking of records.
 
 ## [0.5.0] - 2026-08-27
 

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -1,10 +1,10 @@
 //! `bellbook` - accountability-ledger CLI.
 //!
 //! `validate <receipt>` verifies a receipt offline (feature-independent). The
-//! evolution subcommands (`candidate`, `eval`, `select`, `lineage`) are thin
-//! wrappers over the crate that operate on a persistent log and therefore need
-//! the `persist` feature; JSON in/out, and every mutating command prints the
-//! committed record id.
+//! evolution subcommands (`candidate`, `eval`, `select`, `retract`,
+//! `lineage`, `query`) are thin wrappers over the crate that operate on a
+//! persistent log and therefore need the `persist` feature; JSON in/out, and
+//! every mutating command prints the committed record id.
 //!
 //! **Concurrency (SPEC §5.1):** the persistent log is deliberately
 //! single-writer - `LogWriter` holds an exclusive lock. Parallel candidate
@@ -46,6 +46,8 @@ USAGE:
     bellbook retract       --log <dir> --rules <file> --author <id>
                            --target <record-id> --reason <text> [--json]
     bellbook lineage       --log <dir> --rules <file> <id> [--json]
+    bellbook query <name> [<id>|<objective>]
+                           (--log <dir> --rules <file> | --receipt <file>) [--json]
     bellbook rules init    --author <id>:<role> ... [--admin <id>] ... [--reaffirmer <id>] ...
                            [--max-context <n>] [--out <file>]
     bellbook export        --log <dir> --rules <file> [--out <file>]
@@ -61,6 +63,11 @@ COMMANDS:
                 stays in the log; the receipt reports Tainted from then on.
                 Accepted only from the target's author or an admin actor.
     lineage     Show a candidate's descent, siblings, taint, and standing.
+    query       Run one named read-side query (RFC-0002) over a verified
+                log or a portable receipt: descent <id>, descendants <id>,
+                siblings <id>, frontier, standing <id>, evidence <id>,
+                selected <objective>. Deterministic and read-only; the
+                --json output is the shared shape every surface emits.
     rules init  Generate a starter verifier-rules file. Roles are one of
                 user|provider|system|executor|verifier. --admin allows an
                 actor to retract records it did not author; --reaffirmer
@@ -85,7 +92,7 @@ fn main() -> ExitCode {
     match command {
         "validate" => cmd_validate(&rest),
         "rules" => cmd_rules(&rest),
-        "candidate" | "eval" | "select" | "retract" | "lineage" | "export" => {
+        "candidate" | "eval" | "select" | "retract" | "lineage" | "export" | "query" => {
             cmd_evolution(command, &rest)
         }
         other => {
@@ -353,6 +360,7 @@ fn cmd_evolution(command: &str, rest: &[String]) -> ExitCode {
         "retract" => persist_cmds::retract(rest),
         "lineage" => persist_cmds::lineage(rest),
         "export" => persist_cmds::export(rest),
+        "query" => persist_cmds::query(rest),
         _ => unreachable!(),
     };
     match result {
@@ -980,6 +988,216 @@ mod persist_cmds {
         siblings: Vec<String>,
         considered_by: Vec<String>,
         selected_by: Vec<String>,
+    }
+
+    // --- query -------------------------------------------------------------
+
+    /// One node as a single human-readable fragment: id plus the
+    /// annotations a reader needs to judge it (kind, standing, taint,
+    /// retraction).
+    fn node_str(n: &Node) -> String {
+        let mut s = format!("{} [{} {}", n.id, n.kind, n.standing);
+        if n.tainted {
+            s.push_str(", tainted");
+        }
+        if n.retracted {
+            s.push_str(", retracted");
+        }
+        s.push(']');
+        s
+    }
+
+    fn print_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(value).map_err(|e| format!("{e}"))?
+        );
+        Ok(())
+    }
+
+    fn evidence_lines(indent: &str, entries: &[EvidenceEntry]) {
+        for e in entries {
+            println!(
+                "{indent}{} -> {}  {}",
+                e.criterion,
+                e.outcome,
+                node_str(&e.node)
+            );
+        }
+    }
+
+    /// `query <name> [arg]` runs one named read-side query (RFC-0002) over
+    /// a verified log (`--log` with `--rules`) or a portable receipt
+    /// (`--receipt`, rules embedded), printing the shared JSON shape with
+    /// `--json` or a human rendering. Queries never answer over unverified
+    /// history: an invalid log or receipt is an error, not data.
+    pub fn query(rest: &[String]) -> Result<ExitCode, String> {
+        let (name, rest) = rest.split_first().ok_or_else(|| {
+            "query needs a name \
+             (descent|descendants|siblings|frontier|standing|evidence|selected)"
+                .to_string()
+        })?;
+        let p = parse(rest, &["log", "rules", "receipt"], &[], &["json"])?;
+
+        let has_log = p.singles.contains_key("log");
+        let has_receipt = p.singles.contains_key("receipt");
+        if has_log == has_receipt {
+            return Err(
+                "query requires exactly one input: --log with --rules, or --receipt".to_string(),
+            );
+        }
+        // A receipt embeds its rules; a separate --rules with --receipt is
+        // stated intent that cannot be honored, so refuse rather than drop it.
+        if has_receipt && p.singles.contains_key("rules") {
+            return Err("--rules is not valid with --receipt (a receipt embeds its rules)".into());
+        }
+        if p.positionals.len() > 1 {
+            return Err(format!(
+                "query {name} takes at most one argument, got {:?}",
+                p.positionals
+            ));
+        }
+
+        let (records, rules): (Vec<Record>, VerifierRules) = if has_log {
+            let rules = load_rules(&p)?;
+            let dir = require(&p, "log")?;
+            let writer =
+                LogWriter::open(std::path::Path::new(dir), &rules).map_err(|e| format!("{e:?}"))?;
+            (writer.records().to_vec(), rules)
+        } else {
+            let path = require(&p, "receipt")?;
+            let bytes =
+                std::fs::read(path).map_err(|e| format!("cannot read receipt {path}: {e}"))?;
+            // The full offline validation first, so a structurally broken
+            // receipt reports its problem (limits, strict decoding, spec
+            // version), not a replay error.
+            let report = validate(&bytes);
+            if report.status == ValidationStatus::Invalid {
+                let why = report
+                    .problem
+                    .or_else(|| report.reason.map(|r| format!("{r:?}")))
+                    .unwrap_or_else(|| "?".to_string());
+                return Err(format!("receipt does not validate: {why}"));
+            }
+            let receipt = Receipt::from_bytes(&bytes)
+                .map_err(|e| format!("cannot parse receipt {path}: {e}"))?;
+            (receipt.records, receipt.rules)
+        };
+
+        let q = Queries::new(&records, &rules).map_err(|e| format!("{e}"))?;
+        let json = p.bools.contains("json");
+        let arg_id = || -> Result<RecordId, String> {
+            let hex = p
+                .positionals
+                .first()
+                .ok_or_else(|| format!("query {name} requires a record id"))?;
+            parse_id(hex)
+        };
+
+        match name.as_str() {
+            "descent" => {
+                let r = q.descent(arg_id()?).map_err(|e| format!("{e}"))?;
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("target: {}", node_str(&r.target));
+                    println!("line ({}):", r.line.len());
+                    for s in &r.line {
+                        println!("  via {:<20} {}", s.via, node_str(&s.node));
+                    }
+                }
+            }
+            "descendants" => {
+                let r = q.descendants(arg_id()?).map_err(|e| format!("{e}"))?;
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("target: {}", node_str(&r.target));
+                    println!("descendants ({}):", r.descendants.len());
+                    for n in &r.descendants {
+                        println!("  {}", node_str(n));
+                    }
+                }
+            }
+            "siblings" => {
+                let r = q.siblings(arg_id()?).map_err(|e| format!("{e}"))?;
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("target: {}", node_str(&r.target));
+                    println!("siblings ({}):", r.siblings.len());
+                    for n in &r.siblings {
+                        println!("  {}", node_str(n));
+                    }
+                }
+            }
+            "frontier" => {
+                if !p.positionals.is_empty() {
+                    return Err("query frontier takes no argument".to_string());
+                }
+                let r = q.frontier();
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("frontier ({}):", r.frontier.len());
+                    for e in &r.frontier {
+                        println!("  {:<26} {}", e.reason, node_str(&e.node));
+                    }
+                }
+            }
+            "standing" => {
+                let r = q.standing(arg_id()?).map_err(|e| format!("{e}"))?;
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("node: {}", node_str(&r.node));
+                    println!("restorations ({}):", r.restorations.len());
+                    for id in &r.restorations {
+                        println!("  {id}");
+                    }
+                }
+            }
+            "evidence" => {
+                let r = q.evidence(arg_id()?).map_err(|e| format!("{e}"))?;
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("target: {}", node_str(&r.target));
+                    println!("rests_on ({} selections):", r.rests_on.len());
+                    for se in &r.rests_on {
+                        println!("  selection: {}", node_str(&se.selection));
+                        evidence_lines("    ", &se.evidence);
+                    }
+                }
+            }
+            "selected" => {
+                let objective = p
+                    .positionals
+                    .first()
+                    .ok_or_else(|| "query selected requires an objective string".to_string())?;
+                let r = q.selected(objective);
+                if json {
+                    print_json(&r)?;
+                } else {
+                    println!("objective: {}", r.objective);
+                    println!("selections ({}):", r.selections.len());
+                    for s in &r.selections {
+                        println!("  selection: {}", node_str(&s.selection));
+                        for c in &s.chosen {
+                            println!("    chosen: {}", node_str(c));
+                        }
+                        evidence_lines("    ", &s.evidence);
+                    }
+                }
+            }
+            other => {
+                return Err(format!(
+                    "unknown query {other:?} \
+                     (descent|descendants|siblings|frontier|standing|evidence|selected)"
+                ))
+            }
+        }
+        Ok(ExitCode::SUCCESS)
     }
 
     pub fn lineage(rest: &[String]) -> Result<ExitCode, String> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 //! End-to-end tests for the `bellbook` evolution CLI (`candidate`, `eval`,
-//! `select`, `lineage`). Each test drives the real compiled binary against a
+//! `select`, `retract`, `lineage`, `query`). Each test drives the real
+//! compiled binary against a
 //! throwaway log directory, so it exercises the whole path: argument parsing,
 //! rules loading, verified open, commit, and JSON output. The binary is
 //! single-writer by design, so every command runs as its own process and the
@@ -1019,4 +1020,423 @@ fn retract_requires_target_and_reason() {
     );
     assert_eq!(out.status.code(), Some(65));
     assert!(String::from_utf8_lossy(&out.stderr).contains("--target"));
+}
+
+// --- query: the RFC-0002 named set, and the section 8 gate proof -----------
+
+/// Run a query with `--json` and parse the shared JSON shape.
+fn query_json(env: &Env, args: &[&str]) -> Value {
+    let mut full: Vec<&str> = args.to_vec();
+    full.push("--json");
+    let out = run(env, &full);
+    assert!(
+        out.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn eval_failed(env: &Env, author: &str, candidate: &str, criterion: &str) -> String {
+    let out = run(
+        env,
+        &[
+            "eval",
+            "add",
+            "--author",
+            author,
+            "--candidate",
+            candidate,
+            "--criterion",
+            criterion,
+            "--failed",
+            "--json",
+        ],
+    );
+    committed_id(&out)
+}
+
+fn derive_candidate(env: &Env, tree: &str, from: &str) -> String {
+    let out = run(
+        env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            tree,
+            "--derives-from",
+            from,
+            "--json",
+        ],
+    );
+    committed_id(&out)
+}
+
+/// RFC-0002 section 8, validation criterion 1 - the gate proof. The canary
+/// best-of-N field test (2026-08-26) plus the retraction story, rewritten
+/// against the named query set: every question the field test answered by
+/// hand-walking records is answered here by `bellbook query` alone. No
+/// records() walk, no manual ref-chasing, no receipt parsing - if any
+/// assertion below needed one, the named set missed its shape.
+#[test]
+fn field_test_story_needs_zero_hand_walking() {
+    let env = story_env();
+
+    // The story: a baseline adopted on a benchmark, a best-of-N round over
+    // its continuation, then the benchmark turns out broken and is
+    // retracted, and the baseline is re-adopted on fresh evidence.
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "adopt-baseline",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &bench,
+            "--json",
+        ],
+    );
+    let s0 = committed_id(&out);
+    let out = run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_B,
+            "--continues",
+            &s0,
+            "--parent",
+            &c0,
+            "--json",
+        ],
+    );
+    let c1 = committed_id(&out);
+    let c2 = derive_candidate(&env, "2222222222222222222222222222222222222222", &c1);
+    let c3 = derive_candidate(&env, "3333333333333333333333333333333333333333", &c1);
+    let e2 = eval_passed(&env, "evaluator", &c2, "unit-tests");
+    let _e3 = eval_failed(&env, "evaluator", &c3, "unit-tests");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "adopt",
+            "--consider",
+            &c2,
+            &c3,
+            "--choose",
+            &c2,
+            "--uses-eval",
+            &e2,
+            "--json",
+        ],
+    );
+    let s1 = committed_id(&out);
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "evaluator",
+            "--target",
+            &bench,
+            "--reason",
+            "benchmark harness measured the wrong thing",
+            "--json",
+        ],
+    );
+    committed_id(&out);
+    let review = eval_passed(&env, "evaluator", &c0, "benchmark-v2");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "adopt-baseline",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &review,
+            "--replaces",
+            &s0,
+            "--json",
+        ],
+    );
+    let s2 = committed_id(&out);
+
+    // Q1 (field test: "which candidate won the round, on what evidence?").
+    let v = query_json(&env, &["query", "selected", "adopt"]);
+    let sels = v["selections"].as_array().unwrap();
+    assert_eq!(sels.len(), 1);
+    assert_eq!(sels[0]["selection"]["id"], Value::from(s1.clone()));
+    assert_eq!(sels[0]["chosen"][0]["id"], Value::from(c2.clone()));
+    assert_eq!(sels[0]["evidence"][0]["criterion"], "unit-tests");
+    assert_eq!(sels[0]["evidence"][0]["outcome"], "passed");
+
+    // Q2 ("what is the winner's full line of descent?").
+    let v = query_json(&env, &["query", "descent", &c2]);
+    let line = v["line"].as_array().unwrap();
+    let step = |i: usize| {
+        (
+            line[i]["node"]["id"].as_str().unwrap(),
+            line[i]["via"].as_str().unwrap(),
+        )
+    };
+    assert_eq!(line.len(), 3);
+    assert_eq!(step(0), (c1.as_str(), "derivation"));
+    assert_eq!(step(1), (s0.as_str(), "continuation-anchor"));
+    assert_eq!(step(2), (c0.as_str(), "parent"));
+
+    // Q3 ("what does the line rest on?" - the question that exposed the
+    // broken benchmark). The retracted evaluation surfaces, annotated.
+    let v = query_json(&env, &["query", "evidence", &c2]);
+    let rests = v["rests_on"].as_array().unwrap();
+    assert_eq!(rests.len(), 1);
+    assert_eq!(rests[0]["selection"]["id"], Value::from(s0.clone()));
+    assert_eq!(rests[0]["evidence"][0]["node"]["id"], Value::from(bench));
+    assert_eq!(
+        rests[0]["evidence"][0]["node"]["retracted"],
+        Value::from(true)
+    );
+    assert_eq!(rests[0]["evidence"][0]["criterion"], "benchmark");
+
+    // Q4 ("what happened to the adoption after the retraction?"). The
+    // anchor Selection is unsound and tainted; the re-adoption restored its
+    // standing, on the record - and restoration is not erasure.
+    let v = query_json(&env, &["query", "standing", &s0]);
+    assert_eq!(v["node"]["standing"], "unsound");
+    assert_eq!(v["node"]["tainted"], Value::from(true));
+    assert_eq!(v["restorations"], Value::from(vec![s2]));
+
+    // Q5 ("what is still open?"). The continuation was never considered;
+    // the round's winner has no continuation yet. Nothing else.
+    let v = query_json(&env, &["query", "frontier"]);
+    let frontier = v["frontier"].as_array().unwrap();
+    assert_eq!(frontier.len(), 2);
+    assert_eq!(frontier[0]["node"]["id"], Value::from(c1));
+    assert_eq!(frontier[0]["reason"], "unconsidered");
+    assert_eq!(frontier[1]["node"]["id"], Value::from(c2.clone()));
+    assert_eq!(frontier[1]["reason"], "selected-no-continuation");
+
+    // Q6 ("who else was in the winner's generation?").
+    let v = query_json(&env, &["query", "siblings", &c2]);
+    let sibs = v["siblings"].as_array().unwrap();
+    assert_eq!(sibs.len(), 1);
+    assert_eq!(sibs[0]["id"], Value::from(c3));
+
+    // Q7 ("everything downstream of the baseline?").
+    let v = query_json(&env, &["query", "descendants", &c0]);
+    let ids: Vec<&str> = v["descendants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids.len(), 3, "c1, c2, c3 all descend from c0");
+    assert!(ids.contains(&c2.as_str()));
+}
+
+#[test]
+fn query_log_and_receipt_agree_byte_for_byte() {
+    // The same query over the open log and over its exported receipt emits
+    // identical bytes - the shared-shape claim (RFC-0002 C4), asserted.
+    let env = story_env();
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &bench,
+            "--json",
+        ],
+    );
+    committed_id(&out);
+
+    let receipt = env._dir.path().join("r.json");
+    let out = run(&env, &["export", "--out", receipt.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    for args in [
+        vec!["query", "descent", c0.as_str()],
+        vec!["query", "frontier"],
+        vec!["query", "selected", "ship"],
+        vec!["query", "standing", c0.as_str()],
+    ] {
+        let mut log_args = args.clone();
+        log_args.push("--json");
+        let from_log = run(&env, &log_args);
+        let mut receipt_cmd = bellbook();
+        receipt_cmd.args(&args).arg("--json");
+        receipt_cmd.arg("--receipt").arg(&receipt);
+        let from_receipt = receipt_cmd.output().unwrap();
+        assert!(from_log.status.success() && from_receipt.status.success());
+        assert_eq!(
+            from_log.stdout, from_receipt.stdout,
+            "log/receipt divergence on {args:?}"
+        );
+    }
+}
+
+#[test]
+fn query_error_battery() {
+    let env = story_env();
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+
+    // A rejected record is durably in the log but not addressable.
+    let out = run(
+        &env,
+        &[
+            "retract", "--author", "agent", "--target", &bench, "--reason", "not mine", "--json",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rejected = v["id"].as_str().unwrap().to_string();
+    let out = run(&env, &["query", "standing", &rejected]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("rejected at commit"));
+
+    // Kind mismatch: descent addresses candidates only.
+    let out = run(&env, &["query", "descent", &bench]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not a Candidate"));
+
+    // Not found.
+    let ghost = "f".repeat(64);
+    let out = run(&env, &["query", "descent", &ghost]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not found"));
+
+    // Unknown query name.
+    let out = run(&env, &["query", "best-descendant", &c0]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("unknown query"));
+
+    // Missing input, and both inputs at once.
+    let out = bellbook().args(["query", "frontier"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(65));
+    let receipt = env._dir.path().join("r.json");
+    let out = run(&env, &["export", "--out", receipt.to_str().unwrap()]);
+    assert!(out.status.success());
+    let out = run(
+        &env,
+        &["query", "frontier", "--receipt", receipt.to_str().unwrap()],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("exactly one input"));
+
+    // An unreadable receipt is refused with the validation problem, and
+    // queries never answer over it.
+    let bad = env._dir.path().join("bad.json");
+    std::fs::write(&bad, b"not json").unwrap();
+    let out = bellbook()
+        .args(["query", "frontier", "--receipt", bad.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("does not validate"));
+
+    // A receipt embeds its rules; naming both is refused, not resolved.
+    let out = bellbook()
+        .args(["query", "frontier", "--receipt", receipt.to_str().unwrap()])
+        .arg("--rules")
+        .arg(&env.rules)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("embeds its rules"));
+
+    // frontier takes no argument; id queries take exactly one.
+    let out = run(&env, &["query", "frontier", &c0]);
+    assert_eq!(out.status.code(), Some(65));
+    let out = run(&env, &["query", "descent"]);
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("requires a record id"));
+}
+
+#[test]
+fn query_human_rendering_reports_annotations() {
+    // The default (non-JSON) rendering carries the same annotations: after
+    // a retraction, the human output says so in words.
+    let env = story_env();
+    let c0 = add_root(&env, TREE_A);
+    let bench = eval_passed(&env, "evaluator", &c0, "benchmark");
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "ship",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &bench,
+            "--json",
+        ],
+    );
+    let s0 = committed_id(&out);
+    let out = run(
+        &env,
+        &[
+            "retract",
+            "--author",
+            "evaluator",
+            "--target",
+            &bench,
+            "--reason",
+            "broken",
+            "--json",
+        ],
+    );
+    committed_id(&out);
+
+    let out = run(&env, &["query", "standing", &s0]);
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        text.contains("unsound") && text.contains("tainted"),
+        "{text}"
+    );
+
+    let out = run(&env, &["query", "evidence", &s0]);
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        text.contains("retracted") && text.contains("benchmark -> passed"),
+        "{text}"
+    );
 }


### PR DESCRIPTION
Third change of the v0.6.0 milestone (RFC-0002, part of #91), following the core module (#99) and the corpus vectors (#100).

## What

- **`bellbook query NAME [ID|OBJECTIVE] (--log DIR --rules FILE | --receipt FILE) [--json]`**: the CLI surface for the named set - `descent`, `descendants`, `siblings`, `frontier`, `standing`, `evidence`, `selected`. A thin caller over `bellbook::queries`: `--json` emits the shared surface shape every implementation agrees on; the default rendering is human-readable and carries the same annotations (standing, taint, retraction). Works identically over an open log or a portable receipt; a `--rules` given with `--receipt` is refused rather than silently dropped, and an invalid log or receipt is an error, never data.
- **The RFC-0002 section 8 gate proof** (validation criterion 1, pre-registered): the canary best-of-N field test (2026-08-26) plus the retraction story, rewritten as a CLI test against the named set. Every question the field test answered by hand-walking records - which candidate won and on what evidence, the winner's full line of descent, what the line rests on (the question that exposed the broken benchmark), what happened to the adoption's standing after retraction and repair, what is still open on the frontier, the winner's generation, everything downstream of the baseline - is answered by `bellbook query` alone and asserted. Zero `records()` walks, zero manual ref-chasing. CI-enforced from now on.
- **Byte-for-byte log/receipt parity test** (RFC-0002 C4): the same query over the open log and its exported receipt emits identical bytes, asserted across four query shapes.
- **Error battery**: rejected records not addressable, kind mismatch, not found, unknown query name, missing/conflicting inputs, unreadable receipt, argument arity.

## Sequencing note

The Python binding surface follows after the 0.6.0 core publish: the bindings deliberately track the published crate (not a path dependency), and the `queries` module reaches crates.io only at release. The query methods land with the post-publish pin bump, before the PyPI publish, as with previous cycles.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features`: clean.
- Full `cargo test --all-features`: green, including the 33-test CLI suite with the gate proof and parity tests.
- Independent Python validator: 607 assertions, all sections green (unchanged by this PR, re-run as part of the audit).

Part of #91.