### PR TITLE
bindings(python): pin bellbook_core to 0.8 and expose the spec 0.4 surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ pip install bellbook
 `bellbook.validate(bytes)` and `bellbook.read(bytes)` reach the exact
 Clean / Tainted / Invalid decision the Rust verifier does - over the same
 core, never a reimplementation - and `bellbook.Writer` records the v0.3
-evolution kinds to a log and exports a receipt. See
+evolution kinds and the v0.4 requirement binding (requests, requirements,
+artifact-bound candidates, extended evaluations) to a log and exports a
+receipt that can declare the profiles it claims. See
 [`bindings/python/`](bindings/python/) for the full API.
 
 ## Status

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ae7aa59eaa5042f29b927d553b799cd175ce52e2ce69c5a97c8d3030a0c504"
+checksum = "7d5be13ef90e12f5e19df5e0c6927f69b20814629dd014e4e4b4517cd6f4b9e2"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.7", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.8", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -53,8 +53,14 @@ for c in p["clauses"]:        # [{"id": "B1", "passed": True, "detail": "..."}, 
 
 `require_profile` takes one id or a list; results land in `report.profiles`
 in request order, and an unknown id is reported as `"Unknown"`, not raised.
-A profile result is a report alongside the verdict: it never changes
-`status` or `reason`. The profile itself is documented in
+A receipt that declares profiles (spec 0.4, `Writer.receipt(profiles=...)`)
+needs no `require_profile`: every declared profile is evaluated unasked and
+comes first, with `p["declared"]`, `p["declaration_matches"]` (whether the
+declared version and hash name the clause table that was evaluated; `None`
+for an undeclared or unknown profile), and `p["met"]` (Conformant and, if
+declared, matching). A declaration is never trusted. A profile result is a
+report alongside the verdict: it never changes `status` or `reason`. The
+profile itself is documented in
 [docs/profiles/bellbook-core-v1.md](../../docs/profiles/bellbook-core-v1.md).
 
 ## Read
@@ -117,7 +123,8 @@ report = bellbook.validate(w.receipt())
 assert report.status == "clean"
 ```
 
-Each of `candidate`, `evaluate`, `select`, and `retract` commits one record
+Each of `request`, `requirement`, `candidate`, `evaluate`, `select`, and
+`retract` commits one record
 and returns a `Commit` (`id`, `accepted`, `result`, `reason`). A record is durably committed
 whether accepted or rejected - a rejected record is evidence a proposal was
 refused - so `accepted` may be `False` without an exception. Statically-knowable
@@ -136,13 +143,54 @@ written.
     (`derives_from=[sound_parent.id, failing_eval.id]`), and because `Cause`
     carries intent, not taint, retracting that evaluation later does not
     taint the repair.
+  `artifacts` (spec 0.4) binds artifact identities: a list of
+  `"scheme:digest[:name]"` strings or `{"scheme", "digest", "name"?}` dicts
+  (registered schemes: `git-tree-sha1`, `git-tree-sha256`, `manifest-v1`,
+  `git-archive-tar-v1`, `oci-image-manifest`, `sha256-bytes`), checked and
+  canonically ordered before the write.
 - `evaluate(author, candidate, criterion, *, passed=False, failed=False,
-  score=None, scale=None, procedure=None, uses=None)` - exactly one of
-  `passed`, `failed`, or a `score` (with `scale`, a decimal exponent 0-12).
+  score=None, scale=None, procedure=None, uses=None, blocked=False,
+  insufficient=False, stale=False, not_run=False, evaluator=None,
+  evaluator_version=None, procedure_hash=None, input_hash=None, basis=None,
+  requirements=None, artifacts=None)` - exactly one outcome: `passed`,
+  `failed`, a `score` (with `scale`, a decimal exponent 0-12), or one of the
+  spec 0.4 fail-closed outcomes (only `passed` passes). With `evaluator` and
+  `basis` (`"recomputed"` or `"declared"`; never inferred) the extended
+  evaluation is written: who decided with what procedure over what input,
+  the `artifacts` judged, and the accepted Requirement ids it speaks to
+  (`requirements`, each also a `Use` ref, so a retracted requirement taints
+  the evaluations that judged against it). Any of those without both
+  `evaluator` and `basis` raises `ValueError`; without them the v1 shape is
+  written.
 - `select(author, objective, consider, *, choose=None, uses_eval=None,
   none=False, replaces=None, rationale=None)` - exactly one of `choose` (with
   `uses_eval`) or `none=True`; `replaces` reaffirms a prior selection.
   `consider`, `choose`, and `uses_eval` are **lists** of record ids.
+- `request(author, objective)` (spec 0.4) - what a person asked for; the
+  author must have the `user` role. Requirements bind to it.
+- `requirement(author, request, key, description, *, required=True,
+  expected_evidence=None, provenance=None)` (spec 0.4) - an addressable
+  statement of what the request requires. `key` must be unique among the
+  request's accepted, unretracted requirements (a duplicate commits as a
+  rejected record with `RequirementInvalid`; retract-and-record releases
+  it). `provenance` is `"user_authored"` or `"derived"`, defaults from the
+  author's role (user -> user_authored, provider or system -> derived), and
+  a value the role cannot carry raises `ValueError` before the write.
+- `receipt(profiles=None)` - `profiles=["bellbook-core-v1"]` declares the
+  profiles the receipt claims (spec 0.4). A declaration is never trusted:
+  every validator evaluates it unasked and reports `declared`,
+  `declaration_matches`, and `met` beside the result.
+
+```python
+req = w.request(author="human", objective="ship the bound build")
+r1 = w.requirement(author="human", request=req.id, key="R1", description="unit tests pass")
+c0 = w.candidate(author="agent", git_tree=tree, artifacts=[f"git-tree-sha1:{tree}:src"])
+e0 = w.evaluate(author="evaluator", candidate=c0.id, criterion="unit-tests", passed=True,
+                evaluator="test-harness", basis="recomputed",
+                requirements=[r1.id], artifacts=[f"git-tree-sha1:{tree}"])
+report = bellbook.validate(w.receipt(profiles=["bellbook-core-v1"]))
+report.profiles[0]["met"]     # True: Conformant, and the declaration matches
+```
 
 ## Retract
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -10,11 +10,12 @@
 //!   (records, kinds, authors, evidence, refs, payloads). Reading does not
 //!   verify; call `validate` for the decision.
 //! - `bellbook.Writer(log_dir, rules)` records evolution to a persistent,
-//!   single-writer log: `candidate`, `evaluate`, `select`, and `retract`
-//!   each commit one record and return a [`Commit`]. The writer holds the
-//!   same exclusive lock and runs the same replay-on-commit the Rust
-//!   `LogWriter` does. Export the log with `writer.receipt()` and feed it
-//!   straight back to `validate`.
+//!   single-writer log: `request`, `requirement`, `candidate`, `evaluate`,
+//!   `select`, and `retract` each commit one record and return a
+//!   [`Commit`]. The writer holds the same exclusive lock and runs the same
+//!   replay-on-commit the Rust `LogWriter` does. Export the log with
+//!   `writer.receipt()` (optionally declaring profiles) and feed it straight
+//!   back to `validate`.
 //! - The RFC-0002 named query set - `descent`, `descendants`, `siblings`,
 //!   `frontier`, `standing`, `evidence`, `selected` - is available as
 //!   methods on both `Receipt` and `Writer`, returning the shared surface
@@ -27,13 +28,16 @@
 #![allow(clippy::useless_conversion)]
 
 use bellbook_core::{
-    decode, default_space, encode, hex_decode, hex_encode, manifest_from_dir, manifest_hash,
-    schema_id, validate_with_profiles, verify_and_build_state, Author, AuthorType, BindingMode,
-    CandidateBasis, CandidateData, EvaluationData, EvaluationOutcome, GitSource, Kind, LogWriter,
-    Proposal, Queries, Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType,
-    Report as CoreReport, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
+    artifact_ref_well_formed, decode, default_space, encode, hex_decode, hex_encode,
+    manifest_from_dir, manifest_hash, schema_id, validate_with_profiles, verify_and_build_state,
+    ArtifactRef, Author, AuthorType, Basis, BindingMode, CandidateBasis, CandidateData,
+    DeciderBinding, EvaluationData, EvaluationDataV2, EvaluationOutcome, EvaluationOutcomeV2,
+    GitSource, Kind, LogWriter, Proposal, Provenance, Queries, Receipt as CoreReceipt,
+    Record as CoreRecord, RecordId, Ref, RefType, Report as CoreReport, RequestData,
+    RequirementData, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
     SourceBinding, State, ValidationLimits, ValidationStatus, VerdictResult, VerifierRules,
-    SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_RETRACTION, SCHEMA_SELECTION,
+    SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_EVALUATION_V2, SCHEMA_REQUEST, SCHEMA_REQUIREMENT,
+    SCHEMA_RETRACTION, SCHEMA_SELECTION,
 };
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -147,12 +151,18 @@ impl Report {
         Ok(out)
     }
 
-    /// Profile results, in the order requested via
-    /// `validate(..., require_profile=...)`; empty unless profiles were
-    /// requested. Each is a dict `{"id", "hash" (lowercase hex of the
-    /// profile's clause-table hash), "status" ("Conformant" |
-    /// "NonConformant" | "Unknown"), "clauses": [{"id", "passed",
-    /// "detail"}, ...]}`. A profile result is a report alongside the
+    /// Profile results: every profile the receipt declares (spec 0.4), in
+    /// declaration order, then the ids requested via
+    /// `validate(..., require_profile=...)` that the receipt did not declare.
+    /// Empty when the receipt declares nothing and nothing was requested.
+    /// Each is a dict `{"id", "hash" (lowercase hex of the profile's
+    /// clause-table hash the validator evaluated), "status" ("Conformant" |
+    /// "NonConformant" | "Unknown"), "declared" (bool),
+    /// "declaration_matches" (True/False for a declared, known profile:
+    /// whether the declared version and hash name the evaluated table; None
+    /// otherwise), "met" (Conformant and, if declared, matching),
+    /// "clauses": [{"id", "passed", "detail"}, ...]}`. A declaration is
+    /// never trusted, and a profile result is a report alongside the
     /// verdict: it never changes `status` or `reason`.
     #[getter]
     fn profiles<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
@@ -164,6 +174,9 @@ impl Report {
                 out.set_item("id", &p.id)?;
                 out.set_item("hash", hex_encode(&p.hash))?;
                 out.set_item("status", format!("{:?}", p.status))?;
+                out.set_item("declared", p.declared)?;
+                out.set_item("declaration_matches", p.declaration_matches)?;
+                out.set_item("met", p.met())?;
                 let clauses = p
                     .clauses
                     .iter()
@@ -594,6 +607,72 @@ fn parse_id(hex: &str) -> PyResult<RecordId> {
     hex_decode(hex).ok_or_else(|| PyValueError::new_err(format!("invalid record id {hex:?}")))
 }
 
+fn parse_hash(name: &str, hex: &str) -> PyResult<[u8; 32]> {
+    hex_decode(hex).ok_or_else(|| {
+        PyValueError::new_err(format!("invalid {name} {hex:?} (expected 64 hex chars)"))
+    })
+}
+
+/// `artifacts=[...]` (spec 0.4): each entry is `"scheme:digest[:name]"` (the
+/// CLI form) or a dict `{"scheme", "digest", "name"?}`. Every reference is
+/// checked against the artifact rule before anything is written, and the
+/// list is sorted and deduplicated into the canonical order the verifier
+/// requires, so a well-formed call never mints an `ArtifactRefInvalid`
+/// record. `None` when the argument was omitted.
+fn parse_artifacts(items: Option<Vec<Bound<'_, PyAny>>>) -> PyResult<Option<Vec<ArtifactRef>>> {
+    let Some(items) = items else {
+        return Ok(None);
+    };
+    let mut refs = Vec::with_capacity(items.len());
+    for item in items {
+        let a = if let Ok(s) = item.extract::<String>() {
+            let mut parts = s.splitn(3, ':');
+            let scheme = parts.next().unwrap_or_default().to_string();
+            let digest = parts
+                .next()
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "invalid artifact {s:?} (expected scheme:digest[:name])"
+                    ))
+                })?
+                .to_string();
+            ArtifactRef {
+                scheme,
+                digest,
+                name: parts.next().map(str::to_string),
+            }
+        } else if let Ok(d) = item.cast::<PyDict>() {
+            let field = |k: &str| -> PyResult<Option<String>> {
+                match d.get_item(k)? {
+                    Some(v) if !v.is_none() => Ok(Some(v.extract::<String>()?)),
+                    _ => Ok(None),
+                }
+            };
+            ArtifactRef {
+                scheme: field("scheme")?
+                    .ok_or_else(|| PyValueError::new_err("artifact dict requires scheme"))?,
+                digest: field("digest")?
+                    .ok_or_else(|| PyValueError::new_err("artifact dict requires digest"))?,
+                name: field("name")?,
+            }
+        } else {
+            return Err(PyValueError::new_err(
+                "artifacts entries must be 'scheme:digest[:name]' strings or dicts",
+            ));
+        };
+        if !artifact_ref_well_formed(&a) {
+            return Err(PyValueError::new_err(format!(
+                "invalid artifact {}:{}: scheme must match [a-z0-9][a-z0-9.-]* and the digest must be lowercase hex of the scheme's length",
+                a.scheme, a.digest
+            )));
+        }
+        refs.push(a);
+    }
+    refs.sort();
+    refs.dedup();
+    Ok(Some(refs))
+}
+
 /// Encode a payload, then decode it back so the payload's `TryFrom` invariants
 /// (score bounds, non-empty criterion/objective) are checked before the write,
 /// exactly as the CLI does. Without this a statically-knowable violation would
@@ -694,13 +773,131 @@ impl Writer {
         })
     }
 
+    /// Record a Request: what a person asked for (spec 0.4 surfaces bind
+    /// requirements to it). Single-thread writer, so the request's scope is
+    /// the space and it has no parent request. The verifier admits only a
+    /// user-role author.
+    #[pyo3(signature = (author, objective))]
+    fn request(&mut self, author: &str, objective: &str) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        let data = checked_encode(&RequestData {
+            objective: objective.to_string(),
+            scope: self.rules.space,
+            attachments: Vec::new(),
+            parent_request_id: None,
+        })?;
+        self.do_commit(
+            author,
+            Kind::Request,
+            schema_id(SCHEMA_REQUEST),
+            data,
+            Vec::new(),
+        )
+    }
+
+    /// Record a Requirement under a request (spec 0.4): an addressable
+    /// statement of what it requires. Exactly one `Cause` to the request; the
+    /// key must be unique among the request's accepted, unretracted
+    /// requirements (a duplicate commits as a durable rejected record with
+    /// `RequirementInvalid`; retract-and-record releases the key).
+    /// `provenance` is `"user_authored"` or `"derived"` and is bound to the
+    /// author's role by the verifier; it defaults from the role (user ->
+    /// user_authored, provider or system -> derived) and a stated value the
+    /// role cannot carry raises `ValueError` before anything is written.
+    /// `required=False` records an informational requirement a profile never
+    /// counts; `expected_evidence` is recorded, not interpreted.
+    #[pyo3(signature = (author, request, key, description, *, required=true,
+        expected_evidence=None, provenance=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn requirement(
+        &mut self,
+        author: &str,
+        request: &str,
+        key: &str,
+        description: &str,
+        required: bool,
+        expected_evidence: Option<String>,
+        provenance: Option<&str>,
+    ) -> PyResult<Commit> {
+        let author = self.resolve_author(author)?;
+        let request_id = parse_id(request)?;
+        if !self.state.accepted_records.contains(&request_id)
+            || !self
+                .inner
+                .records()
+                .iter()
+                .any(|r| r.id == request_id && r.kind == Kind::Request)
+        {
+            return Err(PyValueError::new_err(format!(
+                "request {request:?} is not an accepted Request in this log"
+            )));
+        }
+        if key.is_empty() || description.is_empty() {
+            return Err(PyValueError::new_err(
+                "key and description must be non-empty",
+            ));
+        }
+        let role_default = match author.type_ {
+            AuthorType::User => Provenance::UserAuthored,
+            AuthorType::Provider | AuthorType::System => Provenance::Derived,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "author {:?} has role {other:?}, which cannot author a Requirement",
+                    author.id
+                )))
+            }
+        };
+        let provenance = match provenance {
+            None => role_default,
+            Some("user_authored") | Some("user-authored") => Provenance::UserAuthored,
+            Some("derived") => Provenance::Derived,
+            Some(other) => {
+                return Err(PyValueError::new_err(format!(
+                    "invalid provenance {other:?} (expected user_authored or derived)"
+                )))
+            }
+        };
+        if provenance != role_default {
+            return Err(PyValueError::new_err(format!(
+                "provenance {:?} cannot be authored by {:?} (role {:?}): provenance is bound to the author's role",
+                match provenance {
+                    Provenance::UserAuthored => "user_authored",
+                    Provenance::Derived => "derived",
+                },
+                author.id,
+                author.type_
+            )));
+        }
+        let data = checked_encode(&RequirementData {
+            key: key.to_string(),
+            description: description.to_string(),
+            required,
+            expected_evidence,
+            provenance,
+        })?;
+        self.do_commit(
+            author,
+            Kind::Requirement,
+            schema_id(SCHEMA_REQUIREMENT),
+            data,
+            vec![Ref {
+                type_: RefType::Cause,
+                target: request_id,
+            }],
+        )
+    }
+
     /// Record a Candidate (a proposed source state). Basis is chosen by exactly
     /// one of `continues` (with `parent`), `derives_from`, or `upgrades`;
     /// omitting all three records a Root. `algo` is `"sha1"` (default) or
     /// `"sha256"`. Passing `manifest` (a directory path) binds the source by a
     /// canonical manifest hash; otherwise the git tree is reported.
+    /// `artifacts` (spec 0.4) binds artifact identities: a list of
+    /// `"scheme:digest[:name]"` strings or `{"scheme", "digest", "name"?}`
+    /// dicts, checked and canonically ordered before the write.
     #[pyo3(signature = (author, git_tree, *, git_commit=None, algo="sha1", note=None,
-        continues=None, parent=None, derives_from=None, upgrades=None, manifest=None))]
+        continues=None, parent=None, derives_from=None, upgrades=None, manifest=None,
+        artifacts=None))]
     #[allow(clippy::too_many_arguments)]
     fn candidate(
         &mut self,
@@ -714,8 +911,10 @@ impl Writer {
         derives_from: Option<Vec<String>>,
         upgrades: Option<&str>,
         manifest: Option<&str>,
+        artifacts: Option<Vec<Bound<'_, PyAny>>>,
     ) -> PyResult<Commit> {
         let author = self.resolve_author(author)?;
+        let artifacts = parse_artifacts(artifacts)?;
         let algo = match algo {
             "sha1" => SourceAlgo::Sha1,
             "sha256" => SourceAlgo::Sha256,
@@ -826,6 +1025,7 @@ impl Writer {
         };
 
         let data = checked_encode(&CandidateData {
+            artifacts,
             source: SourceBinding {
                 git: GitSource {
                     algo,
@@ -848,11 +1048,26 @@ impl Writer {
         )
     }
 
-    /// Record an Evaluation of a candidate. Exactly one of `passed`, `failed`,
-    /// or a `score` (with `scale`) states the outcome. The evaluation Uses its
-    /// candidate, plus any extra `uses` ids.
+    /// Record an Evaluation of a candidate. Exactly one outcome: `passed`,
+    /// `failed`, a `score` (with `scale`), or one of the spec 0.4 fail-closed
+    /// outcomes `blocked`, `insufficient`, `stale`, `not_run` (only `passed`
+    /// passes; a decision that could not run to a pass is recorded as exactly
+    /// what it is). The evaluation Uses its candidate, each requirement it
+    /// speaks to, plus any extra `uses` ids.
+    ///
+    /// With `evaluator` and `basis` (`"recomputed"` or `"declared"`; basis is
+    /// declared, never inferred) the extended shape is written
+    /// (`bellbook.evaluation.v2`): who decided (`evaluator`,
+    /// `evaluator_version`, `procedure_hash`, `input_hash`), the artifacts
+    /// judged (`artifacts`, as on `candidate`), and the accepted Requirement
+    /// ids it speaks to (`requirements`). Any of those, or a fail-closed
+    /// outcome, without both `evaluator` and `basis` raises `ValueError`.
+    /// Without them the v1 shape is written as before.
     #[pyo3(signature = (author, candidate, criterion, *, passed=false, failed=false,
-        score=None, scale=None, procedure=None, uses=None))]
+        score=None, scale=None, procedure=None, uses=None, blocked=false,
+        insufficient=false, stale=false, not_run=false, evaluator=None,
+        evaluator_version=None, procedure_hash=None, input_hash=None, basis=None,
+        requirements=None, artifacts=None))]
     #[allow(clippy::too_many_arguments)]
     fn evaluate(
         &mut self,
@@ -865,31 +1080,118 @@ impl Writer {
         scale: Option<u8>,
         procedure: Option<String>,
         uses: Option<Vec<String>>,
+        blocked: bool,
+        insufficient: bool,
+        stale: bool,
+        not_run: bool,
+        evaluator: Option<String>,
+        evaluator_version: Option<String>,
+        procedure_hash: Option<&str>,
+        input_hash: Option<&str>,
+        basis: Option<&str>,
+        requirements: Option<Vec<String>>,
+        artifacts: Option<Vec<Bound<'_, PyAny>>>,
     ) -> PyResult<Commit> {
         let author = self.resolve_author(author)?;
         let candidate = parse_id(candidate)?;
 
-        let outcome = match (passed, failed, score) {
-            (true, false, None) => EvaluationOutcome::Passed,
-            (false, true, None) => EvaluationOutcome::Failed,
-            (false, false, Some(value)) => {
+        // Exactly one outcome.
+        let unit: Vec<&str> = [
+            ("passed", passed),
+            ("failed", failed),
+            ("blocked", blocked),
+            ("insufficient", insufficient),
+            ("stale", stale),
+            ("not_run", not_run),
+        ]
+        .into_iter()
+        .filter(|(_, on)| *on)
+        .map(|(name, _)| name)
+        .collect();
+        let scored = match score {
+            Some(value) => {
                 let scale = scale.ok_or_else(|| {
                     PyValueError::new_err("score requires scale (the denominator)")
                 })?;
-                EvaluationOutcome::Scored(ScoredValue { value, scale })
+                Some(ScoredValue { value, scale })
             }
-            _ => {
-                return Err(PyValueError::new_err(
-                    "exactly one of passed, failed, or score is required",
-                ))
-            }
+            None => None,
+        };
+        if unit.len() + usize::from(scored.is_some()) != 1 {
+            return Err(PyValueError::new_err(
+                "exactly one of passed, failed, score, blocked, insufficient, stale, or not_run is required",
+            ));
+        }
+        let outcome_v2 = match (unit.first().copied(), scored) {
+            (_, Some(s)) => EvaluationOutcomeV2::Scored(s),
+            (Some("passed"), None) => EvaluationOutcomeV2::Passed,
+            (Some("failed"), None) => EvaluationOutcomeV2::Failed,
+            (Some("blocked"), None) => EvaluationOutcomeV2::Blocked,
+            (Some("insufficient"), None) => EvaluationOutcomeV2::Insufficient,
+            (Some("stale"), None) => EvaluationOutcomeV2::Stale,
+            (Some("not_run"), None) => EvaluationOutcomeV2::NotRun,
+            _ => unreachable!("one outcome was checked above"),
         };
 
-        // The evaluation must Use its candidate, plus any extra uses refs.
+        // The extended shape is chosen by its binding: evaluator and basis
+        // together. Any other 0.4-only argument or outcome needs them.
+        let extended_args: Vec<&str> = [
+            ("evaluator", evaluator.is_some()),
+            ("evaluator_version", evaluator_version.is_some()),
+            ("procedure_hash", procedure_hash.is_some()),
+            ("input_hash", input_hash.is_some()),
+            ("basis", basis.is_some()),
+            ("requirements", requirements.is_some()),
+            ("artifacts", artifacts.is_some()),
+            ("blocked", blocked),
+            ("insufficient", insufficient),
+            ("stale", stale),
+            ("not_run", not_run),
+        ]
+        .into_iter()
+        .filter(|(_, on)| *on)
+        .map(|(name, _)| name)
+        .collect();
+        let extended = !extended_args.is_empty();
+        if extended && !(evaluator.is_some() && basis.is_some()) {
+            return Err(PyValueError::new_err(format!(
+                "the extended evaluation ({}) requires both evaluator and basis ('recomputed' or 'declared')",
+                extended_args.join(", ")
+            )));
+        }
+
+        // The evaluation must Use its candidate, then each requirement it
+        // speaks to (mirrored in the payload), then any extra uses refs.
         let mut refs = vec![Ref {
             type_: RefType::Use,
             target: candidate,
         }];
+        let mut requirement_ids: Vec<RecordId> = requirements
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|s| parse_id(s))
+            .collect::<PyResult<_>>()?;
+        requirement_ids.sort();
+        requirement_ids.dedup();
+        for rid in &requirement_ids {
+            if !self
+                .inner
+                .records()
+                .iter()
+                .any(|r| r.id == *rid && r.kind == Kind::Requirement)
+                || !self.state.accepted_records.contains(rid)
+            {
+                return Err(PyValueError::new_err(format!(
+                    "requirement {} is not an accepted Requirement in this log",
+                    hex_encode(rid)
+                )));
+            }
+            refs.push(Ref {
+                type_: RefType::Use,
+                target: *rid,
+            });
+        }
         if let Some(extra) = &uses {
             for s in extra {
                 refs.push(Ref {
@@ -899,19 +1201,56 @@ impl Writer {
             }
         }
 
-        let data = checked_encode(&EvaluationData {
-            candidate,
-            criterion: criterion.to_string(),
-            procedure,
-            outcome,
-        })?;
-        self.do_commit(
-            author,
-            Kind::Evaluation,
-            schema_id(SCHEMA_EVALUATION),
-            data,
-            refs,
-        )
+        let (schema, data) = if extended {
+            let evaluator_id = evaluator.unwrap_or_default();
+            if evaluator_id.is_empty() {
+                return Err(PyValueError::new_err("evaluator must be non-empty"));
+            }
+            let basis = match basis.unwrap_or_default() {
+                "recomputed" => Basis::Recomputed,
+                "declared" => Basis::Declared,
+                other => {
+                    return Err(PyValueError::new_err(format!(
+                        "invalid basis {other:?} (expected 'recomputed' or 'declared')"
+                    )))
+                }
+            };
+            let data = checked_encode(&EvaluationDataV2 {
+                candidate,
+                criterion: criterion.to_string(),
+                procedure,
+                outcome: outcome_v2,
+                evaluator: DeciderBinding {
+                    id: evaluator_id,
+                    version: evaluator_version,
+                    procedure_hash: procedure_hash
+                        .map(|h| parse_hash("procedure_hash", h))
+                        .transpose()?,
+                    input_hash: input_hash
+                        .map(|h| parse_hash("input_hash", h))
+                        .transpose()?,
+                },
+                basis,
+                evidence: parse_artifacts(artifacts)?.unwrap_or_default(),
+                requirements: requirement_ids,
+            })?;
+            (SCHEMA_EVALUATION_V2, data)
+        } else {
+            let outcome = match outcome_v2 {
+                EvaluationOutcomeV2::Passed => EvaluationOutcome::Passed,
+                EvaluationOutcomeV2::Failed => EvaluationOutcome::Failed,
+                EvaluationOutcomeV2::Scored(s) => EvaluationOutcome::Scored(s),
+                _ => unreachable!("fail-closed outcomes select the extended shape"),
+            };
+            let data = checked_encode(&EvaluationData {
+                candidate,
+                criterion: criterion.to_string(),
+                procedure,
+                outcome,
+            })?;
+            (SCHEMA_EVALUATION, data)
+        };
+        self.do_commit(author, Kind::Evaluation, schema_id(schema), data, refs)
     }
 
     /// Record a Selection over candidates, or a reaffirmation. Exactly one of
@@ -1063,8 +1402,26 @@ impl Writer {
 
     /// Export the log as a portable receipt (canonical JSON bytes). Feed it to
     /// `validate` or `read`, or hand it to any independent verifier.
-    fn receipt<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+    /// `profiles` (spec 0.4) declares the named profiles the receipt claims
+    /// (e.g. `["bellbook-core-v1"]`), with the version and hash this
+    /// package knows; the declaration is not evaluated here - every validator
+    /// re-checks it - so a false claim exports and then reports
+    /// `NonConformant`. An unknown or repeated id raises `ValueError`.
+    #[pyo3(signature = (profiles=None))]
+    fn receipt<'py>(
+        &self,
+        py: Python<'py>,
+        profiles: Option<Vec<String>>,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let declared: Vec<&str> = profiles
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(String::as_str)
+            .collect();
         let bytes = CoreReceipt::new(self.inner.records(), &self.rules)
+            .with_declared_profiles(&declared)
+            .map_err(PyValueError::new_err)?
             .to_bytes()
             .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize receipt: {e}")))?;
         Ok(PyBytes::new(py, &bytes))

--- a/bindings/python/tests/test_story_gate.py
+++ b/bindings/python/tests/test_story_gate.py
@@ -8,7 +8,10 @@ reaffirm on fresh evidence, and watch standing restore while the receipt
 stays Tainted permanently.
 """
 
+import json
 import os
+
+import pytest
 
 import bellbook
 
@@ -82,3 +85,174 @@ def test_broken_benchmark_story_runs_from_python_alone(tmp_path):
     # But standing is restored: nothing compromised, the restoration recorded.
     assert report.standing["compromised"] == []
     assert report.standing["restorations"] == {s0.id: [s1.id]}
+
+def test_requirement_binding_story_from_python_alone(tmp_path):
+    """The v0.8.0 gate, Python half (spec 0.4): request, requirements, a
+    candidate bound to artifacts, extended evaluations bound to the
+    requirements, a selection, a receipt that declares the baseline profile,
+    validated Clean and Conformant with the declaration checked unasked; the
+    query surface shows the bindings; then the taint a retracted requirement
+    spreads. Behavioral equivalence with the CLI story in tests/cli.rs."""
+    tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    digest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    rules = bellbook.default_rules(
+        {"human": "user", "agent": "provider", "evaluator": "provider"}
+    )
+    w = bellbook.Writer(os.path.join(str(tmp_path), "log"), rules)
+
+    req = w.request(author="human", objective="ship the bound build")
+    r1 = w.requirement(
+        author="human", request=req.id, key="R1", description="unit tests pass"
+    )
+    # A provider-authored requirement defaults to derived provenance.
+    r2 = w.requirement(
+        author="agent",
+        request=req.id,
+        key="R2",
+        description="lint is clean",
+        required=False,
+        expected_evidence="lint log",
+    )
+    c0 = w.candidate(
+        author="agent",
+        git_tree=tree,
+        artifacts=[f"sha256-bytes:{digest}:dist.tar", {"scheme": "git-tree-sha1", "digest": tree, "name": "src"}],
+    )
+    e0 = w.evaluate(
+        author="evaluator",
+        candidate=c0.id,
+        criterion="unit-tests",
+        passed=True,
+        evaluator="test-harness",
+        evaluator_version="1.4.0",
+        basis="recomputed",
+        procedure_hash=digest,
+        requirements=[r1.id],
+        artifacts=[f"git-tree-sha1:{tree}"],
+    )
+    # A fail-closed outcome is recorded as exactly what it is.
+    e1 = w.evaluate(
+        author="evaluator",
+        candidate=c0.id,
+        criterion="lint",
+        not_run=True,
+        evaluator="linter",
+        basis="declared",
+        requirements=[r2.id],
+    )
+    s0 = w.select(
+        author="agent",
+        objective="ship",
+        consider=[c0.id],
+        choose=[c0.id],
+        uses_eval=[e0.id, e1.id],
+    )
+    for commit in (req, r1, r2, c0, e0, e1, s0):
+        assert commit.accepted, commit.reason
+
+    receipt = w.receipt(profiles=["bellbook-core-v1"])
+    report = bellbook.validate(receipt)
+    assert report.status == "clean", report.problem or report.reason
+    assert report.record_count == 14
+    (p,) = report.profiles
+    assert p["id"] == "bellbook-core-v1"
+    assert p["status"] == "Conformant"
+    assert p["declared"] is True
+    assert p["declaration_matches"] is True
+    assert p["met"] is True
+    # Requiring the declared profile evaluates it once, as declared.
+    again = bellbook.validate(receipt, require_profile="bellbook-core-v1")
+    assert [q["id"] for q in again.profiles] == ["bellbook-core-v1"]
+
+    # The payloads round-trip the new fields.
+    parsed = bellbook.read(receipt)
+    by_id = {r.id: r for r in parsed.records}
+    assert json.loads(by_id[r1.id].payload_json)["provenance"] == "user_authored"
+    assert json.loads(by_id[r2.id].payload_json)["provenance"] == "derived"
+    assert json.loads(by_id[r2.id].payload_json)["required"] is False
+    e0_payload = json.loads(by_id[e0.id].payload_json)
+    assert e0_payload["evaluator"]["id"] == "test-harness"
+    assert e0_payload["basis"] == "recomputed"
+    assert e0_payload["evidence"][0]["scheme"] == "git-tree-sha1"
+    assert json.loads(by_id[e1.id].payload_json)["outcome"] == "not_run"
+    c0_payload = json.loads(by_id[c0.id].payload_json)
+    assert [a["scheme"] for a in c0_payload["artifacts"]] == ["git-tree-sha1", "sha256-bytes"]
+
+    # The query surface reports the bindings, over the log and the receipt.
+    for surface in (w, parsed):
+        sel = surface.selected("ship")["selections"][0]
+        assert sel["selection"]["id"] == s0.id
+        chosen = sel["chosen"][0]
+        assert chosen["id"] == c0.id
+        assert [a["scheme"] for a in chosen["artifacts"]] == ["git-tree-sha1", "sha256-bytes"]
+        assert "requirements" not in chosen
+        ev = sel["evidence"]
+        assert [e["outcome"] for e in ev] == ["passed", "not_run"]
+        assert ev[0]["node"]["requirements"] == [r1.id]
+        assert ev[0]["node"]["artifacts"][0]["digest"] == tree
+        assert ev[1]["node"]["requirements"] == [r2.id]
+        assert "artifacts" not in ev[1]["node"]
+
+    # Retracting the requirement taints the evaluation that judged against
+    # it and the selection that rested on that evaluation.
+    r = w.retract(author="human", target=r1.id, reason="the requirement was misstated")
+    assert r.accepted, r.reason
+    report = bellbook.validate(w.receipt())
+    assert report.status == "tainted"
+    assert report.retracted == [r1.id]
+    assert e0.id in report.tainted and s0.id in report.tainted
+    assert e1.id not in report.tainted
+
+
+def test_requirement_and_extended_evaluate_refuse_what_the_verifier_would(tmp_path):
+    rules = bellbook.default_rules(
+        {"human": "user", "agent": "provider", "evaluator": "provider"}
+    )
+    w = bellbook.Writer(os.path.join(str(tmp_path), "log"), rules)
+    req = w.request(author="human", objective="ship")
+    c0 = w.candidate(author="agent", git_tree="a" * 40)
+    before = len(w)
+
+    # Provenance is bound to the role: refused before the write.
+    with pytest.raises(ValueError, match="bound to the author's role"):
+        w.requirement(
+            author="agent", request=req.id, key="R1", description="d", provenance="user_authored"
+        )
+    # The request must be an accepted Request.
+    with pytest.raises(ValueError, match="not an accepted Request"):
+        w.requirement(author="human", request=c0.id, key="R1", description="d")
+    # Malformed artifacts never reach the log.
+    with pytest.raises(ValueError, match="invalid artifact"):
+        w.candidate(author="agent", git_tree="b" * 40, artifacts=["git-tree-sha1:abc"])
+    with pytest.raises(ValueError, match="strings or dicts"):
+        w.candidate(author="agent", git_tree="b" * 40, artifacts=[7])
+    # Extended fields need the decider binding; basis is never inferred.
+    with pytest.raises(ValueError, match="requires both evaluator and basis"):
+        w.evaluate(author="evaluator", candidate=c0.id, criterion="c", blocked=True)
+    with pytest.raises(ValueError, match="requires both evaluator and basis"):
+        w.evaluate(author="evaluator", candidate=c0.id, criterion="c", passed=True, evaluator="h")
+    with pytest.raises(ValueError, match="invalid basis"):
+        w.evaluate(
+            author="evaluator", candidate=c0.id, criterion="c", passed=True, evaluator="h", basis="guessed"
+        )
+    with pytest.raises(ValueError, match="exactly one of"):
+        w.evaluate(author="evaluator", candidate=c0.id, criterion="c", passed=True, stale=True)
+    with pytest.raises(ValueError, match="not an accepted Requirement"):
+        w.evaluate(
+            author="evaluator",
+            candidate=c0.id,
+            criterion="c",
+            passed=True,
+            evaluator="h",
+            basis="declared",
+            requirements=[c0.id],
+        )
+    with pytest.raises(ValueError, match="unknown profile"):
+        w.receipt(profiles=["made-up-v1"])
+    assert len(w) == before  # nothing written by any refusal
+
+    # A duplicate key is a verifier rule: a durable rejected record.
+    ok = w.requirement(author="human", request=req.id, key="R1", description="d")
+    assert ok.accepted, ok.reason
+    dup = w.requirement(author="agent", request=req.id, key="R1", description="again")
+    assert not dup.accepted and dup.reason == "RequirementInvalid"


### PR DESCRIPTION
Closes #110. Refs #116. `bellbook` 0.8.0 is on crates.io (Release run 17), so the bindings pin moves to the 0.8 line and the Python half of the 0.4 surfaces lands, as in previous cycles.

## Writer

- `request(author, objective)`: a Request from a user-role author; requirements bind to it.
- `requirement(author, request, key, description, *, required=True, expected_evidence=None, provenance=None)`: provenance defaults from the author's role (`user_authored` for a user, `derived` for a provider or system) and a value the role cannot carry raises `ValueError` before the write; a duplicate key commits as a durable rejected record with `RequirementInvalid`.
- `candidate(..., artifacts=[...])`: `"scheme:digest[:name]"` strings or `{"scheme", "digest", "name"?}` dicts, checked against the artifact rule and canonically ordered before the write.
- `evaluate(...)` gains the fail-closed outcomes `blocked`, `insufficient`, `stale`, `not_run` and the extended binding `evaluator`, `evaluator_version`, `procedure_hash`, `input_hash`, `basis`, `requirements`, `artifacts`. With `evaluator` and `basis` (`"recomputed"` or `"declared"`) it writes `bellbook.evaluation.v2`; any extended argument without both raises, since basis is declared and never inferred; otherwise the v1 shape as before.
- `receipt(profiles=[...])` declares the profiles the receipt claims; unknown or repeated ids raise.

## Report

`Report.profiles` entries carry `declared`, `declaration_matches`, and `met` beside `id`, `hash`, `status`, and `clauses`. Declared profiles come first, evaluated unasked.

## Tests

- The Python half of the v0.8.0 gate story: request, requirements (user-authored and derived), a bound candidate, bound evaluations (`passed` and `not_run`), a selection, a declaring receipt validated Clean and Conformant with the declaration checked unasked, payload round-trips of every new field, the query annotations over the log and the receipt, then the taint a retracted requirement spreads. Behavioral twin of the CLI story in `tests/cli.rs`.
- A refusal battery (role-bound provenance, non-Request target, malformed artifacts, missing decider binding, invalid basis, multiple outcomes, non-Requirement `requirements`, unknown declared profile) and the durable duplicate-key rejection.
- The profile vectors now run against the pinned core instead of skipping.

## Verification

Wheel built against the registry 0.8.0 (`--locked`), `cargo clippy` clean, `cargo fmt --check` clean, 49 tests passed. A fresh `cargo install bellbook --version 0.8.0` recorded a request, requirement, bound candidate, and extended evaluation, exported a declaring receipt, and validated Clean with exit 0.