### PR TITLE
release prep for 0.7.0

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.6.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.7.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-09-02
+
+Profiles foundation. RFC-0003 (accepted 2026-09-02) sets the sequence
+from a Clean receipt to a checkable delivery claim, and this release
+ships its first step: the `bellbook-core-v1` baseline profile, the
+content-addressed agreement two parties name so their receipts are
+comparable. A profile is a report alongside the verdict, never a change
+to it. No record or receipt wire change - the spec epoch stays 0.3 and
+the 0.3 corpus is byte-unchanged - and existing 0.3-0.6 receipts and
+rules validate identically. The Python package gains the profile check
+and baseline-default rules immediately after the core publish (the
+bindings track the published crate).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ evolution kinds to a log and exports a receipt. See
 
 ## Status
 
-**The published release is 0.6.0, implementing spec v0.3 (evolution
+**The published release is 0.7.0, implementing spec v0.3 (evolution
 semantics: Candidate, Evaluation, and Selection records with replay-derived
 lineage standing).** SPEC.md is the authority for what v0.3 means (design
 notes in [`spec/v0.3-delta.md`](spec/v0.3-delta.md)). The previous epoch,
@@ -314,7 +314,8 @@ source binding, the selection and reaffirmation rule battery, and the
 replay-derived standing section, derived state with incremental/full-build
 equivalence, checkpoints, the crash-safe writer with idempotent
 compare-and-append, and portable receipts with the offline `bellbook
-validate` CLI, the `candidate`/`eval`/`select`/`retract`/`lineage` recording
+validate` CLI (including the `bellbook-core-v1` baseline profile check),
+the `candidate`/`eval`/`select`/`retract`/`lineage` recording
 commands, the read-side `query` command (the RFC-0002 named set: descent,
 descendants, siblings, frontier, standing, evidence, selected - over a log
 or a receipt), and `rules init` / `export` to generate a starter rule set and

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Refs #115 (release gate, v0.7.0 - Profiles Foundation). Version checklist only; no code change.

## Gate status

- RFC-0003 (#106) accepted rev 2, gate override recorded, VISION build-ahead entry merged (#118, #119).
- `bellbook-core-v1` defined and shipped with vectors, CLI check, and independent Python evaluation (#120, closes #6).
- Epoch invariant: `git diff --stat v0.6.0 HEAD -- spec/conformance/` is empty. Spec epoch stays 0.3.
- Full audit on this head: fmt clean, clippy 0 diagnostics, 258 Rust tests green, Python validator 629 assertions, no em dashes.

## Version checklist

- `Cargo.toml`, `bindings/python/Cargo.toml` (crate version), `bindings/python/pyproject.toml`, wheel smoke-test guard, both lockfiles: 0.6.0 to 0.7.0.
- Bindings pin stays `bellbook = "0.6"` until the core publish; the pin-bump PR (pin `0.7`, Python `default_rules` baseline thresholds, `validate(..., require_profile=...)`, `Report.profiles`) follows the crates.io publish, then PyPI.
- CHANGELOG `[Unreleased]` finalized as `[0.7.0] - 2026-09-02` with the release framing.
- README status paragraph: published release 0.7.0; the profile check named in the shipped list.

## After merge

1. Dispatch `release.yml` on `main` (crates.io 0.7.0).
2. Pin-bump PR for the bindings; merge when green.
3. Dispatch `publish-pypi.yml` on `main`.
4. Tag `v0.7.0`, GitHub Release, milestone close, site bump, article (user-side steps; text drafted separately).