### PR TITLE
bindings(python): pin bellbook_core to 0.10 and report the signed tier

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb74b67d905913723fe79ed5993085f0fb80bb1e748db56184232864a7d9172"
+checksum = "4f26a02211b844a7b96c172ccf5741b2d0626f9125bd97919305d4de5a5808c1"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.9", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.10", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/bindings/python/tests/test_profiles.py
+++ b/bindings/python/tests/test_profiles.py
@@ -1,8 +1,8 @@
 """The published profiles across the FFI boundary: `validate(...,
 require_profile=...)` carries the profile result, `default_rules` emits a
-baseline-conformant rule set, and every published profile vector (both
-`bellbook-core-v1` and `delivery-receipt-v1`) re-derives identically through
-the wheel. A profile result is a report alongside the verdict, never a change
+baseline-conformant rule set, and every published profile vector
+(`bellbook-core-v1`, `delivery-receipt-v1`, and `bellbook-core-signed-v1`)
+re-derives identically through the wheel. A profile result is a report alongside the verdict, never a change
 to it."""
 
 import json
@@ -17,9 +17,11 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 PROFILES = ROOT / "spec" / "profiles"
 CORE_V1 = "bellbook-core-v1"
 DELIVERY_V1 = "delivery-receipt-v1"
+SIGNED_V1 = "bellbook-core-signed-v1"
 FAILABLE = {
     CORE_V1: {"B1", "B2", "B3", "B4"},
     DELIVERY_V1: {f"D{i}" for i in range(8)},
+    SIGNED_V1: {"S0", "S1", "S2", "S3"},
 }
 BASELINE = {"Candidate": "Reported", "Evaluation": "Reported", "Selection": "Inferred"}
 
@@ -95,13 +97,16 @@ def test_require_profile_type_is_checked():
         bellbook.validate(b"x", require_profile=7)
 
 
-@pytest.mark.parametrize("profile_id", [CORE_V1, DELIVERY_V1])
+@pytest.mark.parametrize("profile_id", [CORE_V1, DELIVERY_V1, SIGNED_V1])
 def test_published_profile_vectors_match_reference(profile_id):
     """Every vector in spec/profiles/<profile>/cases.json yields the stored
     status, declaration flags, per-clause flags, and profile hash through the
     wheel. The delivery vectors carry the fraud battery: one rejecting case
     per clause, including a claim over a failed evaluation with every digest
-    consistent and a passing evaluation reattached to another candidate."""
+    consistent and a passing evaluation reattached to another candidate. The
+    signed vectors carry real Ed25519 signatures under deterministic test
+    keys, one rejecting case per clause, and a stripped-signature receipt
+    (Invalid; every clause fails)."""
     doc = json.loads((PROFILES / profile_id / "cases.json").read_text())
     assert doc["profile"] == profile_id
     expected_hash = bytes(doc["hash"]).hex()

--- a/bindings/python/tests/test_signing.py
+++ b/bindings/python/tests/test_signing.py
@@ -120,9 +120,12 @@ def test_signed_story_from_python_alone(tmp_path):
     for c in (req, r1, c0, e0, s0):
         assert c.accepted, c.reason
 
-    receipt = w.receipt(profiles=["bellbook-core-v1", "delivery-receipt-v1"])
+    receipt = w.receipt(profiles=["bellbook-core-v1", "delivery-receipt-v1", "bellbook-core-signed-v1"])
     report = bellbook.validate(receipt)
     assert report.status == "clean"
+    assert [p["id"] for p in report.profiles] == [
+        "bellbook-core-v1", "delivery-receipt-v1", "bellbook-core-signed-v1"
+    ]
     assert all(p["met"] for p in report.profiles)
     parsed = bellbook.read(receipt)
     by_id = {r.id: r for r in parsed.records}
@@ -144,11 +147,9 @@ def test_signed_story_from_python_alone(tmp_path):
 
 
 def test_signed_tier_profile_through_the_wheel(tmp_path):
-    """The signed tier as the pinned core reports it. The bindings track the
-    published crate: until the pin moves to the core that publishes
-    `bellbook-core-signed-v1`, requiring it is reported Unknown rather than
-    evaluated, and declaring it is refused as an unknown profile. Both
-    assertions flip at the pin bump."""
+    """The signed tier as the wheel reports it: a signed, attested loop
+    required against `bellbook-core-signed-v1` is Conformant on all four
+    clauses, and `met` is what the exit code would be derived from."""
     pubs = _pubs(tmp_path)
     rules = _signed_rules(tmp_path, pubs)
     w = bellbook.Writer(os.path.join(str(tmp_path), "log"), rules, signers={"agent": AGENT, "evaluator": EVALUATOR})
@@ -159,7 +160,7 @@ def test_signed_tier_profile_through_the_wheel(tmp_path):
     assert s0.accepted, s0.reason
     report = bellbook.validate(w.receipt(), require_profile="bellbook-core-signed-v1")
     p = report.profiles[0]
-    if p["status"] == "Unknown":
-        pytest.skip("pinned core predates bellbook-core-signed-v1; flips at the pin bump")
+    assert p["id"] == "bellbook-core-signed-v1"
     assert p["status"] == "Conformant" and p["met"]
+    assert p["declared"] is False and p["declaration_matches"] is None
     assert [c["id"] for c in p["clauses"]] == ["S0", "S1", "S2", "S3"]


### PR DESCRIPTION
Refs #113, #114. The bindings track the published crate; 0.10.0 is on crates.io (Release run 23), so the pin moves to the 0.10 line and the Python half of the signed tier lands.

## What

- `bindings/python/Cargo.toml`: `bellbook_core` pin `0.9` to `0.10`; `Cargo.lock` regenerated against the registry (`bellbook 0.9.0 -> 0.10.0`, nothing else moves).
- No binding code changes. The surfaces shipped in the 0.9.0 package (`default_rules(signed=..., author_keys=...)`, `Writer(signers=...)`, `evaluate(attested=True)`) already wrote records the 0.10 core judges under `bellbook-core-signed-v1`; with that core underneath the profile is accepted as a declaration and evaluated on request, and `Report.profiles` carries its four clauses.
- Tests: the profile vector test is parametrized over all three published profiles (the signed vectors carry real Ed25519 signatures under deterministic keys, one rejecting case per clause, and a stripped-signature receipt that is Invalid with every clause failing); the signed story declares all three profiles and asserts every one met; the signed-tier test that skipped under the 0.9 pin now asserts Conformant on S0 through S3 with `met`.

## Checks

- `cargo fmt --all -- --check`, `cargo clippy --all-targets` (0 diagnostics) in the bindings crate.
- `maturin develop --release` then `pytest -q tests`: 54 passed, 0 skipped (was 52 passed, 1 skipped).
- Published binary, installed fresh with `cargo install bellbook --version 0.10.0`: a signed, attested delivery loop exported declaring all three profiles validates Clean with every profile met; `--require-profile bellbook-core-signed-v1` exits 0; the independent Python validator agrees clause by clause (S0 through S3); the same receipt with one signature stripped is Invalid for both implementations.

## After merge

`publish-pypi.yml` on main publishes the 0.10.0 wheels, then fresh-install verification from PyPI, then the site.