### PR TITLE
bindings(python): pin bellbook_core to 0.9 and expose the delivery profile

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5be13ef90e12f5e19df5e0c6927f69b20814629dd014e4e4b4517cd6f4b9e2"
+checksum = "abb74b67d905913723fe79ed5993085f0fb80bb1e748db56184232864a7d9172"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.8", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.9", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -13,7 +13,8 @@ to cross-check the specification.)
 
 ## Status
 
-Validation (with the `bellbook-core-v1` baseline profile check), reading,
+Validation (with the `bellbook-core-v1` baseline and `delivery-receipt-v1`
+profile checks), reading,
 writing, and the read-side query set (issue #13, RFC-0002, RFC-0003).
 
 ## Validate
@@ -60,8 +61,14 @@ declared version and hash name the clause table that was evaluated; `None`
 for an undeclared or unknown profile), and `p["met"]` (Conformant and, if
 declared, matching). A declaration is never trusted. A profile result is a
 report alongside the verdict: it never changes `status` or `reason`. The
-profile itself is documented in
-[docs/profiles/bellbook-core-v1.md](../../docs/profiles/bellbook-core-v1.md).
+profiles themselves are documented in
+[docs/profiles/bellbook-core-v1.md](../../docs/profiles/bellbook-core-v1.md)
+and
+[docs/profiles/delivery-receipt-v1.md](../../docs/profiles/delivery-receipt-v1.md);
+`require_profile="delivery-receipt-v1"` reports the eight delivery clauses
+D0 through D7, and the
+[delivery-receipt quickstart](../../docs/quickstart-delivery-receipt.md)
+walks the whole flow from Python.
 
 ## Read
 
@@ -176,8 +183,9 @@ written.
   it). `provenance` is `"user_authored"` or `"derived"`, defaults from the
   author's role (user -> user_authored, provider or system -> derived), and
   a value the role cannot carry raises `ValueError` before the write.
-- `receipt(profiles=None)` - `profiles=["bellbook-core-v1"]` declares the
-  profiles the receipt claims (spec 0.4). A declaration is never trusted:
+- `receipt(profiles=None)` - `profiles=["bellbook-core-v1",
+  "delivery-receipt-v1"]` declares the profiles the receipt claims (spec
+  0.4). A declaration is never trusted:
   every validator evaluates it unasked and reports `declared`,
   `declaration_matches`, and `met` beside the result.
 

--- a/bindings/python/tests/test_profiles.py
+++ b/bindings/python/tests/test_profiles.py
@@ -1,7 +1,8 @@
-"""`bellbook-core-v1` across the FFI boundary: `validate(..., require_profile=...)`
-carries the profile result, `default_rules` emits a baseline-conformant rule
-set, and every published profile vector re-derives identically through the
-wheel. A profile result is a report alongside the verdict, never a change
+"""The published profiles across the FFI boundary: `validate(...,
+require_profile=...)` carries the profile result, `default_rules` emits a
+baseline-conformant rule set, and every published profile vector (both
+`bellbook-core-v1` and `delivery-receipt-v1`) re-derives identically through
+the wheel. A profile result is a report alongside the verdict, never a change
 to it."""
 
 import json
@@ -13,8 +14,13 @@ import bellbook
 
 # repo root: bindings/python/tests/ -> bindings/python -> bindings -> root
 ROOT = pathlib.Path(__file__).resolve().parents[3]
-CASES = ROOT / "spec" / "profiles" / "bellbook-core-v1" / "cases.json"
+PROFILES = ROOT / "spec" / "profiles"
 CORE_V1 = "bellbook-core-v1"
+DELIVERY_V1 = "delivery-receipt-v1"
+FAILABLE = {
+    CORE_V1: {"B1", "B2", "B3", "B4"},
+    DELIVERY_V1: {f"D{i}" for i in range(8)},
+}
 BASELINE = {"Candidate": "Reported", "Evaluation": "Reported", "Selection": "Inferred"}
 
 
@@ -89,11 +95,15 @@ def test_require_profile_type_is_checked():
         bellbook.validate(b"x", require_profile=7)
 
 
-def test_published_profile_vectors_match_reference():
-    """Every vector in spec/profiles/bellbook-core-v1/cases.json yields the
-    stored status, per-clause flags, and profile hash through the wheel."""
-    doc = json.loads(CASES.read_text())
-    assert doc["profile"] == CORE_V1
+@pytest.mark.parametrize("profile_id", [CORE_V1, DELIVERY_V1])
+def test_published_profile_vectors_match_reference(profile_id):
+    """Every vector in spec/profiles/<profile>/cases.json yields the stored
+    status, declaration flags, per-clause flags, and profile hash through the
+    wheel. The delivery vectors carry the fraud battery: one rejecting case
+    per clause, including a claim over a failed evaluation with every digest
+    consistent and a passing evaluation reattached to another candidate."""
+    doc = json.loads((PROFILES / profile_id / "cases.json").read_text())
+    assert doc["profile"] == profile_id
     expected_hash = bytes(doc["hash"]).hex()
     assert len(doc["cases"]) >= 7
     # The bindings track the *published* core. Between a spec-epoch bump on
@@ -107,14 +117,22 @@ def test_published_profile_vectors_match_reference():
     probe = bellbook.validate(json.dumps(doc["cases"][0]["receipt"]).encode())
     if probe.problem:
         pytest.skip(f"vectors are from a newer spec epoch than the pinned core: {probe.problem}")
+    failing = set()
     for case in doc["cases"]:
         data = json.dumps(case["receipt"]).encode()
-        report = bellbook.validate(data, require_profile=CORE_V1)
+        report = bellbook.validate(data, require_profile=profile_id)
         expected = case["expect"]["profiles"]
         assert [p["id"] for p in report.profiles] == [e["id"] for e in expected], case["name"]
         for p, e in zip(report.profiles, expected):
             assert p["status"] == e["status"], case["name"]
-            if p["status"] != "Unknown":
+            assert p["declared"] == e["declared"], case["name"]
+            assert p["declaration_matches"] == e.get("declaration_matches"), case["name"]
+            if p["id"] == profile_id and p["status"] != "Unknown":
                 assert p["hash"] == expected_hash, case["name"]
             flags = [{"id": c["id"], "passed": c["passed"]} for c in p["clauses"]]
             assert flags == e["clauses"], case["name"]
+            if p["id"] == profile_id:
+                failing.update(c["id"] for c in p["clauses"] if not c["passed"])
+    # Every clause that can fail does fail somewhere in its own vector set
+    # (B5 and B6 report the rule shape and the binding modes; they never fail).
+    assert failing == FAILABLE[profile_id], (profile_id, sorted(failing))

--- a/bindings/python/tests/test_story_gate.py
+++ b/bindings/python/tests/test_story_gate.py
@@ -87,12 +87,14 @@ def test_broken_benchmark_story_runs_from_python_alone(tmp_path):
     assert report.standing["restorations"] == {s0.id: [s1.id]}
 
 def test_requirement_binding_story_from_python_alone(tmp_path):
-    """The v0.8.0 gate, Python half (spec 0.4): request, requirements, a
-    candidate bound to artifacts, extended evaluations bound to the
-    requirements, a selection, a receipt that declares the baseline profile,
-    validated Clean and Conformant with the declaration checked unasked; the
-    query surface shows the bindings; then the taint a retracted requirement
-    spreads. Behavioral equivalence with the CLI story in tests/cli.rs."""
+    """The v0.8.0 and v0.9.0 gates, Python half (spec 0.4): request,
+    requirements, a candidate bound to artifacts, extended evaluations bound
+    to the requirements with the full decider binding, a selection that is a
+    delivery claim, a receipt that declares both published profiles,
+    validated Clean with both Conformant and both declarations checked
+    unasked; the query surface shows the bindings; then the taint a retracted
+    requirement spreads. Behavioral equivalence with the CLI story in
+    tests/cli.rs."""
     tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
     digest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
     rules = bellbook.default_rules(
@@ -127,10 +129,13 @@ def test_requirement_binding_story_from_python_alone(tmp_path):
         evaluator_version="1.4.0",
         basis="recomputed",
         procedure_hash=digest,
+        input_hash=digest,
         requirements=[r1.id],
         artifacts=[f"git-tree-sha1:{tree}"],
     )
-    # A fail-closed outcome is recorded as exactly what it is.
+    # A fail-closed outcome is recorded as exactly what it is. It judges an
+    # informational requirement, so the claim survives it; like every
+    # evaluation a claim uses, it carries the decider binding and evidence.
     e1 = w.evaluate(
         author="evaluator",
         candidate=c0.id,
@@ -138,7 +143,10 @@ def test_requirement_binding_story_from_python_alone(tmp_path):
         not_run=True,
         evaluator="linter",
         basis="declared",
+        procedure_hash=digest,
+        input_hash=digest,
         requirements=[r2.id],
+        artifacts=[f"git-tree-sha1:{tree}"],
     )
     s0 = w.select(
         author="agent",
@@ -150,19 +158,25 @@ def test_requirement_binding_story_from_python_alone(tmp_path):
     for commit in (req, r1, r2, c0, e0, e1, s0):
         assert commit.accepted, commit.reason
 
-    receipt = w.receipt(profiles=["bellbook-core-v1"])
+    both = ["bellbook-core-v1", "delivery-receipt-v1"]
+    receipt = w.receipt(profiles=both)
     report = bellbook.validate(receipt)
     assert report.status == "clean", report.problem or report.reason
     assert report.record_count == 14
-    (p,) = report.profiles
-    assert p["id"] == "bellbook-core-v1"
-    assert p["status"] == "Conformant"
-    assert p["declared"] is True
-    assert p["declaration_matches"] is True
-    assert p["met"] is True
-    # Requiring the declared profile evaluates it once, as declared.
-    again = bellbook.validate(receipt, require_profile="bellbook-core-v1")
-    assert [q["id"] for q in again.profiles] == ["bellbook-core-v1"]
+    assert [p["id"] for p in report.profiles] == both
+    for p in report.profiles:
+        assert p["status"] == "Conformant", (p["id"], p["clauses"])
+        assert p["declared"] is True
+        assert p["declaration_matches"] is True
+        assert p["met"] is True
+    delivery = report.profiles[1]
+    assert [c["id"] for c in delivery["clauses"]] == [f"D{i}" for i in range(8)]
+    assert all(c["passed"] for c in delivery["clauses"])
+    assert s0.id[:12] in delivery["clauses"][0]["detail"]
+    assert "profile delivery-receipt-v1: CONFORMANT" in str(report)
+    # Requiring the declared profiles evaluates each once, as declared.
+    again = bellbook.validate(receipt, require_profile=both)
+    assert [q["id"] for q in again.profiles] == both
 
     # The payloads round-trip the new fields.
     parsed = bellbook.read(receipt)
@@ -191,7 +205,7 @@ def test_requirement_binding_story_from_python_alone(tmp_path):
         assert ev[0]["node"]["requirements"] == [r1.id]
         assert ev[0]["node"]["artifacts"][0]["digest"] == tree
         assert ev[1]["node"]["requirements"] == [r2.id]
-        assert "artifacts" not in ev[1]["node"]
+        assert ev[1]["node"]["artifacts"][0]["digest"] == tree
 
     # Retracting the requirement taints the evaluation that judged against
     # it and the selection that rested on that evaluation.


### PR DESCRIPTION
Refs #117.

The bindings track the published crate; 0.9.0 is on crates.io (Release run 20), so the pin moves to the 0.9 line and the Python half of the delivery receipt lands.

## What

- `bellbook_core` pinned to `0.9`; the bindings lockfile resolves the registry 0.9.0 crate.
- No binding code changes. The 0.8.0 surface already carried `receipt(profiles=[...])`, `require_profile=[...]`, and the extended `evaluate` keywords; with the 0.9 core underneath, `delivery-receipt-v1` is accepted as a declaration and evaluated on request, and `Report.profiles` carries its eight clauses.
- **Tests.** The profile vector test is parametrized over both published profiles, asserts the declaration flags beside status and clauses, and checks that every failable clause fails somewhere in its own vector set (the fraud battery, for the delivery profile). The story gate's evaluations carry the full decider binding and evidence, the receipt declares both profiles, and both are asserted Conformant and met with D0 through D7 all passing.
- README names the delivery profile and links its document and the quickstart.

## Verification

50 passed locally against the registry 0.9.0 crate (patch config removed before the lockfile was regenerated). Fresh `cargo install bellbook@0.9.0` validates the quickstart receipt with both profiles Conformant (exit 0) and rejects the forged receipt on the delivery profile (exit 3).

## After merge

`publish-pypi.yml` dispatch on main, then fresh-install verification of the 0.9.0 wheel exercising `require_profile="delivery-receipt-v1"`.