### PR TITLE
release prep for 0.10.0: the stability document, the API audit, versions

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.9.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.10.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-09-05
 
-The signed tier, and three small acts from the first-party half of field
-test 3 (`docs/field-tests/ft3-delivery-receipt-canary.md`). No wire
-change; core conformance is byte-unchanged.
+The signed tier. No core or wire change: every record, canonical form,
+signing form, schema, and verdict rule is byte-for-byte that of 0.9.0,
+and core conformance and the earlier profiles' vectors are unchanged. What
+is new is the third published profile, `bellbook-core-signed-v1`, the
+surfaces that reach it from the CLI and Python without touching Rust, the
+stability document that says what 1.0 will promise, and three small acts
+from the first-party half of field test 3
+(`docs/field-tests/ft3-delivery-receipt-canary.md`). This is the line the
+1.0 soak runs on: 1.0.0 is the freeze, tagged after the soak and the
+security review, not a feature release. The Python package gains the
+signed tier's surface right after the core publish (the bindings track the
+published crate).
 
 ### Added
 
@@ -48,6 +57,18 @@ change; core conformance is byte-unchanged.
   listed actors write, and `evaluate(..., attested=True)` selects the
   attested schema. Both story gates record a receipt declaring all three
   profiles and assert every one met.
+- **`docs/STABILITY.md`**: what 1.0 promises (spec epoch 0.4 frozen and
+  forward-valid receipts; the profile triple immutable; the crate's public
+  items, the CLI grammar and JSON, and the Python surface under semantic
+  versioning; MSRV policy), what it does not (capture completeness,
+  confidentiality, what a profile does not check, performance, internals,
+  message text), the deprecation period for each surface, and the support
+  policy. The 0.10.x line already behaves this way; 1.0.0 is tagged when
+  the release gates hold. The public API audit that accompanies it: every
+  public item of the crate is documented, nothing is deprecated, and
+  `cargo semver-checks` against the published 0.9.0 (the bump treated as
+  minor, 196 checks) reports no breaking change - 0.10.0 is additive over
+  0.9.0.
 
 - `conformance/python/validate_receipt.py`: the independent validator's
   one-receipt entry point for a skeptic - structural decode, replay, every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -319,12 +319,13 @@ receipt that can declare the profiles it claims. See
 
 ## Status
 
-**The published release is 0.9.0, implementing spec v0.4 (RFC-0003:
+**The published release is 0.10.0, implementing spec v0.4 (RFC-0003:
 requirement binding - the `Requirement` record, first-class artifact
 identity, the extended `Evaluation`, and receipt profile declarations -
 on top of the v0.3 evolution semantics: Candidate, Evaluation, and
 Selection records with replay-derived lineage standing) and publishing
-both profiles, `bellbook-core-v1` and `delivery-receipt-v1`.** SPEC.md is the
+three profiles, `bellbook-core-v1`, `delivery-receipt-v1`, and
+`bellbook-core-signed-v1`.** SPEC.md is the
 authority for what each version means (v0.3 design notes in
 [`spec/v0.3-delta.md`](spec/v0.3-delta.md); v0.4 design in
 [RFC-0003](docs/rfcs/0003-requirement-binding.md)). Earlier epochs stay
@@ -332,7 +333,9 @@ valid: a 0.4 validator replays a v0.3 receipt under the v0.3 schema set
 and reaches the identical decision (the v0.3 vectors and corpus are
 byte-frozen and re-checked in CI, including under the published 0.7.0
 binary), and 0.2.0 implementing spec v0.2 stays published and frozen as
-the validator for v0.2 artifacts.
+the validator for v0.2 artifacts. What 1.0 promises about the wire
+format, the crate, the CLI, and the Python package, and how anything
+promised can change, is [docs/STABILITY.md](docs/STABILITY.md).
 
 It ships exactly what is implemented and tested today: the
 content-addressed (JCS-canonical) record model, the deterministic verifier

--- a/SPEC.md
+++ b/SPEC.md
@@ -1240,7 +1240,7 @@ what could not be checked. [RFC-0003](docs/rfcs/0003-requirement-binding.md)
 - **`delivery-receipt-v1`** (crate 0.9.0, shipped): the grammar of a
   delivery claim - requirement, evidence, evaluator decision, artifact
   identity, capability profile - with its own fraud-rejection vectors.
-- **`bellbook-core-signed-v1`** (crate 0.10.0): the signed tier above the
+- **`bellbook-core-signed-v1`** (crate 0.10.0, shipped): the signed tier above the
   baseline - signatures required on every evolution kind, every such
   author key-pinned, every evaluation a selection rests on attested.
 

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,0 +1,157 @@
+# Stability
+
+What Bellbook 1.0 promises, what it does not, and how anything that is
+promised can change. This document is normative for the project's own
+releases; SPEC.md stays the authority for what a record or receipt means.
+
+1.0 is a promise, not a feature. A trust root earns the label by surviving
+use and review, so 1.0.0 is tagged only after the gates in the release
+issue hold: an adopter in production on the 0.x line for a 30-day soak with
+no breaking change needed, spec epoch 0.4 unchanged through it, the
+external security review complete, and the public surface below audited.
+Until then this document describes what 1.0 *will* promise, and the 0.10.x
+line already behaves this way.
+
+## Versioning
+
+Releases follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+over the surfaces listed in "What is covered". From 1.0.0:
+
+- **Patch** (1.0.x): fixes that change no covered surface and no decision
+  any conforming validator reaches on any valid input.
+- **Minor** (1.x.0): additive changes only. New functions, types, record
+  kinds, schemas, profiles, CLI commands and flags, Python parameters,
+  reason codes, and JSON fields. Nothing covered is removed, renamed,
+  retyped, or given a different meaning.
+- **Major** (2.0.0): anything else. A spec epoch that changes the meaning
+  of an existing record, a removed or renamed public item, a CLI flag that
+  stops being accepted, an exit code that changes meaning.
+
+Before 1.0.0 (the 0.x line), minor releases may break, as they have; the
+CHANGELOG names every such change under "Changed" or "Removed".
+
+## What is covered
+
+### The wire format (SPEC.md)
+
+- **Spec epoch 0.4 is frozen.** The record envelope, RFC 8785 canonical
+  form, record id derivation, signing form and domain string, every schema
+  the epoch names, the receipt document, and the verdict rules are fixed.
+  A 1.x validator reaches, for every 0.3 and 0.4 receipt, the identical
+  decision (status, reason, retracted and tainted sets, standing) that the
+  epoch's own validator reached. This is enforced by the byte-frozen
+  vectors and conformance corpora under `spec/`, re-derived in CI on every
+  commit, and by replaying frozen receipts through published binaries.
+- **Receipts are forward-valid.** A receipt produced by any 1.x release
+  validates under every later 1.y release with the same decision.
+- **New epochs are additive.** A later epoch (0.5 and beyond, or whatever
+  the numbering becomes) may add record kinds, schemas, and receipt fields.
+  It never changes what an existing epoch's record means, and validators
+  keep every earlier epoch's schema set. An epoch that could not keep this
+  promise would be a major release.
+- **Reason codes** are stable identifiers. New codes may be added (minor);
+  no existing code is removed or reassigned. A validator never reaches a
+  new code on an input a previous validator accepted.
+
+### Profiles (SPEC.md section 12.2)
+
+A profile is identified by `(id, version, clause-table hash)`. That triple
+is immutable: any change to a clause statement is a new version with a new
+hash, published beside the old one, and the old version keeps evaluating
+exactly as it did. The clause *semantics* behind a published table are
+fixed by its vectors; a change in what a clause accepts on an existing
+vector is a defect, fixed as a patch, never a reinterpretation. New
+profiles are minor.
+
+### The Rust crate
+
+Every `pub` item reachable from the `bellbook` crate root and its `pub mod`
+paths is covered: names, signatures, field sets, enum variants, trait
+impls, and documented behavior. All of them are documented (`missing_docs`
+is denied in CI). Behavior that the documentation calls out as
+unspecified, or that is reachable only through `unsafe` or private paths,
+is not covered.
+
+- **MSRV** is 1.75 and is checked in CI. Raising it is a minor change,
+  announced in the CHANGELOG.
+- **Features**: the `persist` feature (on by default) gates the writer and
+  the CLI's recording commands. Removing a feature or changing a default is
+  major.
+- **Dependencies** are not part of the surface, except that the crate's
+  public types never expose a third-party type without a documented reason.
+
+### The CLI (`bellbook`)
+
+Command names, flag names and their accepted values, positional arguments,
+exit codes, and the shape of `--json` output are covered. Human-readable
+output (the non-JSON text) is not: it may be reworded in any release. New
+commands, flags, and JSON fields are minor; consumers of `--json` must
+ignore fields they do not know.
+
+### The Python package (`bellbook` on PyPI)
+
+Public functions, classes, methods, their positional and keyword
+parameters, return shapes (including the dict keys of `Report.profiles`
+and the query surfaces), and exception types are covered. New keyword
+parameters with defaults and new dict keys are minor. The package tracks
+the published crate: its version is the crate version it pins.
+
+### The independent Python validator (`conformance/python/`)
+
+Covered as a *checkable claim*, not as a library: it agrees with the
+reference on every published vector and corpus case, and
+`validate_receipt.py` reports what `bellbook validate` reports with the
+same exit codes. Its module and function names are not covered.
+
+## What is not covered
+
+- **Completeness of capture.** Bellbook proves recorded history is
+  consistent and honestly graded, never that everything the agent did was
+  recorded (SPEC.md section 13).
+- **Confidentiality.** Payloads are in the clear by design.
+- **Anything a profile does not check.** A conformant `delivery-receipt-v1`
+  receipt proves the recorded process, not that the evaluator was
+  competent or the requirements were the right ones.
+- **Performance.** No throughput, latency, or size figure is a promise;
+  the validation limits are, and they are documented.
+- **Internal module layout** below the documented paths, private items, and
+  the text of error and detail messages.
+- **The site, the articles, and the field-test reports.** Evidence and
+  explanation, not interfaces.
+
+## Deprecation
+
+Nothing covered is removed without a deprecation period.
+
+1. A deprecated Rust item carries `#[deprecated(since, note)]` naming its
+   replacement for at least one minor release before a major removes it.
+2. A deprecated CLI flag or command keeps working and prints a one-line
+   notice to stderr naming its replacement for at least one minor release.
+   Its `--json` output does not change.
+3. A deprecated Python parameter keeps working and emits a
+   `DeprecationWarning` naming its replacement for at least one minor
+   release.
+4. Spec epochs are never deprecated: a validator keeps every epoch it ever
+   supported.
+5. Profiles are never deprecated: an old version keeps evaluating. The
+   profile document may say a newer version exists.
+
+Every deprecation and removal is listed in the CHANGELOG under
+"Deprecated" or "Removed" with the release it takes effect in.
+
+## Support
+
+- The latest minor release receives fixes. A security fix to the
+  verification path is released as a patch on the latest minor and noted
+  in the CHANGELOG and the security advisory, with the affected range.
+- Published 0.x releases stay on the registries and keep validating the
+  epochs they implement; they receive no further changes.
+- Reports of a decision the two implementations disagree on, or of a
+  frozen vector that no longer re-derives, are treated as defects of the
+  highest priority: they are the promise this document makes.
+
+## How this document changes
+
+A change that narrows a promise is a major release. A change that widens
+one, or clarifies wording without changing what holds, is recorded in the
+CHANGELOG and may land in any release.


### PR DESCRIPTION
Refs #114. The third and last piece of the signed-tier chapter before the publish: 0.10.0 is the line the 1.0 soak runs on.

## What

- **`docs/STABILITY.md`** (new): what 1.0 promises and how anything promised can change. Spec epoch 0.4 frozen and receipts forward-valid; the profile triple (`bellbook-core-v1`, `delivery-receipt-v1`, `bellbook-core-signed-v1`) immutable by construction; the crate's public items, the CLI grammar and JSON output, and the Python surface under semantic versioning; the MSRV policy. What it does not promise: capture completeness, confidentiality, anything a profile does not check, performance, internals, message text. The deprecation period per surface and the support policy. README links it from the status section.
- **API audit for 0.10.0**: every public item documented, nothing deprecated, and `cargo semver-checks check-release --baseline-version 0.9.0 --release-type minor` reports no breaking change (196 checks pass, 58 not applicable). 0.10.0 is additive over 0.9.0. Recorded in the CHANGELOG.
- **Versions to 0.10.0**: crate, bindings crate, pyproject, the wheel smoke-test guard, both lockfiles. The bindings pin stays on the published 0.9 core until the crate publish; the pin bump follows as its own PR, exactly as for 0.9.0.
- **CHANGELOG** frames `## [0.10.0] - 2026-09-05`: no core or wire change, the signed tier, its surfaces, the stability document, the field-test acts. **SPEC** section 12.2 marks the signed tier shipped. **README** status names the three profiles.

## Checks

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (0 diagnostics), `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, `cargo test --all-features` (17 binaries, all green), `cargo build --no-default-features`.
- `python3 conformance/python/run_conformance.py`: every vector of every profile agrees, both epochs.
- Core conformance and the 0.3/0.4 vector files byte-unchanged against v0.9.0.
- No em dashes.

## After merge

`release.yml` on main publishes 0.10.0 to crates.io, then the pin-bump PR (bindings to 0.10, signed-tier tests unskipped), then `publish-pypi.yml`, then fresh-install verification of both registries, then the site.