### PR TITLE
surfaces: sign records and reach the signed tier from the CLI and Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ change; core conformance is byte-unchanged.
   deterministic test key, which the independent Python validator verifies;
   it implements every clause from scratch and agrees on every vector.
   Profile document: `docs/profiles/bellbook-core-signed-v1.md`.
+- **Signing surfaces**, so the signed tier is reachable without touching
+  Rust. CLI: `rules init --signed` requires a signature on the five
+  evolution kinds and `--author-key <id>:<pubkey-hex>` (repeatable) pins an
+  actor's key; every recording command takes `--sign-key <file>` (the
+  Ed25519 secret as 64 hex characters or 32 raw bytes) and signs the record
+  before it is committed; `eval add --attested` writes
+  `bellbook.evaluation.attested.v1` (refused without `--sign-key`);
+  `key public --secret <file>` prints the public key to pin. Key generation
+  and storage stay with the host; the CLI never prints a secret. Python:
+  `default_rules(..., signed=True, author_keys={actor: [pubkey_hex]})`,
+  `Writer(log_dir, rules, signers={actor: secret})` signs every record the
+  listed actors write, and `evaluate(..., attested=True)` selects the
+  attested schema. Both story gates record a receipt declaring all three
+  profiles and assert every one met.
 
 - `conformance/python/validate_receipt.py`: the independent validator's
   one-receipt entry point for a skeptic - structural decode, replay, every

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -200,6 +200,43 @@ report = bellbook.validate(w.receipt(profiles=["bellbook-core-v1"]))
 report.profiles[0]["met"]     # True: Conformant, and the declaration matches
 ```
 
+## Sign
+
+The signed tier (`bellbook-core-signed-v1`) needs three things, all
+available from Python: rules that require a signature on every evolution
+kind and pin each actor's Ed25519 public key, a writer that signs what
+those actors write, and attested evaluations.
+
+```python
+rules = bellbook.default_rules(
+    {"human": "user", "agent": "provider", "evaluator": "provider"},
+    signed=True,                                       # signature_required_kinds: the five evolution kinds
+    author_keys={"human": [HUMAN_PUB], "agent": [AGENT_PUB], "evaluator": [EVALUATOR_PUB]},
+)
+w = bellbook.Writer("./log", rules, signers={"human": HUMAN_SECRET, "agent": AGENT_SECRET,
+                                             "evaluator": EVALUATOR_SECRET})
+e = w.evaluate(author="evaluator", candidate=c0.id, criterion="unit-tests", passed=True,
+               evaluator="test-harness", basis="recomputed", attested=True)   # bellbook.evaluation.attested.v1
+```
+
+- `author_keys` values are lists of 64-hex-character public keys; every
+  listed actor must be in `authors`. A pinned actor's records always
+  require a signature, whatever the kind.
+- `signers` maps an actor to its secret (64 hex characters or 32 bytes).
+  Key generation and storage are yours; the secret is held only for the
+  writer's lifetime and never exposed. The public key a secret produces is
+  what the signature carries as `key_id` (`bellbook key public --secret
+  FILE` prints it from the CLI).
+- `attested=True` writes the same payload under the attested schema, whose
+  base class is `Verified`; it needs the extended shape and a signer for
+  the author, and the verifier admits it only when that author's key is
+  pinned.
+
+The verifier's answers come back as verdicts, not exceptions: an unsigned
+record by a pinned actor is a rejected record with reason
+`SignatureMissing`, and one signed with a key the rules do not pin for its
+author is `SignatureInvalid`.
+
 ## Retract
 
 `retract(author, target, reason)` asserts a committed record's content is

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -9,11 +9,13 @@
 //! - `bellbook.read(data: bytes) -> Receipt` parses a receipt for inspection
 //!   (records, kinds, authors, evidence, refs, payloads). Reading does not
 //!   verify; call `validate` for the decision.
-//! - `bellbook.Writer(log_dir, rules)` records evolution to a persistent,
-//!   single-writer log: `request`, `requirement`, `candidate`, `evaluate`,
-//!   `select`, and `retract` each commit one record and return a
+//! - `bellbook.Writer(log_dir, rules, signers=None)` records evolution to a
+//!   persistent, single-writer log: `request`, `requirement`, `candidate`,
+//!   `evaluate`, `select`, and `retract` each commit one record and return a
 //!   [`Commit`]. The writer holds the same exclusive lock and runs the same
-//!   replay-on-commit the Rust `LogWriter` does. Export the log with
+//!   replay-on-commit the Rust `LogWriter` does, and signs every record a
+//!   listed actor writes (the signed tier: `default_rules(signed=True,
+//!   author_keys=...)`, `evaluate(attested=True)`). Export the log with
 //!   `writer.receipt()` (optionally declaring profiles) and feed it straight
 //!   back to `validate`.
 //! - The RFC-0002 named query set - `descent`, `descendants`, `siblings`,
@@ -31,19 +33,52 @@ use bellbook_core::{
     artifact_ref_well_formed, decode, default_space, encode, hex_decode, hex_encode,
     manifest_from_dir, manifest_hash, schema_id, validate_with_profiles, verify_and_build_state,
     ArtifactRef, Author, AuthorType, Basis, BindingMode, CandidateBasis, CandidateData,
-    DeciderBinding, EvaluationData, EvaluationDataV2, EvaluationOutcome, EvaluationOutcomeV2,
-    GitSource, Kind, LogWriter, Proposal, Provenance, Queries, Receipt as CoreReceipt,
-    Record as CoreRecord, RecordId, Ref, RefType, Report as CoreReport, RequestData,
-    RequirementData, RetractionData, ScoredValue, SelectionData, SelectionOutcome, SourceAlgo,
-    SourceBinding, State, ValidationLimits, ValidationStatus, VerdictResult, VerifierRules,
-    SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_EVALUATION_V2, SCHEMA_REQUEST, SCHEMA_REQUIREMENT,
-    SCHEMA_RETRACTION, SCHEMA_SELECTION,
+    DeciderBinding, Ed25519Signer, EvaluationData, EvaluationDataV2, EvaluationOutcome,
+    EvaluationOutcomeV2, GitSource, Kind, LogWriter, Proposal, Provenance, Queries,
+    Receipt as CoreReceipt, Record as CoreRecord, RecordId, Ref, RefType, Report as CoreReport,
+    RequestData, RequirementData, RetractionData, ScoredValue, SelectionData, SelectionOutcome,
+    SourceAlgo, SourceBinding, State, ValidationLimits, ValidationStatus, VerdictResult,
+    VerifierRules, SCHEMA_CANDIDATE, SCHEMA_EVALUATION, SCHEMA_EVALUATION_ATTESTED,
+    SCHEMA_EVALUATION_V2, SCHEMA_REQUEST, SCHEMA_REQUIREMENT, SCHEMA_RETRACTION, SCHEMA_SELECTION,
 };
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use std::collections::BTreeMap;
 use std::path::Path;
+
+/// The evolution kinds the signed tier (`bellbook-core-signed-v1`, S1)
+/// requires signatures for. Listed here because the bindings track the
+/// published core.
+const SIGNED_TIER_KINDS: [Kind; 5] = [
+    Kind::Candidate,
+    Kind::Evaluation,
+    Kind::Selection,
+    Kind::Retraction,
+    Kind::Requirement,
+];
+
+/// A 32-byte Ed25519 secret from a Python value: 64 hex characters or 32
+/// raw bytes.
+fn parse_secret(who: &str, value: &Bound<'_, PyAny>) -> PyResult<Ed25519Signer> {
+    if let Ok(s) = value.extract::<String>() {
+        let bytes = hex_decode(s.trim()).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "signer for {who:?}: expected 64 hex characters or 32 bytes"
+            ))
+        })?;
+        return Ok(Ed25519Signer::from_secret_bytes(&bytes));
+    }
+    if let Ok(b) = value.extract::<Vec<u8>>() {
+        let bytes: [u8; 32] = b.as_slice().try_into().map_err(|_| {
+            PyValueError::new_err(format!("signer for {who:?}: expected exactly 32 bytes"))
+        })?;
+        return Ok(Ed25519Signer::from_secret_bytes(&bytes));
+    }
+    Err(PyValueError::new_err(format!(
+        "signer for {who:?}: expected a hex string or bytes"
+    )))
+}
 
 /// The result of validating a receipt. A read-only view over the crate's
 /// `Report`; every field is re-derived by validation, never trusted from the
@@ -527,12 +562,15 @@ fn parse_role(s: &str) -> PyResult<AuthorType> {
 /// w = bellbook.Writer("./log", rules)
 /// ```
 #[pyfunction]
-#[pyo3(signature = (authors, max_context=200, admins=None, reaffirmers=None))]
+#[pyo3(signature = (authors, max_context=200, admins=None, reaffirmers=None, signed=false,
+    author_keys=None))]
 fn default_rules(
     authors: BTreeMap<String, String>,
     max_context: u32,
     admins: Option<Vec<String>>,
     reaffirmers: Option<Vec<String>>,
+    signed: bool,
+    author_keys: Option<BTreeMap<String, Vec<String>>>,
 ) -> PyResult<String> {
     if authors.is_empty() {
         return Err(PyValueError::new_err(
@@ -562,6 +600,40 @@ fn default_rules(
     }
     for id in reaffirmers.iter().flatten() {
         rules.reaffirmation_actors.insert(id.clone().into());
+    }
+    // The signed tier's rule shape (bellbook-core-signed-v1 S1 and S2):
+    // `signed=True` requires a signature on every evolution kind;
+    // `author_keys` pins the Ed25519 public keys (64 hex characters each)
+    // an actor may sign with. A pinned actor's records always require a
+    // signature, whatever the kind.
+    if signed {
+        for kind in SIGNED_TIER_KINDS {
+            rules.signature_required_kinds.insert(kind);
+        }
+    }
+    for (id, keys) in author_keys.iter().flatten() {
+        if !authors.contains_key(id) {
+            return Err(PyValueError::new_err(format!(
+                "author_keys entry {id:?} has no author binding; add it to authors"
+            )));
+        }
+        if keys.is_empty() {
+            return Err(PyValueError::new_err(format!(
+                "author_keys entry {id:?} lists no keys"
+            )));
+        }
+        for hex in keys {
+            let key = hex_decode(hex.trim()).ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "author_keys entry {id:?}: a public key must be 64 lowercase hex characters"
+                ))
+            })?;
+            rules
+                .author_keys
+                .entry(id.clone().into())
+                .or_default()
+                .insert(key);
+        }
     }
     serde_json::to_string(&rules)
         .map_err(|e| PyRuntimeError::new_err(format!("cannot serialize rules: {e}")))
@@ -700,6 +772,8 @@ struct Writer {
     inner: LogWriter,
     rules: VerifierRules,
     state: State,
+    /// Actor id -> the signer for every record that actor writes.
+    signers: BTreeMap<String, Ed25519Signer>,
 }
 
 impl Writer {
@@ -737,10 +811,16 @@ impl Writer {
             data,
             refs,
         };
-        let (id, verdict) = self
-            .inner
-            .commit(proposal, &self.rules, &mut self.state)
-            .map_err(|e| PyRuntimeError::new_err(format!("commit failed: {e}")))?;
+        // A listed actor's records are signed before they are committed; the
+        // signature covers the signing form and is bound into the record id.
+        let (id, verdict) = match self.signers.get(&proposal.author.id) {
+            Some(signer) => {
+                self.inner
+                    .commit_signed(proposal, &self.rules, &mut self.state, signer)
+            }
+            None => self.inner.commit(proposal, &self.rules, &mut self.state),
+        }
+        .map_err(|e| PyRuntimeError::new_err(format!("commit failed: {e}")))?;
         let accepted = verdict.result == VerdictResult::Accept;
         Ok(Commit {
             id: hex_encode(&id),
@@ -756,11 +836,30 @@ impl Writer {
     /// Open (or create) the log at `log_dir` under `rules` (a JSON string).
     /// Rebuilds and re-verifies state from the committed records; raises if the
     /// existing log does not verify, or if another writer holds the lock.
+    ///
+    /// `signers` maps an actor id to the Ed25519 secret (64 hex characters or
+    /// 32 bytes) that signs every record the actor writes; an actor with no
+    /// signer writes unsigned. Key generation and storage are the host's;
+    /// the secret is held only for the writer's lifetime and never exposed.
+    /// Every listed actor must be registered in the rules' `author_roles`.
     #[new]
-    #[pyo3(signature = (log_dir, rules))]
-    fn new(log_dir: &str, rules: &str) -> PyResult<Self> {
+    #[pyo3(signature = (log_dir, rules, signers=None))]
+    fn new(
+        log_dir: &str,
+        rules: &str,
+        signers: Option<BTreeMap<String, Bound<'_, PyAny>>>,
+    ) -> PyResult<Self> {
         let rules: VerifierRules = serde_json::from_str(rules)
             .map_err(|e| PyValueError::new_err(format!("invalid rules JSON: {e}")))?;
+        let mut parsed_signers = BTreeMap::new();
+        for (who, secret) in signers.iter().flatten() {
+            if !rules.author_roles.contains_key(who.as_str()) {
+                return Err(PyValueError::new_err(format!(
+                    "signer {who:?} is not registered in the rules' author_roles"
+                )));
+            }
+            parsed_signers.insert(who.clone(), parse_secret(who, secret)?);
+        }
         let inner = LogWriter::open(Path::new(log_dir), &rules)
             .map_err(|e| PyRuntimeError::new_err(format!("cannot open log: {e}")))?;
         let state = verify_and_build_state(inner.records(), &rules).map_err(|_| {
@@ -770,6 +869,7 @@ impl Writer {
             inner,
             rules,
             state,
+            signers: parsed_signers,
         })
     }
 
@@ -1067,7 +1167,7 @@ impl Writer {
         score=None, scale=None, procedure=None, uses=None, blocked=false,
         insufficient=false, stale=false, not_run=false, evaluator=None,
         evaluator_version=None, procedure_hash=None, input_hash=None, basis=None,
-        requirements=None, artifacts=None))]
+        requirements=None, artifacts=None, attested=false))]
     #[allow(clippy::too_many_arguments)]
     fn evaluate(
         &mut self,
@@ -1091,9 +1191,20 @@ impl Writer {
         basis: Option<&str>,
         requirements: Option<Vec<String>>,
         artifacts: Option<Vec<Bound<'_, PyAny>>>,
+        attested: bool,
     ) -> PyResult<Commit> {
         let author = self.resolve_author(author)?;
         let candidate = parse_id(candidate)?;
+        // The attested schema (base class Verified) is admitted only under a
+        // signature from an author with pinned keys: refuse an unsigned one
+        // before anything is written. Whether the key is pinned is the
+        // verifier's decision, recorded as the verdict.
+        if attested && !self.signers.contains_key(&author.id) {
+            return Err(PyValueError::new_err(format!(
+                "attested=True requires a signer for {:?}: pass signers={{...}} to Writer",
+                author.id
+            )));
+        }
 
         // Exactly one outcome.
         let unit: Vec<&str> = [
@@ -1234,7 +1345,17 @@ impl Writer {
                 evidence: parse_artifacts(artifacts)?.unwrap_or_default(),
                 requirements: requirement_ids,
             })?;
-            (SCHEMA_EVALUATION_V2, data)
+            // Same payload; the schema id is the only difference, and it is
+            // what moves the base class from Reported to Verified.
+            if attested {
+                (SCHEMA_EVALUATION_ATTESTED, data)
+            } else {
+                (SCHEMA_EVALUATION_V2, data)
+            }
+        } else if attested {
+            return Err(PyValueError::new_err(
+                "attested=True requires the extended shape: give evaluator and basis",
+            ));
         } else {
             let outcome = match outcome_v2 {
                 EvaluationOutcomeV2::Passed => EvaluationOutcome::Passed,

--- a/bindings/python/tests/test_signing.py
+++ b/bindings/python/tests/test_signing.py
@@ -1,0 +1,165 @@
+"""Signing from Python: `default_rules(signed=..., author_keys=...)` shapes
+the rules for the signed tier, `Writer(signers=...)` signs every record a
+listed actor writes, and `evaluate(attested=True)` selects the attested
+schema. The negative branches are the verifier's, reached through the
+bindings: an unsigned record by a pinned actor, a record signed with a key
+the rules do not pin for its author, and an attested evaluation from an
+actor with no signer (refused before the write)."""
+
+import hashlib
+import json
+import os
+
+import pytest
+
+import bellbook
+
+# Deterministic test secrets; the matching public keys are pinned in the
+# rules. Any 32 bytes are a valid Ed25519 secret.
+HUMAN = "15" * 32
+AGENT = "16" * 32
+EVALUATOR = "17" * 32
+# Public keys derived by the reference (`Ed25519Signer::public_key_hex`) for
+# the secrets above; pinned as the CLI story pins them.
+HUMAN_PUB = "d54207da194977dcf46adbfec2bc2e75b52d5a8a42184fedfdc00024f0e3e8da"
+TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+DIGEST = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+FIVE = {"Candidate", "Evaluation", "Selection", "Retraction", "Requirement"}
+
+
+def _signed_rules(tmp_path, pubs: dict) -> str:
+    return bellbook.default_rules(
+        {"human": "user", "agent": "provider", "evaluator": "provider"},
+        signed=True,
+        author_keys={who: [pub] for who, pub in pubs.items()},
+    )
+
+
+def _pubs(tmp_path) -> dict:
+    out = {}
+    for who, secret in (("human", HUMAN), ("agent", AGENT), ("evaluator", EVALUATOR)):
+        rules = bellbook.default_rules({"agent": "provider"})
+        w = bellbook.Writer(os.path.join(str(tmp_path), f"probe-{who}"), rules, signers={"agent": secret})
+        c = w.candidate(author="agent", git_tree=TREE)
+        assert c.accepted
+        # The receipt's wire form carries the key id the signature names.
+        receipt = json.loads(w.receipt())
+        rec = next(r for r in receipt["records"] if bytes(r["id"]).hex() == c.id)
+        out[who] = rec["author"]["signature"]["key_id"]
+    assert out["human"] == HUMAN_PUB
+    return out
+
+
+def test_default_rules_shape_the_signed_tier(tmp_path):
+    pubs = _pubs(tmp_path)
+    rules = json.loads(_signed_rules(tmp_path, pubs))
+    assert set(rules["signature_required_kinds"]) >= FIVE
+    assert set(rules["author_keys"]) == {"human", "agent", "evaluator"}
+    assert bytes(rules["author_keys"]["human"][0]).hex() == HUMAN_PUB
+    # Refusals before anything is written.
+    with pytest.raises(ValueError, match="no author binding"):
+        bellbook.default_rules({"agent": "provider"}, author_keys={"ghost": [HUMAN_PUB]})
+    with pytest.raises(ValueError, match="64 lowercase hex"):
+        bellbook.default_rules({"agent": "provider"}, author_keys={"agent": ["abc"]})
+    with pytest.raises(ValueError, match="lists no keys"):
+        bellbook.default_rules({"agent": "provider"}, author_keys={"agent": []})
+
+
+def test_signed_story_from_python_alone(tmp_path):
+    pubs = _pubs(tmp_path)
+    rules = _signed_rules(tmp_path, pubs)
+
+    # A pinned actor writing unsigned is impersonation: a durable rejected
+    # record with the verifier's reason, not an exception.
+    unsigned = bellbook.Writer(os.path.join(str(tmp_path), "unsigned"), rules)
+    r = unsigned.request(author="human", objective="ship the signed build")
+    assert not r.accepted and r.reason == "SignatureMissing"
+    del unsigned
+
+    # A signer for an actor the rules do not know is refused up front.
+    with pytest.raises(ValueError, match="not registered"):
+        bellbook.Writer(os.path.join(str(tmp_path), "ghost"), rules, signers={"ghost": HUMAN})
+    with pytest.raises(ValueError, match="64 hex characters or 32 bytes"):
+        bellbook.Writer(os.path.join(str(tmp_path), "bad"), rules, signers={"human": "zz"})
+
+    w = bellbook.Writer(
+        os.path.join(str(tmp_path), "log"),
+        rules,
+        signers={"human": HUMAN, "agent": bytes.fromhex(AGENT), "evaluator": EVALUATOR},
+    )
+    req = w.request(author="human", objective="ship the signed build")
+    r1 = w.requirement(author="human", request=req.id, key="R1", description="unit tests pass")
+    c0 = w.candidate(author="agent", git_tree=TREE, artifacts=[f"git-tree-sha1:{TREE}:src"])
+    # attested=True needs the extended shape...
+    with pytest.raises(ValueError, match="extended shape"):
+        w.evaluate(author="evaluator", candidate=c0.id, criterion="unit-tests", passed=True, attested=True)
+    # ...and a signer for the author (agent-as-evaluator would also fail D4,
+    # but the point here is a signer-less actor).
+    plain = bellbook.Writer(os.path.join(str(tmp_path), "plain"), bellbook.default_rules(
+        {"agent": "provider", "evaluator": "provider"}))
+    pc = plain.candidate(author="agent", git_tree=TREE)
+    with pytest.raises(ValueError, match="requires a signer"):
+        plain.evaluate(author="evaluator", candidate=pc.id, criterion="c", passed=True,
+                       evaluator="h", basis="declared", attested=True)
+    del plain
+
+    e0 = w.evaluate(
+        author="evaluator",
+        candidate=c0.id,
+        criterion="unit-tests",
+        passed=True,
+        evaluator="test-harness",
+        basis="recomputed",
+        procedure_hash=DIGEST,
+        input_hash=DIGEST,
+        requirements=[r1.id],
+        artifacts=[f"git-tree-sha1:{TREE}"],
+        attested=True,
+    )
+    s0 = w.select(author="agent", objective="deliver", consider=[c0.id], choose=[c0.id], uses_eval=[e0.id])
+    for c in (req, r1, c0, e0, s0):
+        assert c.accepted, c.reason
+
+    receipt = w.receipt(profiles=["bellbook-core-v1", "delivery-receipt-v1"])
+    report = bellbook.validate(receipt)
+    assert report.status == "clean"
+    assert all(p["met"] for p in report.profiles)
+    parsed = bellbook.read(receipt)
+    by_id = {r.id: r for r in parsed.records}
+    assert all(by_id[c.id].signed for c in (req, r1, c0, e0, s0))
+    # `Record.schema` is the schema id: sha256 of the schema name.
+    schema_id = lambda name: hashlib.sha256(name.encode()).hexdigest()  # noqa: E731
+    assert by_id[e0.id].schema == schema_id("bellbook.evaluation.attested.v1")
+    assert by_id[c0.id].schema == schema_id("bellbook.candidate.v1")
+
+    # A record signed with a key the rules do not pin for its author: the
+    # signature verifies against the key it carries and binds nothing.
+    wrong = bellbook.Writer(
+        os.path.join(str(tmp_path), "wrong"),
+        rules,
+        signers={"human": AGENT},
+    )
+    r = wrong.request(author="human", objective="ship")
+    assert not r.accepted and r.reason == "SignatureInvalid"
+
+
+def test_signed_tier_profile_through_the_wheel(tmp_path):
+    """The signed tier as the pinned core reports it. The bindings track the
+    published crate: until the pin moves to the core that publishes
+    `bellbook-core-signed-v1`, requiring it is reported Unknown rather than
+    evaluated, and declaring it is refused as an unknown profile. Both
+    assertions flip at the pin bump."""
+    pubs = _pubs(tmp_path)
+    rules = _signed_rules(tmp_path, pubs)
+    w = bellbook.Writer(os.path.join(str(tmp_path), "log"), rules, signers={"agent": AGENT, "evaluator": EVALUATOR})
+    c0 = w.candidate(author="agent", git_tree=TREE)
+    e0 = w.evaluate(author="evaluator", candidate=c0.id, criterion="c", passed=True,
+                    evaluator="h", basis="declared", attested=True)
+    s0 = w.select(author="agent", objective="ship", consider=[c0.id], choose=[c0.id], uses_eval=[e0.id])
+    assert s0.accepted, s0.reason
+    report = bellbook.validate(w.receipt(), require_profile="bellbook-core-signed-v1")
+    p = report.profiles[0]
+    if p["status"] == "Unknown":
+        pytest.skip("pinned core predates bellbook-core-signed-v1; flips at the pin bump")
+    assert p["status"] == "Conformant" and p["met"]
+    assert [c["id"] for c in p["clauses"]] == ["S0", "S1", "S2", "S3"]

--- a/docs/profiles/bellbook-core-signed-v1.md
+++ b/docs/profiles/bellbook-core-signed-v1.md
@@ -75,6 +75,38 @@ Three changes to a baseline setup, none of which reshapes a payload:
 Changing the rules changes `rules_hash`: a receipt exported under baseline
 rules stays valid under them and stays NonConformant here.
 
+From the CLI, with one secret per actor (any 32 random bytes, kept by the
+host; `openssl rand -hex 32 > agent.hex` is enough):
+
+```sh
+bellbook key public --secret agent.hex          # the hex to pin
+bellbook rules init --author human:user --author agent:provider --author evaluator:provider \
+  --signed --author-key human:HUMAN_PUB --author-key agent:AGENT_PUB \
+  --author-key evaluator:EVALUATOR_PUB --out rules.json
+bellbook candidate add ... --author agent --sign-key agent.hex
+bellbook eval add ... --author evaluator --evaluator harness --basis recomputed \
+  --attested --sign-key evaluator.hex
+bellbook select ... --author agent --sign-key agent.hex
+bellbook export --profile bellbook-core-v1 bellbook-core-signed-v1 delivery-receipt-v1 --out receipt.json
+```
+
+From Python:
+
+```python
+rules = bellbook.default_rules({"human": "user", "agent": "provider", "evaluator": "provider"},
+                               signed=True,
+                               author_keys={"human": [HUMAN_PUB], "agent": [AGENT_PUB],
+                                            "evaluator": [EVALUATOR_PUB]})
+w = bellbook.Writer("./log", rules, signers={"human": HUMAN_SECRET, "agent": AGENT_SECRET,
+                                             "evaluator": EVALUATOR_SECRET})
+e = w.evaluate(author="evaluator", ..., evaluator="harness", basis="recomputed", attested=True)
+```
+
+The writer signs every record a listed actor writes; an unsigned record by
+a pinned actor is rejected by the verifier as `SignatureMissing`, and a
+record signed with a key the rules do not pin for its author as
+`SignatureInvalid`. Both are durable rejected records, not errors.
+
 ## Declaring
 
 ```sh

--- a/src/bin/bellbook.rs
+++ b/src/bin/bellbook.rs
@@ -51,7 +51,7 @@ USAGE:
                            [--evaluator <id> --basis recomputed|declared
                             [--evaluator-version <s>] [--procedure-hash <hex>]
                             [--input-hash <hex>] [--requirement <id> ...]
-                            [--artifact <scheme>:<digest>[:<name>] ...]]
+                            [--artifact <scheme>:<digest>[:<name>] ...] [--attested]]
     bellbook select        --log <dir> --rules <file> --author <id>
                            --objective <s> --consider <id> ...
                            (--choose <id> ... --uses-eval <id> ... | --none)
@@ -62,9 +62,15 @@ USAGE:
     bellbook query <name> [<id>|<objective>]
                            (--log <dir> --rules <file> | --receipt <file>) [--json]
     bellbook rules init    --author <id>:<role> ... [--admin <id>] ... [--reaffirmer <id>] ...
+                           [--signed] [--author-key <id>:<pubkey-hex>] ...
                            [--max-context <n>] [--out <file>]
+    bellbook key public    --secret <file>
     bellbook export        --log <dir> --rules <file> [--out <file>]
                            [--profile <id> ...]
+
+    Every recording command (request, requirement, candidate, eval, select,
+    retract) also takes [--sign-key <file>]: the record is signed with the
+    Ed25519 secret in <file> (64 hex characters or 32 raw bytes).
 
 COMMANDS:
     validate    Verify a receipt offline: ids (RFC 8785 canonical form),
@@ -130,6 +136,7 @@ fn main() -> ExitCode {
     match command {
         "validate" => cmd_validate(&rest),
         "rules" => cmd_rules(&rest),
+        "key" => cmd_key(&rest),
         "request" | "requirement" | "candidate" | "eval" | "select" | "retract" | "lineage"
         | "export" | "query" => cmd_evolution(command, &rest),
         other => {
@@ -179,9 +186,33 @@ fn cmd_rules(rest: &[String]) -> ExitCode {
     let mut reaffirmers: Vec<String> = Vec::new();
     let mut max_context: u32 = 200;
     let mut out: Option<String> = None;
+    let mut signed = false;
+    let mut author_keys: Vec<(String, PublicKeyBytes)> = Vec::new();
     let mut it = rest.iter();
     while let Some(arg) = it.next() {
         match arg.as_str() {
+            "--signed" => signed = true,
+            "--author-key" => {
+                let Some(v) = it.next() else {
+                    eprintln!("--author-key requires <id>:<pubkey-hex>");
+                    return ExitCode::from(64);
+                };
+                let Some((id, hex)) = v.rsplit_once(':') else {
+                    eprintln!("--author-key must be <id>:<pubkey-hex>, got {v:?}");
+                    return ExitCode::from(64);
+                };
+                if id.is_empty() {
+                    eprintln!("--author-key id must be non-empty");
+                    return ExitCode::from(64);
+                }
+                let Some(key) = hex_decode(hex) else {
+                    eprintln!(
+                        "--author-key {id}: the public key must be 64 lowercase hex characters"
+                    );
+                    return ExitCode::from(64);
+                };
+                author_keys.push((id.to_string(), key));
+            }
             "--admin" => {
                 let Some(v) = it.next() else {
                     eprintln!("--admin requires an actor id");
@@ -265,6 +296,14 @@ fn cmd_rules(rest: &[String]) -> ExitCode {
             }
         }
     }
+    // A pinned key for an actor with no role binding could never sign an
+    // accepted record; refuse the silent no-op the same way.
+    for (id, _) in &author_keys {
+        if !authors.iter().any(|(a, _)| a == id) {
+            eprintln!("--author-key {id:?} has no --author {id}:<role> binding; add one");
+            return ExitCode::from(64);
+        }
+    }
 
     // Baseline evidence thresholds (RFC-0003 clause B3) are on by default so
     // a generated rule set conforms to bellbook-core-v1 out of the box.
@@ -277,6 +316,18 @@ fn cmd_rules(rest: &[String]) -> ExitCode {
     }
     for id in reaffirmers {
         rules = rules.with_reaffirmation_actor(id);
+    }
+    // The signed tier's rule shape (bellbook-core-signed-v1 S1 and S2): a
+    // signature required on every evolution kind, and the keys each actor
+    // may sign with. A pinned actor's records always require a signature,
+    // whatever the kind.
+    if signed {
+        for kind in SIGNED_TIER_KINDS {
+            rules.signature_required_kinds.insert(kind);
+        }
+    }
+    for (id, key) in author_keys {
+        rules.author_keys.entry(id).or_default().insert(key);
     }
     let json = match serde_json::to_string(&rules) {
         Ok(s) => s,
@@ -419,6 +470,75 @@ fn cmd_validate(rest: &[String]) -> ExitCode {
     }
 }
 
+/// Read an Ed25519 secret from `path`: 64 hex characters (surrounding
+/// whitespace ignored) or exactly 32 raw bytes. The secret never leaves the
+/// process and is never printed. Key generation is the host's concern; any
+/// 32 random bytes are a valid secret (`openssl rand -hex 32 > secret.hex`).
+fn read_signer(path: &str) -> Result<Ed25519Signer, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("cannot read key file {path}: {e}"))?;
+    let secret: [u8; 32] = if bytes.len() == 32 {
+        bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| "unreachable".to_string())?
+    } else {
+        let text = String::from_utf8(bytes)
+            .map_err(|_| format!("key file {path}: expected 64 hex characters or 32 raw bytes"))?;
+        hex_decode(text.trim())
+            .ok_or_else(|| format!("key file {path}: expected 64 hex characters or 32 raw bytes"))?
+    };
+    Ok(Ed25519Signer::from_secret_bytes(&secret))
+}
+
+/// `key public --secret <file>` prints the public key (64 lowercase hex
+/// characters) of the Ed25519 secret in `<file>` - the value to pin with
+/// `rules init --author-key <id>:<hex>`. It is the only key operation the
+/// CLI offers: generating and storing secrets stays with the host.
+fn cmd_key(rest: &[String]) -> ExitCode {
+    let (sub, rest) = match rest.split_first() {
+        Some((s, r)) => (s.as_str(), r),
+        None => {
+            eprintln!("key needs a subcommand (public)\n\n{USAGE}");
+            return ExitCode::from(64);
+        }
+    };
+    if sub != "public" {
+        eprintln!("unknown key subcommand {sub:?} (expected public)\n\n{USAGE}");
+        return ExitCode::from(64);
+    }
+    let mut secret: Option<&str> = None;
+    let mut it = rest.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--secret" => match it.next() {
+                Some(v) => secret = Some(v.as_str()),
+                None => {
+                    eprintln!("--secret requires a path");
+                    return ExitCode::from(64);
+                }
+            },
+            other => {
+                eprintln!("unexpected argument {other:?}\n\n{USAGE}");
+                return ExitCode::from(64);
+            }
+        }
+    }
+    let Some(path) = secret else {
+        eprintln!("key public requires --secret <file>");
+        return ExitCode::from(64);
+    };
+    match read_signer(path) {
+        Ok(signer) => {
+            println!("{}", signer.public_key_hex());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            ExitCode::from(66)
+        }
+    }
+}
+
 #[cfg(not(feature = "persist"))]
 fn cmd_evolution(command: &str, _rest: &[String]) -> ExitCode {
     eprintln!("the {command:?} command requires the `persist` feature (build without --no-default-features)");
@@ -506,7 +626,8 @@ mod persist_cmds {
                         return Err(format!("--{name} requires at least one value"));
                     }
                     p.multis.entry(name.to_string()).or_default().extend(vals);
-                } else if singles.contains(&name) {
+                } else if singles.contains(&name) || name == "sign-key" {
+                    // Every recording command takes `--sign-key <file>`.
                     let Some(v) = rest.get(i + 1) else {
                         return Err(format!("--{name} requires a value"));
                     };
@@ -648,17 +769,34 @@ mod persist_cmds {
         reason: Option<String>,
     }
 
-    /// Commit a proposal, print its id, and map the verdict to an exit code.
+    /// The signer named by `--sign-key <file>`, if any: a file holding the
+    /// 32-byte Ed25519 secret as 64 hex characters (a trailing newline is
+    /// fine) or as 32 raw bytes. Key generation and storage are the host's
+    /// (`openssl rand -hex 32 > secret.hex` is enough); the CLI only reads
+    /// the secret and never prints it. `bellbook key public` derives the hex
+    /// to pin in `rules init --author-key`.
+    fn signer_from(p: &Parsed) -> Result<Option<Ed25519Signer>, String> {
+        let Some(path) = p.singles.get("sign-key") else {
+            return Ok(None);
+        };
+        crate::read_signer(path).map(Some)
+    }
+
+    /// Commit a proposal (signed when `--sign-key` was given), print its id,
+    /// and map the verdict to an exit code.
     fn commit_and_print(
         mut writer: LogWriter,
         rules: &VerifierRules,
         mut state: State,
         proposal: Proposal,
-        json: bool,
+        p: &Parsed,
     ) -> Result<ExitCode, String> {
-        let (id, verdict) = writer
-            .commit(proposal, rules, &mut state)
-            .map_err(|e| format!("commit failed: {e:?}"))?;
+        let json = p.bools.contains("json");
+        let (id, verdict) = match signer_from(p)? {
+            Some(signer) => writer.commit_signed(proposal, rules, &mut state, &signer),
+            None => writer.commit(proposal, rules, &mut state),
+        }
+        .map_err(|e| format!("commit failed: {e:?}"))?;
         let accepted = verdict.result == VerdictResult::Accept;
         let out = CommitOutput {
             id: hex_encode(&id),
@@ -760,7 +898,7 @@ mod persist_cmds {
             data,
             refs: Vec::new(),
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- requirement add ---------------------------------------------------
@@ -867,7 +1005,7 @@ mod persist_cmds {
                 target: request,
             }],
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- candidate add -----------------------------------------------------
@@ -1020,7 +1158,7 @@ mod persist_cmds {
             data,
             refs,
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- eval add ----------------------------------------------------------
@@ -1058,6 +1196,7 @@ mod persist_cmds {
                 "insufficient",
                 "stale",
                 "not-run",
+                "attested",
             ],
         )?;
         let rules = load_rules(&p)?;
@@ -1218,7 +1357,24 @@ mod persist_cmds {
                 evidence: parse_artifacts(&p)?.unwrap_or_default(),
                 requirements,
             })?;
-            (SCHEMA_EVALUATION_V2, data)
+            // `--attested` writes the same payload under the attested schema
+            // (base class Verified); the verifier admits it only under a
+            // signature from an author with pinned keys, so it needs
+            // `--sign-key` and a rules file that pins the evaluator.
+            if p.bools.contains("attested") {
+                if !p.singles.contains_key("sign-key") {
+                    return Err(
+                        "--attested requires --sign-key: the attested schema is admitted only under a pinned signature".into(),
+                    );
+                }
+                (SCHEMA_EVALUATION_ATTESTED, data)
+            } else {
+                (SCHEMA_EVALUATION_V2, data)
+            }
+        } else if p.bools.contains("attested") {
+            return Err(
+                "--attested requires the extended shape: give --evaluator and --basis".into(),
+            );
         } else {
             let outcome = match outcome_v2 {
                 EvaluationOutcomeV2::Passed => EvaluationOutcome::Passed,
@@ -1244,7 +1400,7 @@ mod persist_cmds {
             data,
             refs,
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- retract -----------------------------------------------------------
@@ -1291,7 +1447,7 @@ mod persist_cmds {
             data,
             refs,
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- select ------------------------------------------------------------
@@ -1384,7 +1540,7 @@ mod persist_cmds {
             data,
             refs,
         };
-        commit_and_print(writer, &rules, state, proposal, p.bools.contains("json"))
+        commit_and_print(writer, &rules, state, proposal, &p)
     }
 
     // --- lineage -----------------------------------------------------------

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2261,3 +2261,342 @@ fn artifact_and_extended_eval_flags_are_checked_before_the_write() {
     assert!(sel["evidence"][0]["node"].get("requirements").is_none());
     assert!(sel["evidence"][0]["node"].get("artifacts").is_none());
 }
+
+// ---------------------------------------------------------------------------
+// The signed tier from the CLI alone (bellbook-core-signed-v1)
+// ---------------------------------------------------------------------------
+
+/// `rules init --signed --author-key`, `key public`, `--sign-key` on every
+/// recording command, and `eval add --attested`: a receipt that declares all
+/// three profiles and meets them, recorded with nothing but the binary. The
+/// negative branches are the verifier's, reached through the CLI: an unsigned
+/// record by a pinned author, a record signed with another actor's key, an
+/// attested evaluation without a signature, and a pinned key for an actor
+/// with no role binding.
+#[test]
+fn signed_tier_story_from_the_cli_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("log");
+    let rules = dir.path().join("rules.json");
+    let key_file = |name: &str, byte: u8| {
+        let p = dir.path().join(format!("{name}.hex"));
+        std::fs::write(&p, format!("{}\n", hex_encode(&[byte; 32]))).unwrap();
+        p
+    };
+    let human_key = key_file("human", 0x15);
+    let agent_key = key_file("agent", 0x16);
+    let evaluator_key = key_file("evaluator", 0x17);
+    let public = |secret: &PathBuf| -> String {
+        let out = bellbook()
+            .args(["key", "public", "--secret"])
+            .arg(secret)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    };
+    let (human_pub, agent_pub, evaluator_pub) = (
+        public(&human_key),
+        public(&agent_key),
+        public(&evaluator_key),
+    );
+    // `key public` derives exactly the key the core would pin.
+    assert_eq!(
+        human_pub,
+        Ed25519Signer::from_secret_bytes(&[0x15; 32]).public_key_hex()
+    );
+
+    // A pinned key for an actor with no role binding is refused, like an
+    // admin without one.
+    let out = bellbook()
+        .args([
+            "rules",
+            "init",
+            "--author",
+            "human:user",
+            "--author-key",
+            &format!("ghost:{human_pub}"),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(64));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--author-key \"ghost\" has no --author"));
+
+    let out = bellbook()
+        .args([
+            "rules",
+            "init",
+            "--author",
+            "human:user",
+            "--author",
+            "agent:provider",
+            "--author",
+            "evaluator:provider",
+            "--signed",
+            "--author-key",
+            &format!("human:{human_pub}"),
+            "--author-key",
+            &format!("agent:{agent_pub}"),
+            "--author-key",
+            &format!("evaluator:{evaluator_pub}"),
+            "--out",
+        ])
+        .arg(&rules)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed: VerifierRules =
+        serde_json::from_str(&std::fs::read_to_string(&rules).unwrap()).unwrap();
+    for kind in SIGNED_TIER_KINDS {
+        assert!(parsed.signature_required_kinds.contains(&kind), "{kind:?}");
+    }
+    assert_eq!(parsed.author_keys.len(), 3);
+    assert!(parsed.author_keys["human"]
+        .contains(&Ed25519Signer::from_secret_bytes(&[0x15; 32]).public_key()));
+
+    let env = Env {
+        _dir: dir,
+        log,
+        rules,
+    };
+    let human_key = human_key.to_str().unwrap();
+    let agent_key = agent_key.to_str().unwrap();
+    let evaluator_key = evaluator_key.to_str().unwrap();
+
+    // An unsigned record by a pinned author is impersonation: durably
+    // rejected, exit 65, the verifier's reason.
+    let out = run(
+        &env,
+        &[
+            "request",
+            "add",
+            "--author",
+            "human",
+            "--objective",
+            "ship the signed build",
+            "--json",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["result"], "reject");
+    assert_eq!(v["reason"], "SignatureMissing");
+
+    let req = committed_id(&run(
+        &env,
+        &[
+            "request",
+            "add",
+            "--author",
+            "human",
+            "--objective",
+            "ship the signed build",
+            "--sign-key",
+            human_key,
+            "--json",
+        ],
+    ));
+    let r1 = committed_id(&run(
+        &env,
+        &[
+            "requirement",
+            "add",
+            "--author",
+            "human",
+            "--request",
+            &req,
+            "--key",
+            "R1",
+            "--description",
+            "unit tests pass on the signed tree",
+            "--sign-key",
+            human_key,
+            "--json",
+        ],
+    ));
+    let c0 = committed_id(&run(
+        &env,
+        &[
+            "candidate",
+            "add",
+            "--author",
+            "agent",
+            "--git-tree",
+            TREE_A,
+            "--artifact",
+            &format!("git-tree-sha1:{TREE_A}:src"),
+            "--sign-key",
+            agent_key,
+            "--json",
+        ],
+    ));
+
+    // The attested schema is admitted only under a pinned signature; the
+    // CLI refuses to write one unsigned before anything is committed.
+    let procedure = hex_encode(&[0x51; 32]);
+    let input = hex_encode(&[0x52; 32]);
+    let eval_args = |extra: &[&str]| -> Vec<String> {
+        let mut a: Vec<String> = [
+            "eval",
+            "add",
+            "--author",
+            "evaluator",
+            "--candidate",
+            &c0,
+            "--criterion",
+            "unit-tests",
+            "--passed",
+            "--evaluator",
+            "test-harness",
+            "--basis",
+            "recomputed",
+            "--procedure-hash",
+            &procedure,
+            "--input-hash",
+            &input,
+            "--requirement",
+            &r1,
+            "--artifact",
+            &format!("git-tree-sha1:{TREE_A}"),
+            "--attested",
+            "--json",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        a.extend(extra.iter().map(|s| s.to_string()));
+        a
+    };
+    let unsigned = eval_args(&[]);
+    let out = run(
+        &env,
+        &unsigned.iter().map(String::as_str).collect::<Vec<_>>(),
+    );
+    assert_eq!(out.status.code(), Some(65));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--attested requires --sign-key"));
+    let signed = eval_args(&["--sign-key", evaluator_key]);
+    let e1 = committed_id(&run(
+        &env,
+        &signed.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+
+    // A record signed with another actor's key: the signature verifies
+    // against the key it carries, but that key is not pinned for the author.
+    let out = run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "deliver",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &e1,
+            "--sign-key",
+            evaluator_key,
+            "--json",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(65));
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["reason"], "SignatureInvalid");
+
+    committed_id(&run(
+        &env,
+        &[
+            "select",
+            "--author",
+            "agent",
+            "--objective",
+            "deliver",
+            "--consider",
+            &c0,
+            "--choose",
+            &c0,
+            "--uses-eval",
+            &e1,
+            "--sign-key",
+            agent_key,
+            "--json",
+        ],
+    ));
+
+    // Export declaring all three profiles; every one met.
+    let receipt = env._dir.path().join("signed.json");
+    let out = run(
+        &env,
+        &[
+            "export",
+            "--profile",
+            BELLBOOK_CORE_V1,
+            BELLBOOK_CORE_SIGNED_V1,
+            DELIVERY_RECEIPT_V1,
+            "--out",
+            receipt.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let out = bellbook()
+        .args(["validate", "--json"])
+        .arg(&receipt)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["status"], "Clean");
+    let ids: Vec<&str> = v["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        [
+            BELLBOOK_CORE_V1,
+            BELLBOOK_CORE_SIGNED_V1,
+            DELIVERY_RECEIPT_V1
+        ]
+    );
+    for p in v["profiles"].as_array().unwrap() {
+        assert_eq!(p["status"], "Conformant", "{}", p["id"]);
+        assert_eq!(p["met"], true, "{}", p["id"]);
+    }
+    let signed_tier = &v["profiles"][1];
+    let clauses: Vec<&str> = signed_tier["clauses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(clauses, ["S0", "S1", "S2", "S3"]);
+    // Every record a pinned author wrote is signed in the exported receipt,
+    // except the one deliberately unsigned request, which stays in the log
+    // as a durable rejected record (verdicts are materialized unsigned by
+    // the commit protocol and are not authored by a pinned actor).
+    let exported: Receipt = serde_json::from_slice(&std::fs::read(&receipt).unwrap()).unwrap();
+    let unsigned: Vec<&Record> = exported
+        .records
+        .iter()
+        .filter(|r| r.kind != Kind::Verdict && r.author.signature.is_none())
+        .collect();
+    assert_eq!(unsigned.len(), 1);
+    assert_eq!(unsigned[0].kind, Kind::Request);
+    assert_eq!(unsigned[0].author.id, "human");
+}


### PR DESCRIPTION
Closes #113. The signed tier (`bellbook-core-signed-v1`, #138) is now reachable without touching Rust. No core change.

## CLI

- `rules init --signed` requires a signature on the five evolution kinds; `--author-key <id>:<pubkey-hex>` (repeatable) pins an actor's Ed25519 public key, refused for an actor with no role binding the way an admin without one is.
- Every recording command takes `--sign-key <file>` (the secret as 64 hex characters or 32 raw bytes) and signs the record before it is committed; the signature covers the signing form and is bound into the id.
- `eval add --attested` writes `bellbook.evaluation.attested.v1`; refused without `--sign-key`, since the verifier admits that schema only under a pinned signature.
- `key public --secret <file>` prints the public key to pin. Key generation and storage stay with the host (`openssl rand -hex 32` is enough); the CLI never prints a secret and adds no dependency.

## Python

- `default_rules(..., signed=True, author_keys={actor: [pubkey_hex]})` shapes the rules (refusals: an actor without a binding, an empty key list, a malformed key).
- `Writer(log_dir, rules, signers={actor: secret})` signs every record a listed actor writes; a signer for an actor the rules do not know is refused up front.
- `evaluate(..., attested=True)` selects the attested schema; refused without the extended shape or without a signer for the author.
- The bindings stay pinned to the published 0.9 line, which already carries `commit_signed`; nothing here needs the 0.10 core.

## Gates

- **CLI story**: `key public`, `rules init --signed --author-key`, signed records on every command, an attested evaluation, export declaring all three profiles, validate exit 0 with every profile met and clauses S0 through S3 passing. The verifier's answers reached through the binary: `SignatureMissing` for an unsigned record by a pinned author, `SignatureInvalid` for one signed with another actor's key, the attested refusal, the unbound `--author-key` refusal.
- **Python story** (`tests/test_signing.py`): the same through the wheel, plus the refusals. Requiring `bellbook-core-signed-v1` through the pinned 0.9 core reports `Unknown` and the test skips with a note; it flips at the pin bump.

## Docs

Profile document shows both flows; bindings README gains a "Sign" section; CHANGELOG `[Unreleased]`.

## Audit

Root: `cargo fmt --check`, clippy 0 diagnostics, `cargo doc` with warnings denied, `cargo test --all-features` (17 binaries green), `--no-default-features` build. Bindings: fmt, clippy 0, 52 passed and 1 skipped against the pinned core. No em dashes.