### PR TITLE
release prep for 0.9.0

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.8.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.9.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-09-05
+
+The delivery receipt. No core or wire change: every record, canonical
+form, signing form, schema, and verdict rule is byte-for-byte that of
+0.8.0, and core conformance (`spec/conformance`, the 0.3 and 0.4 vector
+files) is unchanged. What is new is the second published profile,
+`delivery-receipt-v1`: the grammar of a delivery claim over the spec 0.4
+records, with its own vector set and a fraud battery that both
+implementations reject on replay, and the quickstart that takes a
+delivery loop to a receipt a skeptic can check. The Python package gains
+the profile's surface right after the core publish (the bindings track
+the published crate).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -319,11 +319,12 @@ receipt that can declare the profiles it claims. See
 
 ## Status
 
-**The published release is 0.8.0, implementing spec v0.4 (RFC-0003:
+**The published release is 0.9.0, implementing spec v0.4 (RFC-0003:
 requirement binding - the `Requirement` record, first-class artifact
 identity, the extended `Evaluation`, and receipt profile declarations -
 on top of the v0.3 evolution semantics: Candidate, Evaluation, and
-Selection records with replay-derived lineage standing).** SPEC.md is the
+Selection records with replay-derived lineage standing) and publishing
+both profiles, `bellbook-core-v1` and `delivery-receipt-v1`.** SPEC.md is the
 authority for what each version means (v0.3 design notes in
 [`spec/v0.3-delta.md`](spec/v0.3-delta.md); v0.4 design in
 [RFC-0003](docs/rfcs/0003-requirement-binding.md)). Earlier epochs stay
@@ -346,8 +347,9 @@ battery, and the
 replay-derived standing section, derived state with incremental/full-build
 equivalence, checkpoints, the crash-safe writer with idempotent
 compare-and-append, and portable receipts with the offline `bellbook
-validate` CLI (including the `bellbook-core-v1` baseline profile check,
-with declared profiles evaluated unasked), the
+validate` CLI (including the `bellbook-core-v1` baseline and
+`delivery-receipt-v1` profile checks, with declared profiles evaluated
+unasked), the
 `request`/`requirement`/`candidate`/`eval`/`select`/`retract`/`lineage`
 recording commands, the read-side `query` command (the RFC-0002 named set: descent,
 descendants, siblings, frontier, standing, evidence, selected - over a log

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.8.0"
+version = "0.9.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Refs #117.

No core or wire change: 0.9.0 ships the `delivery-receipt-v1` profile (#131), its vectors and fraud battery, and the delivery-receipt quickstart (#132). Core conformance (`spec/conformance`, the 0.3 and 0.4 vector files, the `bellbook-core-v1` table) is byte-identical to the v0.8.0 tag (`git diff --stat v0.8.0 main -- spec/conformance spec/test-vectors-v0.4.json spec/test-vectors-v0.3.json spec/profiles/bellbook-core-v1` is empty).

## Version checklist

- Crate, bindings crate, pyproject, and the wheel smoke guard to 0.9.0; both lockfiles updated with cargo.
- The bindings keep `bellbook_core` pinned to the published 0.8 line until the 0.9.0 crate is on crates.io, as in every previous release; the pin bump and the Python half of the delivery profile (bindings tests over the delivery vectors, the story gate declaring both profiles) follow the publish in their own PR.
- CHANGELOG frames `[0.9.0] - 2026-09-05`.
- README status names 0.9.0 and the two published profiles; the offline-validate sentence names both profile checks.

## Audit on the bumped tree

`cargo fmt --check`, `cargo clippy --all-targets --all-features` (0 diagnostics), `cargo doc` with warnings denied, `cargo test --all-features` (16 binaries green), `conformance/python/run_conformance.py` (both epochs, both profiles). No em dashes.

## After merge

Publish sequence: `release.yml` dispatch on main (crates.io), pin-bump PR, `publish-pypi.yml` dispatch, fresh-install verification of both registries exercising `--require-profile delivery-receipt-v1`, site bump. Tag, GitHub Release, and milestone close are the maintainer's; #117 checklist updated as each lands. The field-test 3 and cutover items on #117 stay open until the adopter runs against the published artifacts.