### PR TITLE
docs and release prep for 0.6.0

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.5.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.6.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-08-27
+
+The read side. RFC-0002 names the seven questions a Bellbook log can
+answer about lineage, evidence, and standing, and this release implements
+the closed set - `descent`, `descendants`, `siblings`, `frontier`,
+`standing`, `evidence`, `selected` - in the Rust core, on the CLI (over a
+log or a receipt), in the conformance corpus, and in the independent
+Python validator. No new record kinds and no spec change - the epoch
+stays 0.3 - and no ranking anywhere: queries report annotated facts and
+the caller decides. The PyPI package gains the same query methods
+immediately after the core publish (the bindings track the published
+crate, which gains the queries module at this release). Existing 0.3/0.4/0.5
+receipts and rules validate identically.
 
 ### Added
 
@@ -19,8 +31,7 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   carries its standing, taint, and retraction annotations so nothing is
   silently filtered. A closed set with fixed semantics: `selected`
   matches its objective exactly, and the general query engine remains
-  gated on RFC-0001 section 15. Library-only in this change; the CLI,
-  Python, and corpus surfaces follow in the same milestone.
+  gated on RFC-0001 section 15.
 - **Conformance corpus query vectors and an independent query
   implementation** (#91). The corpus gains
   `spec/conformance/v0.3/query-cases.json`: cases pairing a portable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ bellbook select        --log <dir> --rules <file> --author <id> --objective <s> 
 bellbook retract       --log <dir> --rules <file> --author <id> \
          --target <record-id> --reason <text>   # receipt reports Tainted from then on
 bellbook lineage       --log <dir> --rules <file> <id> [--json]
+bellbook query <name> [<id>|<objective>]   # descent|descendants|siblings|frontier
+         (--log <dir> --rules <file> | --receipt <file>)   # |standing|evidence|selected
 bellbook export        --log <dir> --rules <file> [--out <file>]   # log -> receipt
 ```
 
@@ -288,7 +290,7 @@ evolution kinds to a log and exports a receipt. See
 
 ## Status
 
-**The published release is 0.5.0, implementing spec v0.3 (evolution
+**The published release is 0.6.0, implementing spec v0.3 (evolution
 semantics: Candidate, Evaluation, and Selection records with replay-derived
 lineage standing).** SPEC.md is the authority for what v0.3 means (design
 notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)). The previous epoch,
@@ -307,18 +309,21 @@ replay-derived standing section, derived state with incremental/full-build
 equivalence, checkpoints, the crash-safe writer with idempotent
 compare-and-append, and portable receipts with the offline `bellbook
 validate` CLI, the `candidate`/`eval`/`select`/`retract`/`lineage` recording
-commands, and `rules init` / `export` to generate a starter rule set and
+commands, the read-side `query` command (the RFC-0002 named set: descent,
+descendants, siblings, frontier, standing, evidence, selected - over a log
+or a receipt), and `rules init` / `export` to generate a starter rule set and
 bundle a log into a receipt - fully tested (every rejection reason code has a
 triggering test), clippy-clean, no `unsafe`, no panics in library code.
 
 The repository also carries a language-neutral **conformance corpus**
-(`spec/conformance/v0.3/`: record, malformed, receipt-replay, and standing
-cases, run by `tests/conformance.rs`; the frozen `spec/conformance/v0.2/`
-corpus stays valid under v0.2 rules) and an **independent Python
-implementation** of the verifier (`conformance/python/`) that shares no
+(`spec/conformance/v0.3/`: record, malformed, receipt-replay, standing,
+and named-query cases, run by `tests/conformance.rs`; the frozen
+`spec/conformance/v0.2/` corpus stays valid under v0.2 rules) and an
+**independent Python implementation** of the verifier and the named query
+set (`conformance/python/`) that shares no
 code with this crate, recomputes every record id, and re-derives every
-verdict and standing section across the corpus, agreeing with this
-reference on every case - including the deliberately malformed and forged
+verdict, standing section, and query answer across the corpus, agreeing
+with this reference on every case - including the deliberately malformed and forged
 inputs it must reject.
 
 Open work, **not implemented**:

--- a/SPEC.md
+++ b/SPEC.md
@@ -1090,6 +1090,32 @@ reason codes (`Refused`, `InvalidCheckpoint`, `RefCrossSpace`) that the
 single-space, checkpoint-free receipt format cannot express and that the
 reference implementation's own test suite exercises instead.
 
+### 12.4 Read-side queries (the named set)
+
+Implementations may expose the **named query set** of
+[RFC-0002](docs/rfcs/0002-read-side-queries.md): seven deterministic,
+read-only queries over canonical record relationships - `descent`,
+`descendants`, `siblings`, `frontier`, `standing`, `evidence`,
+`selected` - answerable identically over a verified log or a receipt.
+The set is closed and its semantics are fixed. Queries derive from what
+replay already computes (never stored, never ranked), answer only over
+verified state (an input that does not verify is an error, not answers),
+address only accepted records (a rejected record made no claim), and
+annotate every reported record with its standing, taint, and retraction
+status rather than filtering anything silently. `selected` matches its
+objective exactly; there are no patterns, predicates, or composition
+(RFC-0002 section 7).
+
+The queries are surface, not wire format: they change no record, schema,
+or receipt byte, and carry no spec-version implications. Their authority
+chain is RFC-0002 (semantics and edge cases), this section (existence
+and boundaries), and the corpus's `query-cases.json` (executable
+answers: each vector pairs a receipt and a query with the exact surface
+JSON the query must return, and every name appears at least once). An
+implementation claiming the read-side surface re-derives each stored
+answer from the stored receipt, as the independent validator in
+`conformance/python/` does.
+
 ## 13. Known limitations
 
 - **Integrity, not confidentiality.** Records and receipts carry full

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/docs/quickstart-best-of-n.md
+++ b/docs/quickstart-best-of-n.md
@@ -171,6 +171,51 @@ whole episode - the break, the taint, and the repair - on the record. That
 is not a limitation; it is the point. A record that could quietly return to
 Clean after a retraction would be a record you could not trust.
 
+## Tie-breaks: when two candidates pass, record why one won
+
+Rewind to the selection at the start: suppose `c0` and `c1` had both
+*passed* the only criterion and you chose `c1`. If the reason lives only
+in the selection's free-text `rationale`, the record shows a valid
+choice whose stated evidence does not distinguish the winner - a
+verifier sees two green candidates and a coin flip. The discriminating
+fact deserves to be evidence, not prose: record it as its own
+Evaluation under its own criterion, and make the selection use it.
+
+```python
+# both c0 and c1 passed "unit-tests"; c1 also covers the edge cases
+e_tb = w.evaluate(author="evaluator", candidate=cands[1],
+                  criterion="completeness", passed=True)
+s = w.select(author="agent", objective="best-of-n",
+             consider=cands, choose=[cands[1]],
+             uses_eval=[evals[1], e_tb.id],
+             rationale="both green; c1 also covers the edge cases")
+```
+
+```sh
+etb=$(bellbook eval add --log $LOG --rules $RULES --author evaluator \
+        --candidate $c1 --criterion completeness --passed --json | jq -r .id)
+bellbook select --log $LOG --rules $RULES --author agent --objective best-of-n \
+  --consider $c0 $c1 --choose $c1 --uses-eval $e1 $etb
+```
+
+Now the tie-break is queryable evidence. Ask the record why the winner
+won, or what any descendant of the winner rests on, and the
+`completeness` evaluation is in the answer:
+
+```sh
+bellbook query selected best-of-n --log $LOG --rules $RULES
+bellbook query evidence $c1 --log $LOG --rules $RULES
+```
+
+`rationale` stays what it is - a recorded statement, useful to humans,
+verified by no one. Bellbook records consequences, not scoring logic, so
+there is no first-class ranking field and no rule forcing chosen
+candidates to be evidence-distinguishable from rejected ones; the
+pattern above is the supported way to make a tie-break hold up under
+verification. `bellbook query NAME [ID|OBJECTIVE] (--log DIR --rules
+FILE | --receipt FILE)` runs any of the seven named read-side queries
+(RFC-0002) the same way over a live log or an exported receipt.
+
 ## What Clean means (and does not)
 
 A **Clean** receipt means the recorded history is internally consistent under


### PR DESCRIPTION
Fourth and final change of the v0.6.0 milestone (RFC-0002, part of #91), following #99, #100, and #101.

Closes #90

## What

- **SPEC section 12.4, the named query set**: existence and boundaries in the spec, per the acceptance resolution (RFC-0002 section 9.3). The authority chain is explicit: RFC-0002 for semantics and edge cases, the SPEC section for existence and boundaries, `query-cases.json` for executable answers. The queries are surface, not wire format - no record, schema, or receipt byte changes, no spec-version implications.
- **The tie-break pattern in the best-of-N quickstart** (closes #90, per RFC-0002 section 9.4): the discriminating fact between two passing candidates is recorded as an Evaluation under its own criterion (e.g. `completeness`), so the selection's `uses_eval` genuinely distinguishes the winner and `bellbook query evidence`/`selected` surface it. `rationale` stays what it is - prose, verified by no one. The section also states why there is no first-class ranking field and no evidence-distinguishability rule, as the issue asked.
- **README**: the `query` command in the CLI grammar, the named set in the capability list, corpus/validator coverage updated, release line to 0.6.0.
- **Versions to 0.6.0**: crate, bindings crate, pyproject, wheel version guard, both lockfiles. The bindings' `bellbook_core` pin stays on the published 0.5 line until the new core is on crates.io (the pin policy documented in the bindings' Cargo.toml); the Python query methods land with that post-publish pin bump, before the PyPI publish.
- **CHANGELOG finalized**: `[0.6.0] - 2026-08-27` with the release framing (the read side; epoch stays 0.3; no ranking anywhere).

## Release sequence after this merges

1. Run the crates.io publish workflow (`release.yml`) on main.
2. Pin-bump PR: bindings `bellbook_core` to `0.6` + Python `Receipt`/`Writer` query methods + tests.
3. Run the PyPI publish workflow (`publish-pypi.yml`).
4. Tag, GitHub Release, milestone close (yours).

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features`: clean.
- Full `cargo test --all-features`: green (version bump rebuilds everything).
- Independent Python validator: all sections green.
- No stray `0.5.0` references outside the changelog history and the historically named v0.5.0 gate test.

Part of #91.