### PR TITLE
bindings(python): pin bellbook_core to 0.11

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bellbook"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f26a02211b844a7b96c172ccf5741b2d0626f9125bd97919305d4de5a5808c1"
+checksum = "5cfc2a4cedc9dc9609c9ac73d2fc806ebf43764cd636f1d2524cf47b9f2a2729"
 dependencies = [
  "ed25519-dalek",
  "fs4",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 # previous published line until the new core is on crates.io (the library API
 # is unchanged across the bump), avoiding a publish-ordering deadlock; it is
 # aligned to the current line right after publish, as this release does.
-bellbook_core = { package = "bellbook", version = "0.10", default-features = false, features = [
+bellbook_core = { package = "bellbook", version = "0.11", default-features = false, features = [
     "persist",
 ] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }


### PR DESCRIPTION
Refs #147. The bindings track the published crate; 0.11.0 is on crates.io (Release run on `5eb64cc`), so the pin moves to the 0.11 line.

## What

- `bindings/python/Cargo.toml`: `bellbook_core` pin `0.10` to `0.11`; `Cargo.lock` regenerated against the registry (`bellbook 0.10.0 -> 0.11.0`, nothing else moves).
- No binding code changes. The wheel picks up correctly rounded number parsing and the refusal of integer-valued doubles in [2^53, 1e21) from the core.

## Checks

- `cargo fmt --all -- --check`, `cargo clippy --all-targets` (0) in the bindings crate.
- `maturin develop --release` then `pytest -q tests`: 54 passed.
- Published crate, installed fresh with `cargo install bellbook --version 0.11.0`: the signed smoke receipts validate Clean with all three profiles met, `--require-profile bellbook-core-signed-v1` exits 0, the stripped-signature receipt exits 1.

## After merge

`publish-pypi.yml` on main, then fresh-install verification from PyPI, then the site footer (bellbook-ai/site #11) and the tag.