### PR TITLE
bindings(python): pin bellbook_core to 0.7 and expose the baseline profile

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9389baa6854da4de249b5f47c62e332a64ad902061fdec2c73b9b33d1495c"
+checksum = "61ae7aa59eaa5042f29b927d553b799cd175ce52e2ce69c5a97c8d3030a0c504"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.6", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.7", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -13,8 +13,8 @@ to cross-check the specification.)
 
 ## Status
 
-Validation, reading, writing, and the read-side query set (issue #13,
-RFC-0002).
+Validation (with the `bellbook-core-v1` baseline profile check), reading,
+writing, and the read-side query set (issue #13, RFC-0002, RFC-0003).
 
 ## Validate
 
@@ -39,7 +39,23 @@ print(report)                 # the full human-readable report (same as the CLI)
 Validation never raises for a bad receipt: an unparseable or failing receipt
 returns a `Report` with `status == "invalid"` and a `problem` or `reason`
 set. As with the CLI, **Clean is relative to the rules embedded in the
-receipt** - compare `rules_hash` against a rule set you trust.
+receipt** - compare `rules_hash` against a rule set you trust, or name the
+shared baseline:
+
+```python
+report = bellbook.validate(data, require_profile="bellbook-core-v1")
+p = report.profiles[0]
+print(p["status"])            # "Conformant" | "NonConformant" | "Unknown"
+print(p["hash"])              # hex of the profile's clause-table hash
+for c in p["clauses"]:        # [{"id": "B1", "passed": True, "detail": "..."}, ...]
+    print(c["id"], c["passed"], c["detail"])
+```
+
+`require_profile` takes one id or a list; results land in `report.profiles`
+in request order, and an unknown id is reported as `"Unknown"`, not raised.
+A profile result is a report alongside the verdict: it never changes
+`status` or `reason`. The profile itself is documented in
+[docs/profiles/bellbook-core-v1.md](../../docs/profiles/bellbook-core-v1.md).
 
 ## Read
 
@@ -79,7 +95,9 @@ never hand-author a rules object. `authors` maps an actor id to a role (`user`,
 `provider`, `system`, `executor`, or `verifier`, case-insensitive). `admins`
 lists actors allowed to retract records they did not author; `reaffirmers`,
 when given, restricts reaffirming selections to the listed actors. Both must
-also appear in `authors`:
+also appear in `authors`. Like `rules init`, the result carries the
+`bellbook-core-v1` baseline evidence thresholds, so a log committed under it
+conforms to the baseline profile out of the box:
 
 ```python
 import bellbook

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,9 +1,11 @@
 //! Python bindings for Bellbook (issue #13): offline receipt validation and
 //! reading from Python.
 //!
-//! - `bellbook.validate(data: bytes) -> Report` wraps the crate's `validate`,
-//!   so Python reaches the exact same Clean / Tainted / Invalid decision the
-//!   Rust CLI does, over the same core.
+//! - `bellbook.validate(data: bytes, require_profile=None) -> Report` wraps
+//!   the crate's `validate`, so Python reaches the exact same Clean / Tainted
+//!   / Invalid decision the Rust CLI does, over the same core. Naming a
+//!   profile (`"bellbook-core-v1"`, or a list of ids) adds the profile
+//!   results to the report without changing the verdict.
 //! - `bellbook.read(data: bytes) -> Receipt` parses a receipt for inspection
 //!   (records, kinds, authors, evidence, refs, payloads). Reading does not
 //!   verify; call `validate` for the decision.
@@ -26,12 +28,12 @@
 
 use bellbook_core::{
     decode, default_space, encode, hex_decode, hex_encode, manifest_from_dir, manifest_hash,
-    schema_id, validate as core_validate, verify_and_build_state, Author, AuthorType, BindingMode,
+    schema_id, validate_with_profiles, verify_and_build_state, Author, AuthorType, BindingMode,
     CandidateBasis, CandidateData, EvaluationData, EvaluationOutcome, GitSource, Kind, LogWriter,
     Proposal, Queries, Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType,
     Report as CoreReport, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
-    SourceBinding, State, ValidationStatus, VerdictResult, VerifierRules, SCHEMA_CANDIDATE,
-    SCHEMA_EVALUATION, SCHEMA_RETRACTION, SCHEMA_SELECTION,
+    SourceBinding, State, ValidationLimits, ValidationStatus, VerdictResult, VerifierRules,
+    SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_RETRACTION, SCHEMA_SELECTION,
 };
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -145,6 +147,40 @@ impl Report {
         Ok(out)
     }
 
+    /// Profile results, in the order requested via
+    /// `validate(..., require_profile=...)`; empty unless profiles were
+    /// requested. Each is a dict `{"id", "hash" (lowercase hex of the
+    /// profile's clause-table hash), "status" ("Conformant" |
+    /// "NonConformant" | "Unknown"), "clauses": [{"id", "passed",
+    /// "detail"}, ...]}`. A profile result is a report alongside the
+    /// verdict: it never changes `status` or `reason`.
+    #[getter]
+    fn profiles<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        self.inner
+            .profiles
+            .iter()
+            .map(|p| {
+                let out = PyDict::new(py);
+                out.set_item("id", &p.id)?;
+                out.set_item("hash", hex_encode(&p.hash))?;
+                out.set_item("status", format!("{:?}", p.status))?;
+                let clauses = p
+                    .clauses
+                    .iter()
+                    .map(|c| {
+                        let d = PyDict::new(py);
+                        d.set_item("id", &c.id)?;
+                        d.set_item("passed", c.passed)?;
+                        d.set_item("detail", &c.detail)?;
+                        Ok(d)
+                    })
+                    .collect::<PyResult<Vec<_>>>()?;
+                out.set_item("clauses", clauses)?;
+                Ok(out)
+            })
+            .collect()
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Report(status={:?}, records={}, spec_version={:?})",
@@ -165,11 +201,33 @@ impl Report {
 /// re-derived, evidence, taint, and the standing section. It never raises for
 /// an invalid receipt - an unparseable or failing receipt returns a `Report`
 /// with `status == "invalid"` and a `problem` or `reason` set.
+///
+/// `require_profile` names a profile id (or a list of ids) to evaluate on
+/// top of the verdict, e.g. `"bellbook-core-v1"`; the results land in
+/// `Report.profiles` in request order. An id the validator does not know is
+/// reported as `"Unknown"`, never raised. Profiles never change the verdict.
 #[pyfunction]
-fn validate(data: &[u8]) -> Report {
-    Report {
-        inner: core_validate(data),
+#[pyo3(signature = (data, require_profile=None))]
+fn validate(data: &[u8], require_profile: Option<Bound<'_, PyAny>>) -> PyResult<Report> {
+    let profiles = match require_profile {
+        None => Vec::new(),
+        Some(v) => profile_ids(&v)?,
+    };
+    let ids: Vec<&str> = profiles.iter().map(String::as_str).collect();
+    Ok(Report {
+        inner: validate_with_profiles(data, &ValidationLimits::default(), &ids),
+    })
+}
+
+/// `require_profile` accepts one id or a list of ids; anything else is a
+/// `ValueError` rather than a silently ignored argument.
+fn profile_ids(v: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
+    if let Ok(one) = v.extract::<String>() {
+        return Ok(vec![one]);
     }
+    v.extract::<Vec<String>>().map_err(|_| {
+        PyValueError::new_err("require_profile must be a profile id (str) or a list of ids")
+    })
 }
 
 // --- read-side queries (RFC-0002, the named set) ---------------------------
@@ -445,6 +503,11 @@ fn parse_role(s: &str) -> PyResult<AuthorType> {
 /// `authors`: an actor with no role binding could never author an accepted
 /// record, so listing it here would be a silent no-op.
 ///
+/// Like `bellbook rules init`, the result carries the `bellbook-core-v1`
+/// baseline evidence thresholds (Candidate `Reported`, Evaluation
+/// `Reported`, Selection `Inferred` - the schema base classes), so a log
+/// committed under it conforms to the baseline profile out of the box.
+///
 /// ```python
 /// rules = bellbook.default_rules({"agent": "provider", "evaluator": "provider"},
 ///                                admins=["agent"])
@@ -463,7 +526,7 @@ fn default_rules(
             "default_rules needs at least one author binding",
         ));
     }
-    let mut rules = VerifierRules::new(default_space(), max_context);
+    let mut rules = VerifierRules::new(default_space(), max_context).with_baseline_thresholds();
     for (id, role) in &authors {
         if id.is_empty() {
             return Err(PyValueError::new_err("author id must be non-empty"));
@@ -479,9 +542,8 @@ fn default_rules(
             }
         }
     }
-    // Insert into the public sets directly rather than through the core's
-    // builder methods, so the binding keeps building against the published
-    // core crate (the builders arrive with the next core release).
+    // Direct inserts into the public sets; equivalent to the core's
+    // `with_admin_retraction_actor` / `with_reaffirmation_actor` builders.
     for id in admins.iter().flatten() {
         rules.admin_retraction_actors.insert(id.clone().into());
     }

--- a/bindings/python/tests/test_profiles.py
+++ b/bindings/python/tests/test_profiles.py
@@ -1,0 +1,106 @@
+"""`bellbook-core-v1` across the FFI boundary: `validate(..., require_profile=...)`
+carries the profile result, `default_rules` emits a baseline-conformant rule
+set, and every published profile vector re-derives identically through the
+wheel. A profile result is a report alongside the verdict, never a change
+to it."""
+
+import json
+import pathlib
+
+import pytest
+
+import bellbook
+
+# repo root: bindings/python/tests/ -> bindings/python -> bindings -> root
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+CASES = ROOT / "spec" / "profiles" / "bellbook-core-v1" / "cases.json"
+CORE_V1 = "bellbook-core-v1"
+BASELINE = {"Candidate": "Reported", "Evaluation": "Reported", "Selection": "Inferred"}
+
+
+def _line(tmp_path, rules_json: str) -> bytes:
+    """One candidate, one passing evaluation, one selection: a Clean line."""
+    w = bellbook.Writer(str(tmp_path / "log"), rules_json)
+    c = w.candidate(author="agent", git_tree="a" * 40)
+    e = w.evaluate(author="evaluator", candidate=c.id, criterion="fitness", passed=True)
+    s = w.select(
+        author="agent",
+        objective="best-of-n",
+        consider=[c.id],
+        choose=[c.id],
+        uses_eval=[e.id],
+    )
+    assert s.accepted, s.reason
+    return w.receipt()
+
+
+def _authors():
+    return {"agent": "provider", "evaluator": "provider"}
+
+
+def test_default_rules_conform_to_the_baseline(tmp_path):
+    rules = bellbook.default_rules(_authors())
+    assert json.loads(rules)["evidence_thresholds"] == BASELINE
+
+    report = bellbook.validate(_line(tmp_path, rules), require_profile=CORE_V1)
+    assert report.status == "clean"
+    (p,) = report.profiles
+    assert p["id"] == CORE_V1
+    assert p["status"] == "Conformant"
+    assert [c["id"] for c in p["clauses"]] == ["B1", "B2", "B3", "B4", "B5", "B6"]
+    assert all(c["passed"] for c in p["clauses"])
+    assert len(p["hash"]) == 64 and int(p["hash"], 16)
+    # The human rendering names the profile, as the CLI does.
+    assert f"profile {CORE_V1}: CONFORMANT" in str(report)
+
+
+def test_profiles_are_a_report_alongside_the_verdict(tmp_path):
+    # Strip the thresholds: still valid rules, still a Clean log, but not
+    # comparable under the baseline. The verdict fields are untouched.
+    rules = json.loads(bellbook.default_rules(_authors()))
+    rules["evidence_thresholds"] = {}
+    receipt = _line(tmp_path, json.dumps(rules))
+
+    plain = bellbook.validate(receipt)
+    assert plain.profiles == []
+    report = bellbook.validate(receipt, require_profile=[CORE_V1])
+    assert (report.status, report.reason) == (plain.status, plain.reason) == ("clean", None)
+    assert report.head_hash == plain.head_hash
+    assert report.rules_hash == plain.rules_hash
+
+    (p,) = report.profiles
+    assert p["status"] == "NonConformant"
+    b3 = next(c for c in p["clauses"] if c["id"] == "B3")
+    assert not b3["passed"]
+    assert "missing" in b3["detail"]
+    assert all(c["passed"] for c in p["clauses"] if c["id"] != "B3")
+
+
+def test_unknown_profile_is_reported_not_raised(tmp_path):
+    receipt = _line(tmp_path, bellbook.default_rules(_authors()))
+    report = bellbook.validate(receipt, require_profile=["no-such-profile-v9", CORE_V1])
+    assert [p["status"] for p in report.profiles] == ["Unknown", "Conformant"]
+    assert report.profiles[0]["hash"] == "0" * 64
+    assert report.profiles[0]["clauses"] == []
+
+
+def test_require_profile_type_is_checked():
+    with pytest.raises(ValueError, match="require_profile"):
+        bellbook.validate(b"x", require_profile=7)
+
+
+def test_published_profile_vectors_match_reference():
+    """Every vector in spec/profiles/bellbook-core-v1/cases.json yields the
+    stored status, per-clause flags, and profile hash through the wheel."""
+    doc = json.loads(CASES.read_text())
+    assert doc["profile"] == CORE_V1
+    expected_hash = bytes(doc["hash"]).hex()
+    assert len(doc["cases"]) >= 7
+    for case in doc["cases"]:
+        data = json.dumps(case["receipt"]).encode()
+        report = bellbook.validate(data, require_profile=CORE_V1)
+        (p,) = report.profiles
+        assert p["hash"] == expected_hash, case["name"]
+        assert p["status"] == case["expect"]["status"], case["name"]
+        flags = [{"id": c["id"], "passed": c["passed"]} for c in p["clauses"]]
+        assert flags == case["expect"]["clauses"], case["name"]


### PR DESCRIPTION
Refs #115. The core is on crates.io at 0.7.0 (Release run 14); this aligns the bindings and lands the Python side of the profiles foundation. PyPI publish follows this merge.

## What

- **Pin**: `bellbook_core` `0.6` to `0.7`; lockfile resolves `bellbook 0.7.0`.
- **`validate(data, require_profile=None)`**: one profile id or a list. Results land in `Report.profiles` in request order as dicts `{id, hash (hex), status, clauses: [{id, passed, detail}]}`. An unknown id is reported as `"Unknown"`, never raised; a wrong argument type is a `ValueError`. The verdict fields are untouched (pinned by test).
- **`default_rules(...)`** now carries the `bellbook-core-v1` baseline evidence thresholds, matching `bellbook rules init`, so a Python-written log conforms out of the box.
- **Tests** (`tests/test_profiles.py`, 5 new; 47 total pass on the fresh wheel): baseline conformance through the `Writer`; thresholds stripped gives `NonConformant` with B3 failing while `status`, `reason`, `head_hash`, `rules_hash` are identical to the plain report; unknown profile; argument type; and every published vector in `spec/profiles/bellbook-core-v1/cases.json` re-derived through the wheel (status, per-clause flags, profile hash).
- **README**: Validate and Write sections.

## Audit

- `cargo fmt --check` clean; `cargo clippy --all-targets` 0 diagnostics in the bindings crate.
- Wheel built locally against crates.io 0.7.0 (`bellbook-0.7.0-cp39-abi3-manylinux_2_34_x86_64.whl`); `pytest tests`: 47 passed.
- No em dashes.