### PR TITLE
skeptic surfaces: one-receipt entry point, `met` in the CLI JSON, D2 wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Three small acts from the first-party half of field test 3
+(`docs/field-tests/ft3-delivery-receipt-canary.md`). No wire change.
+
+### Added
+
+- `conformance/python/validate_receipt.py`: the independent validator's
+  one-receipt entry point for a skeptic - structural decode, replay, every
+  declared profile and any `--require-profile` id, with `bellbook
+  validate`'s exit codes; standard library only, and it refuses to run with
+  the `bellbook` package imported.
+- `bellbook validate --json` reports `met` on every profile entry, the
+  field the exit code is derived from, for parity with the Python
+  surface's `Report.profiles`.
+
+### Changed
+
+- The `delivery-receipt-v1` D2 detail line names the claim's used
+  evaluations ("every used evaluation of a required requirement passed"),
+  matching the clause's stated scope. Detail text only; no clause, vector,
+  or hash changes.
+- The profile document says what D5 does not prescribe: how
+  `procedure_hash` and `input_hash` are computed is the evaluator's
+  published convention, and names the simplest checkable one.
+
 ## [0.9.0] - 2026-09-05
 
 The delivery receipt. No core or wire change: every record, canonical

--- a/conformance/python/README.md
+++ b/conformance/python/README.md
@@ -94,6 +94,20 @@ python3 conformance/python/run_conformance.py
 Exit code 0 means every independent check agreed with the reference; non-zero
 prints the first disagreement. CI runs this on every push and pull request.
 
+To validate one receipt of your own with this implementation, as a skeptic
+who does not want to trust the reference:
+
+```
+python3 conformance/python/validate_receipt.py receipt.json
+python3 conformance/python/validate_receipt.py receipt.json --require-profile delivery-receipt-v1 --json
+```
+
+It prints what `bellbook validate` prints (status, reason, every declared
+profile and any required one, clause by clause) and exits the same way: 0
+Clean and every profile met, 1 Invalid, 2 Tainted, 3 a profile not met. It
+imports nothing from the `bellbook` package and refuses to run if that
+package is loaded.
+
 ## Files
 
 - `bellbook_conformance.py` - the wire validator: JCS canonicalization, ids,
@@ -102,3 +116,5 @@ prints the first disagreement. CI runs this on every push and pull request.
   retraction + taint state machine, and whole-log replay.
 - `run_conformance.py` - the runner: drives both against the vectors and the
   corpus and asserts agreement.
+- `validate_receipt.py` - the one-receipt entry point: validates a receipt
+  you hold, profiles included, with the reference's exit codes.

--- a/conformance/python/bellbook_profiles.py
+++ b/conformance/python/bellbook_profiles.py
@@ -298,7 +298,7 @@ def evaluate_delivery_v1(
         if non_passing:
             note("D2", False, f"{tag}: non-passing {', '.join(non_passing)}")
         else:
-            note("D2", True, f"{tag}: every required-bound evaluation passed")
+            note("D2", True, f"{tag}: every used evaluation of a required requirement passed")
 
         # D3: one candidate, judged by every evaluation, evidence on record.
         notes = []

--- a/conformance/python/validate_receipt.py
+++ b/conformance/python/validate_receipt.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate one receipt with the independent implementation.
+
+    python3 conformance/python/validate_receipt.py RECEIPT [--require-profile ID ...] [--json]
+
+The skeptic's entry point: structural decode, whole-log replay, every
+profile the receipt declares (never trusted), then each required profile it
+did not declare. Prints the same facts `bellbook validate` prints and exits
+the same way: 0 Clean and every profile met, 1 Invalid, 2 Tainted, 3 valid
+but a declared or required profile not met. Standard library only; the
+`bellbook` package is never imported, so agreement with the reference is a
+fact of the run, not a shared code path.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import bellbook_conformance as bc  # noqa: E402
+import bellbook_profiles as bp  # noqa: E402
+import bellbook_verdict as bv  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PROFILES = ROOT / "spec" / "profiles"
+
+
+def _hex(b) -> str:
+    return bytes(b).hex() if not isinstance(b, str) else b
+
+
+def _usage(code: int) -> int:
+    print(__doc__.strip(), file=sys.stderr)
+    return code
+
+
+def main(argv: list[str]) -> int:
+    path = None
+    required: list[str] = []
+    as_json = False
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--json":
+            as_json = True
+        elif a == "--require-profile":
+            i += 1
+            while i < len(argv) and not argv[i].startswith("--"):
+                required.append(argv[i])
+                i += 1
+            continue
+        elif a.startswith("--"):
+            return _usage(64)
+        elif path is None:
+            path = a
+        else:
+            return _usage(64)
+        i += 1
+    if path is None:
+        return _usage(64)
+    if "bellbook" in sys.modules:
+        print("refusing to run: the bellbook package is imported", file=sys.stderr)
+        return 70
+
+    try:
+        text = pathlib.Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"cannot read {path}: {e}", file=sys.stderr)
+        return 66
+
+    status, problem = bc.validate(text)
+    out: dict = {"status": "Invalid", "reason": None, "problem": None, "profiles": []}
+    if status != "StructurallyValid":
+        out["problem"] = problem
+    else:
+        rc = json.loads(text)
+        report = bv.validate_receipt(rc["records"], rc["rules"], rc["spec_version"])
+        tables = {
+            p.name: json.loads((p / "profile.json").read_text()) for p in PROFILES.iterdir() if p.is_dir()
+        }
+        profiles = bp.evaluate_receipt(rc, rc["records"], report, required, tables)
+        out.update(
+            status=report["status"],
+            reason=report["reason"],
+            records=len(rc["records"]),
+            retracted=[_hex(x) for x in report["retracted"]],
+            tainted=[_hex(x) for x in report["tainted"]],
+            profiles=[
+                {
+                    "id": g["id"],
+                    "hash": _hex(g["hash"]),
+                    "status": g["status"],
+                    "declared": g["declared"],
+                    "declaration_matches": g["declaration_matches"],
+                    "met": bp.met(g),
+                    "clauses": g["clauses"],
+                }
+                for g in profiles
+            ],
+        )
+
+    if as_json:
+        print(json.dumps(out, indent=2))
+    else:
+        print(f"status:          {out['status'].upper()}")
+        if out["problem"] is not None:
+            print(f"problem:         {out['problem']}")
+        if out["reason"] is not None:
+            print(f"reject reason:   {out['reason']}")
+        if "records" in out:
+            print(f"records:         {out['records']}")
+        for p in out["profiles"]:
+            origin = "required"
+            if p["declared"]:
+                origin = "declared, declaration " + (
+                    "matches" if p["declaration_matches"] else "MISMATCH"
+                    if p["declaration_matches"] is False else "unverifiable"
+                )
+            print(f"profile {p['id']}: {p['status'].upper()} ({origin})")
+            print(f"  hash:          {p['hash']}")
+            for c in p["clauses"]:
+                print(f"  {'ok  ' if c['passed'] else 'FAIL'} {c['id']}: {c['detail']}")
+
+    if out["status"] == "Invalid":
+        return 1
+    if any(not p["met"] for p in out["profiles"]):
+        return 3
+    return 0 if out["status"] == "Clean" else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/profiles/delivery-receipt-v1.md
+++ b/docs/profiles/delivery-receipt-v1.md
@@ -63,6 +63,17 @@ Evidence references are compared by scheme and digest; the optional name is
 never identity. `required: false` requirements are informational: an
 evaluation of one may carry any outcome and they never count for D1 or D2.
 
+D5 requires the decider binding to be present; it does not, and cannot,
+prescribe how `procedure_hash` and `input_hash` are computed. Those are the
+evaluator's conventions, and a skeptic can check them only if the evaluator
+publishes them. The simplest checkable convention, and the one the field
+test used, is `procedure_hash` = SHA-256 of the procedure's own bytes and
+`input_hash` = SHA-256 of exactly the evidence the evaluation cites, so
+that a skeptic holding the evidence and the procedure can recompute both
+and re-run the procedure. An evaluator whose input is wider than the cited
+evidence (a tree plus a configuration, an environment) should say what the
+hash covers.
+
 ## The fraud battery
 
 The vectors in `cases.json` pair each honest shape with the ways a claim

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -377,7 +377,21 @@ fn cmd_validate(rest: &[String]) -> ExitCode {
     let report = validate_with_profiles(&bytes, &limits, &profiles);
 
     if json {
-        match serde_json::to_string_pretty(&report) {
+        // The report's own shape, plus `met` on every profile entry: the
+        // one-word answer the exit code is derived from, so a JSON consumer
+        // need not recombine status and declaration_matches (the Python
+        // surface reports the same field).
+        let rendered = serde_json::to_value(&report).map(|mut v| {
+            if let Some(entries) = v.get_mut("profiles").and_then(|p| p.as_array_mut()) {
+                for (entry, profile) in entries.iter_mut().zip(&report.profiles) {
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert("met".to_string(), serde_json::Value::Bool(profile.met()));
+                    }
+                }
+            }
+            v
+        });
+        match rendered.and_then(|v| serde_json::to_string_pretty(&v)) {
             Ok(s) => println!("{s}"),
             Err(e) => {
                 eprintln!("cannot serialize report: {e}");

--- a/src/profiles/delivery_v1.rs
+++ b/src/profiles/delivery_v1.rs
@@ -325,7 +325,9 @@ pub fn evaluate(receipt: &Receipt, report: &Report) -> ProfileResult {
             }
         }
         if non_passing.is_empty() {
-            d2.1.push(format!("{tag}: every required-bound evaluation passed"));
+            d2.1.push(format!(
+                "{tag}: every used evaluation of a required requirement passed"
+            ));
         } else {
             d2.0 = false;
             d2.1.push(format!("{tag}: non-passing {}", non_passing.join(", ")));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1516,6 +1516,8 @@ fn non_conformant_receipt_exits_3_and_verdict_is_reported() {
     assert_eq!(v["status"], "Clean");
     assert_eq!(v["profiles"][0]["id"], "bellbook-core-v1");
     assert_eq!(v["profiles"][0]["status"], "NonConformant");
+    // `met` is the one-word answer the exit code is derived from.
+    assert_eq!(v["profiles"][0]["met"], false);
     let b3 = v["profiles"][0]["clauses"]
         .as_array()
         .unwrap()
@@ -1602,6 +1604,7 @@ fn export_declares_a_profile_and_validate_checks_the_claim_unasked() {
     assert_eq!(v["profiles"][0]["status"], "Conformant");
     assert_eq!(v["profiles"][0]["declared"], true);
     assert_eq!(v["profiles"][0]["declaration_matches"], true);
+    assert_eq!(v["profiles"][0]["met"], true);
 
     // Requiring the declared profile evaluates it once, as declared.
     let out = bellbook()


### PR DESCRIPTION
Refs #135. The three acts from the first-party half of field test 3 (`docs/field-tests/ft3-delivery-receipt-canary.md`, #136). No wire change; no clause, vector, or profile hash changes.

## What

- **`conformance/python/validate_receipt.py`** (friction F1): the independent validator's one-receipt entry point for a skeptic. Structural decode, replay, every declared profile and any `--require-profile` id, printed the way `bellbook validate` prints them and exited the same way (0 Clean and every profile met, 1 Invalid, 2 Tainted, 3 a profile not met). Standard library only; it refuses to run with the `bellbook` package imported. Documented in the conformance README.
- **`bellbook validate --json` carries `met`** on every profile entry (F2): the one-word answer the exit code is derived from, and the field the Python surface already reports. Injected at the CLI's JSON rendering; library types untouched, so nothing that deserializes a `ProfileResult` changes. CLI tests assert it on a met and a not-met profile.
- **D2 detail wording** (F3): "every used evaluation of a required requirement passed", matching the clause's stated scope, in both implementations. `cases.json` stores clause flags, not detail strings, so nothing regenerates.
- **Profile document** (F4): says what D5 does not prescribe about `procedure_hash` and `input_hash` and names the simplest checkable convention (hash of the procedure's bytes; hash of exactly the cited evidence).
- CHANGELOG `[Unreleased]`.

## Verification

Exercised the entry point on the field test's honest, forged, and edited receipts: exits 0, 3, 1, with the D2 detail in its new wording. `cargo fmt --check`, `cargo clippy --all-targets --all-features` (0 diagnostics), `cargo doc` with warnings denied, `cargo test --all-features` (16 binaries green), `conformance/python/run_conformance.py` (both epochs, both profiles). No em dashes.