### PR TITLE
bindings(python): pin bellbook_core to 0.6 and expose the named query set

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530e84e85092344403f5265b10296ce62cdc6335ed0ea0edfb1ffc20db514b9d"
+checksum = "34c9389baa6854da4de249b5f47c62e332a64ad902061fdec2c73b9b33d1495c"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.5", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.6", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -13,6 +13,11 @@
 //!   same exclusive lock and runs the same replay-on-commit the Rust
 //!   `LogWriter` does. Export the log with `writer.receipt()` and feed it
 //!   straight back to `validate`.
+//! - The RFC-0002 named query set - `descent`, `descendants`, `siblings`,
+//!   `frontier`, `standing`, `evidence`, `selected` - is available as
+//!   methods on both `Receipt` and `Writer`, returning the shared surface
+//!   JSON shapes as plain dicts/lists. Queries run only over verified
+//!   state: an input that does not verify raises `ValueError`, not answers.
 
 // `#[pyfunction]` generates a result conversion that clippy reads as a
 // useless `PyErr -> PyErr` conversion for any `PyResult`-returning function.
@@ -23,7 +28,7 @@ use bellbook_core::{
     decode, default_space, encode, hex_decode, hex_encode, manifest_from_dir, manifest_hash,
     schema_id, validate as core_validate, verify_and_build_state, Author, AuthorType, BindingMode,
     CandidateBasis, CandidateData, EvaluationData, EvaluationOutcome, GitSource, Kind, LogWriter,
-    Proposal, Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType,
+    Proposal, Queries, Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType,
     Report as CoreReport, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
     SourceBinding, State, ValidationStatus, VerdictResult, VerifierRules, SCHEMA_CANDIDATE,
     SCHEMA_EVALUATION, SCHEMA_RETRACTION, SCHEMA_SELECTION,
@@ -167,9 +172,49 @@ fn validate(data: &[u8]) -> Report {
     }
 }
 
+// --- read-side queries (RFC-0002, the named set) ---------------------------
+
+/// Convert a query report (surface JSON) into Python dicts/lists via the
+/// stdlib `json` module, so every surface hands out the identical shape.
+fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> PyResult<Py<PyAny>> {
+    let s = serde_json::to_string(value).map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    Ok(py.import("json")?.call_method1("loads", (s,))?.unbind())
+}
+
+/// Flatten a query result into the surface JSON value, mapping both a query
+/// error and the (unreachable in practice) serialization error to a message.
+fn to_value<T: serde::Serialize>(
+    result: Result<T, bellbook_core::QueryError>,
+) -> Result<serde_json::Value, String> {
+    let report = result.map_err(|e| e.to_string())?;
+    serde_json::to_value(report).map_err(|e| e.to_string())
+}
+
+/// Build the verified query context and run one named query. Queries never
+/// answer over unverified history: a log or receipt that does not verify
+/// raises `ValueError`, as do a missing or rejected id and a kind mismatch.
+fn run_query<F>(
+    py: Python<'_>,
+    records: &[CoreRecord],
+    rules: &VerifierRules,
+    f: F,
+) -> PyResult<Py<PyAny>>
+where
+    F: FnOnce(&Queries<'_>) -> Result<serde_json::Value, String>,
+{
+    let q = Queries::new(records, rules).map_err(|e| PyValueError::new_err(format!("{e}")))?;
+    let value = f(&q).map_err(PyValueError::new_err)?;
+    json_to_py(py, &value)
+}
+
 /// A parsed receipt, for inspection. Reading does not verify: call
 /// [`validate`] for the Clean / Tainted / Invalid decision. A record's fields
 /// are as recorded; only replay confirms they are consistent.
+///
+/// The receipt also answers the RFC-0002 named query set (`descent`,
+/// `descendants`, `siblings`, `frontier`, `standing`, `evidence`,
+/// `selected`); those methods replay the receipt first and raise
+/// `ValueError` if it does not verify.
 #[pyclass(frozen, name = "Receipt", module = "bellbook")]
 struct Receipt {
     inner: CoreReceipt,
@@ -197,6 +242,70 @@ impl Receipt {
     /// Number of records (subjects and verdicts).
     fn __len__(&self) -> usize {
         self.inner.records.len()
+    }
+
+    /// q1 `descent(id)`: the line of descent from a candidate back to its
+    /// roots (RFC-0002). Returns the shared surface JSON as dicts/lists.
+    fn descent(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(q.descent(id))
+        })
+    }
+
+    /// q2 `descendants(id)`: every candidate whose descent passes through
+    /// the record, in log order.
+    fn descendants(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(q.descendants(id))
+        })
+    }
+
+    /// q3 `siblings(id)`: the candidate's generation (same anchor Selection,
+    /// or same exact derivation cause set), excluding itself.
+    fn siblings(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(q.siblings(id))
+        })
+    }
+
+    /// q4 `frontier()`: candidates no accepted Selection considered, and
+    /// chosen candidates with no continuation yet. Nothing is silently
+    /// filtered; every node carries its annotations.
+    fn frontier(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(Ok(q.frontier()))
+        })
+    }
+
+    /// q5 `standing(id)`: the record's standing, taint, and retraction
+    /// status, plus any restoring Selection ids.
+    fn standing(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(q.standing(id))
+        })
+    }
+
+    /// q6 `evidence(id)`: what the record rests on. For a Selection, its own
+    /// evidence; for a Candidate, the evidence of every anchor Selection
+    /// along its full descent (unbounded by design).
+    fn evidence(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(q.evidence(id))
+        })
+    }
+
+    /// q7 `selected(objective)`: the accepted Selected selections whose
+    /// objective equals the string exactly (no patterns), with chosen
+    /// candidates and evidence.
+    fn selected(&self, py: Python<'_>, objective: &str) -> PyResult<Py<PyAny>> {
+        run_query(py, &self.inner.records, &self.inner.rules, |q| {
+            to_value(Ok(q.selected(objective)))
+        })
     }
 
     fn __repr__(&self) -> String {
@@ -897,6 +1006,71 @@ impl Writer {
             .to_bytes()
             .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize receipt: {e}")))?;
         Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// q1 `descent(id)`: the line of descent from a candidate back to its
+    /// roots (RFC-0002). Returns the shared surface JSON as dicts/lists -
+    /// byte-for-byte the shapes `Receipt` and the CLI emit.
+    fn descent(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(q.descent(id))
+        })
+    }
+
+    /// q2 `descendants(id)`: every candidate whose descent passes through
+    /// the record, in log order.
+    fn descendants(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(q.descendants(id))
+        })
+    }
+
+    /// q3 `siblings(id)`: the candidate's generation (same anchor Selection,
+    /// or same exact derivation cause set), excluding itself.
+    fn siblings(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(q.siblings(id))
+        })
+    }
+
+    /// q4 `frontier()`: candidates no accepted Selection considered, and
+    /// chosen candidates with no continuation yet. Nothing is silently
+    /// filtered; every node carries its annotations.
+    fn frontier(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(Ok(q.frontier()))
+        })
+    }
+
+    /// q5 `standing(id)`: the record's standing, taint, and retraction
+    /// status, plus any restoring Selection ids.
+    fn standing(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(q.standing(id))
+        })
+    }
+
+    /// q6 `evidence(id)`: what the record rests on. For a Selection, its own
+    /// evidence; for a Candidate, the evidence of every anchor Selection
+    /// along its full descent (unbounded by design).
+    fn evidence(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        let id = parse_id(id)?;
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(q.evidence(id))
+        })
+    }
+
+    /// q7 `selected(objective)`: the accepted Selected selections whose
+    /// objective equals the string exactly (no patterns), with chosen
+    /// candidates and evidence.
+    fn selected(&self, py: Python<'_>, objective: &str) -> PyResult<Py<PyAny>> {
+        run_query(py, self.inner.records(), &self.rules, |q| {
+            to_value(Ok(q.selected(objective)))
+        })
     }
 
     fn __repr__(&self) -> String {

--- a/bindings/python/tests/test_query.py
+++ b/bindings/python/tests/test_query.py
@@ -1,0 +1,160 @@
+"""The RFC-0002 named query set from Python, on `Writer` and `Receipt` alike.
+
+Seven deterministic, read-only queries - descent, descendants, siblings,
+frontier, standing, evidence, selected - returning the shared surface JSON
+shapes as plain dicts/lists, identical to what the Rust core and the CLI
+emit. Queries run only over verified state: an input that does not verify
+raises ValueError, as do a missing or rejected id and a kind mismatch.
+"""
+
+import pytest
+
+import bellbook
+
+
+def _writer(tmp_path, name="log"):
+    rules = bellbook.default_rules(
+        {"agent": "provider", "evaluator": "provider", "human": "user"}
+    )
+    return bellbook.Writer(str(tmp_path / name), rules)
+
+
+def _story(w):
+    """The field-test story: adopt a baseline on a benchmark, run a
+    best-of-N round over its continuation, retract the benchmark, repair."""
+    c0 = w.candidate(author="agent", git_tree="a" * 40).id
+    bench = w.evaluate(
+        author="evaluator", candidate=c0, criterion="benchmark", passed=True
+    ).id
+    s0 = w.select(
+        author="agent",
+        objective="adopt-baseline",
+        consider=[c0],
+        choose=[c0],
+        uses_eval=[bench],
+    ).id
+    c1 = w.candidate(
+        author="agent", git_tree="b" * 40, continues=s0, parent=c0
+    ).id
+    c2 = w.candidate(author="agent", git_tree="c" * 40, derives_from=[c1]).id
+    c3 = w.candidate(author="agent", git_tree="d" * 40, derives_from=[c1]).id
+    e2 = w.evaluate(
+        author="evaluator", candidate=c2, criterion="unit-tests", passed=True
+    ).id
+    w.evaluate(author="evaluator", candidate=c3, criterion="unit-tests", failed=True)
+    s1 = w.select(
+        author="agent",
+        objective="adopt",
+        consider=[c2, c3],
+        choose=[c2],
+        uses_eval=[e2],
+    ).id
+    r = w.retract(author="evaluator", target=bench, reason="harness was broken")
+    assert r.accepted, r.reason
+    review = w.evaluate(
+        author="evaluator", candidate=c0, criterion="benchmark-v2", passed=True
+    ).id
+    s2 = w.select(
+        author="agent",
+        objective="adopt-baseline",
+        consider=[c0],
+        choose=[c0],
+        uses_eval=[review],
+        replaces=s0,
+    ).id
+    return dict(c0=c0, bench=bench, s0=s0, c1=c1, c2=c2, c3=c3, s1=s1, s2=s2)
+
+
+def test_the_named_set_answers_the_field_test(tmp_path):
+    w = _writer(tmp_path)
+    ids = _story(w)
+
+    # q7: which candidate won the round, on what evidence.
+    sel = w.selected("adopt")
+    assert [s["selection"]["id"] for s in sel["selections"]] == [ids["s1"]]
+    assert [c["id"] for c in sel["selections"][0]["chosen"]] == [ids["c2"]]
+    assert sel["selections"][0]["evidence"][0]["criterion"] == "unit-tests"
+    assert sel["selections"][0]["evidence"][0]["outcome"] == "passed"
+
+    # q1: the winner's full line of descent.
+    d = w.descent(ids["c2"])
+    assert [(s["node"]["id"], s["via"]) for s in d["line"]] == [
+        (ids["c1"], "derivation"),
+        (ids["s0"], "continuation-anchor"),
+        (ids["c0"], "parent"),
+    ]
+
+    # q6: what the line rests on - the retracted benchmark surfaces.
+    ev = w.evidence(ids["c2"])
+    assert [se["selection"]["id"] for se in ev["rests_on"]] == [ids["s0"]]
+    entry = ev["rests_on"][0]["evidence"][0]
+    assert entry["node"]["id"] == ids["bench"]
+    assert entry["node"]["retracted"] is True
+    assert entry["criterion"] == "benchmark"
+
+    # q5: the anchor Selection is unsound and tainted; the re-adoption is a
+    # restoration on the record, not an erasure.
+    st = w.standing(ids["s0"])
+    assert st["node"]["standing"] == "unsound"
+    assert st["node"]["tainted"] is True
+    assert st["restorations"] == [ids["s2"]]
+
+    # q4: the continuation was never considered; the round's winner has no
+    # continuation yet.
+    fr = w.frontier()
+    assert [(e["node"]["id"], e["reason"]) for e in fr["frontier"]] == [
+        (ids["c1"], "unconsidered"),
+        (ids["c2"], "selected-no-continuation"),
+    ]
+
+    # q3: the winner's generation.
+    sib = w.siblings(ids["c2"])
+    assert [n["id"] for n in sib["siblings"]] == [ids["c3"]]
+
+    # q2: everything downstream of the baseline.
+    de = w.descendants(ids["c0"])
+    assert {n["id"] for n in de["descendants"]} == {ids["c1"], ids["c2"], ids["c3"]}
+
+
+def test_receipt_and_writer_answers_are_identical(tmp_path):
+    # The shared-shape claim (RFC-0002 C4): the same query over the live
+    # writer and over its exported receipt returns equal Python objects.
+    w = _writer(tmp_path)
+    ids = _story(w)
+    r = bellbook.read(w.receipt())
+
+    assert r.descent(ids["c2"]) == w.descent(ids["c2"])
+    assert r.descendants(ids["c0"]) == w.descendants(ids["c0"])
+    assert r.siblings(ids["c2"]) == w.siblings(ids["c2"])
+    assert r.frontier() == w.frontier()
+    assert r.standing(ids["s0"]) == w.standing(ids["s0"])
+    assert r.evidence(ids["c2"]) == w.evidence(ids["c2"])
+    assert r.selected("adopt") == w.selected("adopt")
+
+
+def test_query_errors_are_specific(tmp_path):
+    w = _writer(tmp_path)
+    ids = _story(w)
+
+    # A rejected record is durably committed but not addressable.
+    rejected = w.retract(author="agent", target=ids["bench"], reason="not mine")
+    assert not rejected.accepted
+    with pytest.raises(ValueError, match="rejected at commit"):
+        w.standing(rejected.id)
+
+    # Kind mismatch: descent addresses candidates only.
+    with pytest.raises(ValueError, match="not a Candidate"):
+        w.descent(ids["bench"])
+
+    # Not found, and a malformed id.
+    with pytest.raises(ValueError, match="not found"):
+        w.descent("f" * 64)
+    with pytest.raises(ValueError, match="invalid record id"):
+        w.descent("zzzz")
+
+
+def test_exact_objective_no_patterns(tmp_path):
+    w = _writer(tmp_path)
+    _story(w)
+    assert w.selected("adopt-")["selections"] == []
+    assert w.selected("adopt*")["selections"] == []


### PR DESCRIPTION
The post-publish half of the v0.6.0 release (part of #91): `bellbook` 0.6.0 is on crates.io, so the bindings align to it and gain the read-side surface the milestone deferred to this exact point.

## What

- **Pin `bellbook_core` to `0.6`** (from `0.5`), per the pin policy in the bindings' Cargo.toml: the bindings track the published crate, and the `queries` module reached crates.io with the 0.6.0 publish minutes ago.
- **The named query set on `Receipt` and `Writer`**: `descent`, `descendants`, `siblings`, `frontier`, `standing`, `evidence`, `selected` - thin callers over `bellbook::queries` returning the shared surface JSON shapes as plain dicts/lists (converted via the stdlib `json` module, so the shapes are byte-for-byte what the Rust core and the CLI emit). Queries run only over verified state: a log or receipt that does not verify raises `ValueError`, as do a missing or rejected id and a kind mismatch.
- **Tests** (42 passing locally, 4 new): the field-test story answered from the `Writer` surface, `Writer`/`Receipt` answer equality over the same log (RFC-0002 C4), the error battery, and exact objective matching (no patterns).

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets` in the bindings workspace: clean.
- `maturin develop --release` against published `bellbook` 0.6.0, then `pytest tests -q`: 42 passed.

After this merges: trigger `publish-pypi.yml` so the 0.6.0 wheel ships with the query methods included.

Part of #91.