### PR TITLE
release prep for 0.11.0: number canonicalization

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --find-links bindings/python/dist bellbook
-          python -c "import bellbook; assert bellbook.__version__ == '0.10.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
+          python -c "import bellbook; assert bellbook.__version__ == '0.11.0', bellbook.__version__; assert bellbook.validate(b'x').status == 'invalid'; print('ok', bellbook.__version__)"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to Bellbook are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2026-09-05
+
+Number canonicalization. No API change (`cargo semver-checks` against
+0.10.0: 196 checks pass), no CLI or Python surface change, and spec epoch
+0.4 unchanged: SPEC section 3 gained the number rules that close a corner
+where the two implementations had disagreed, so there was no agreed
+decision to preserve. What changes is a validator decision: a record whose
+`Action.params` carries a double may reach a different verdict than under
+0.10.0 (see Fixed), which is why this is a minor release and not a patch
+under the rules `docs/STABILITY.md` states. No committed vector, corpus
+case, or receipt was affected. Also in this release: the 1.0 security gate
+re-scoped, the internal adversarial review published, and the Fuzz workflow
+filing its findings as issues. The Python package gains the parser fix at
+the pin bump right after the core publish.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bellbook"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bellbook"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Bellbook AI <contact@bellbook.ai>"]
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ receipt that can declare the profiles it claims. See
 
 ## Status
 
-**The published release is 0.10.0, implementing spec v0.4 (RFC-0003:
+**The published release is 0.11.0, implementing spec v0.4 (RFC-0003:
 requirement binding - the `Requirement` record, first-class artifact
 identity, the extended `Evaluation`, and receipt profile declarations -
 on top of the v0.3 evolution semantics: Candidate, Evaluation, and

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bellbook-python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bellbook",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,7 @@
 # CI and `cargo package` are unaffected (the root crate excludes `bindings/`).
 [package]
 name = "bellbook-python"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This is the bindings crate's own MSRV and does
 # not affect the library crate (a separate workspace), whose MSRV job is

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bellbook"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python bindings for Bellbook: record, read, and validate tamper-evident, replay-verifiable agent-activity receipts offline."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -16,7 +16,7 @@ surface below audited. 1.0 does not ship on an external security review,
 and its release notes will say so: nothing outside the project depends on
 Bellbook enough yet to justify one, and Bellbook does not claim assurance it
 has not earned. Until then this document describes what 1.0 *will* promise,
-and the 0.10.x line already behaves this way.
+and the 0.11.x line already behaves this way.
 
 ## Versioning
 


### PR DESCRIPTION
Refs #147 (the 0.11.0 release gate). Contents of the release: #145 (fixed in #142), #146 (#143), the re-scoped security gate (#142).

## What

- **Versions to 0.11.0**: crate, bindings crate, pyproject, the wheel smoke-test guard, both lockfiles. The bindings pin stays on the published 0.10 core until the crate publish; the pin bump follows as its own PR.
- **CHANGELOG** frames `## [0.11.0] - 2026-09-05`: no API, CLI, or Python surface change; spec epoch 0.4 unchanged (SPEC section 3 gained the number rules that close a corner where the two implementations had disagreed); a validator decision changes for records whose `Action.params` carry a double, which is why this is a minor and not a patch under `docs/STABILITY.md`. No committed vector, corpus case, or receipt affected.
- **README** status names 0.11.0; **STABILITY** names the 0.11.x line.

## Checks

- `cargo semver-checks check-release --baseline-version 0.10.0 --release-type minor`: 196 checks pass.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (0), `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, `cargo test --all-features` (17 binaries green), `cargo build --no-default-features`.
- `python3 conformance/python/run_conformance.py`: every vector and both epochs' corpora agree.
- Frozen epochs 0.2 and 0.3 and all three profile vector sets byte-unchanged since v0.10.0.
- No em dashes.

## After merge

`release.yml` on main publishes 0.11.0 to crates.io, then the pin-bump PR, then `publish-pypi.yml`, fresh-install verification of both registries, the site footer, and the tag and Release from the prepared notes.